### PR TITLE
Mobile-web Safari: seamless adaptive top chrome, character & auth polish

### DIFF
--- a/app/(auth)/forgot-password.web.tsx
+++ b/app/(auth)/forgot-password.web.tsx
@@ -176,8 +176,8 @@ export default function WebForgotPasswordScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="cover"
-            contentPosition="top center"
+            contentFit="contain"
+            contentPosition="center"
           />
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
@@ -221,12 +221,12 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '40vh',
-    minHeight: 240,
-    maxHeight: 380,
+    height: '46vh',
+    minHeight: 290,
+    maxHeight: 440,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
-    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
+    paddingTop: 'calc(env(safe-area-inset-top) + 12px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,

--- a/app/(auth)/forgot-password.web.tsx
+++ b/app/(auth)/forgot-password.web.tsx
@@ -181,9 +181,7 @@ export default function WebForgotPasswordScreen() {
           />
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
-        <View style={styles.mobileLogo}>
-          <HeroLogo iconSize={36} fontSize={28} color={COLORS.beige} gap={10} />
-        </View>
+        {/* Logo is provided by the shared logo-only TopBar (see _layout.web.tsx). */}
         <View style={styles.mobileCard}>
           <View style={styles.mobileCardHandle} />
           {formContent}

--- a/app/(auth)/forgot-password.web.tsx
+++ b/app/(auth)/forgot-password.web.tsx
@@ -175,9 +175,9 @@ export default function WebForgotPasswordScreen() {
         <View style={styles.mobileIllustrationWrap}>
           <Image
             source={LOGIN_HERO}
-            style={StyleSheet.absoluteFill}
+            style={styles.mobileHeroImg as object}
             contentFit="contain"
-            contentPosition="top center"
+            contentPosition="bottom center"
           />
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
@@ -221,20 +221,26 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '42vh',
-    minHeight: 240,
-    maxHeight: 420,
+    height: '36vh',
+    minHeight: 220,
+    maxHeight: 360,
+    flexShrink: 0,
     backgroundColor: COLORS.navy,
+    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
+  } as object,
+  mobileHeroImg: {
+    flex: 1,
+    width: '100%',
   } as object,
   mobileScrim: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    height: '55%',
-    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 65%, ${COLORS.beige} 100%)`,
+    height: '45%',
+    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 70%, ${COLORS.beige} 100%)`,
   } as object,
   mobileLogo: {
     position: 'absolute',

--- a/app/(auth)/forgot-password.web.tsx
+++ b/app/(auth)/forgot-password.web.tsx
@@ -176,8 +176,8 @@ export default function WebForgotPasswordScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="contain"
-            contentPosition="bottom center"
+            contentFit="cover"
+            contentPosition="top center"
           />
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
@@ -221,12 +221,12 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '36vh',
-    minHeight: 220,
-    maxHeight: 360,
+    height: '40vh',
+    minHeight: 240,
+    maxHeight: 380,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
-    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
+    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -172,8 +172,8 @@ export default function WebLoginScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="cover"
-            contentPosition="top center"
+            contentFit="contain"
+            contentPosition="center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -230,19 +230,19 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '42vh',
-    minHeight: 260,
-    maxHeight: 400,
+    height: '48vh',
+    minHeight: 300,
+    maxHeight: 460,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
-    // Clear the floating logo bar and leave breathing room above the head.
-    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
+    // Small top clearance; the square art carries its own headroom above the
+    // head, and the floating logo bar sits over that space.
+    paddingTop: 'calc(env(safe-area-inset-top) + 12px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,
-  // Portrait fills the width of the area below the headroom padding (cover), so
-  // it reads large and prominent with navy space above the head; the scrim fades
-  // its lower body into the card.
+  // Whole character shown (contain) at a large size, its lower edge fading into
+  // the card via the scrim.
   mobileHeroImg: {
     flex: 1,
     width: '100%',

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -178,10 +178,7 @@ export default function WebLoginScreen() {
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
 
-        {/* Logo — floats top-left over illustration */}
-        <View style={styles.mobileLogo}>
-          <HeroLogo iconSize={36} fontSize={28} color={COLORS.beige} gap={10} />
-        </View>
+        {/* Logo is provided by the shared logo-only TopBar (see _layout.web.tsx). */}
 
         {/* Form card — rises from bottom */}
         <View style={styles.mobileCard}>

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -172,8 +172,8 @@ export default function WebLoginScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="contain"
-            contentPosition="bottom center"
+            contentFit="cover"
+            contentPosition="top center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -230,18 +230,19 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '38vh',
-    minHeight: 220,
-    maxHeight: 360,
+    height: '42vh',
+    minHeight: 260,
+    maxHeight: 400,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
     // Clear the floating logo bar and leave breathing room above the head.
-    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
+    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,
-  // Portrait fills the area below the headroom padding, anchored to the bottom
-  // so it rises into the card with navy space above its head.
+  // Portrait fills the width of the area below the headroom padding (cover), so
+  // it reads large and prominent with navy space above the head; the scrim fades
+  // its lower body into the card.
   mobileHeroImg: {
     flex: 1,
     width: '100%',

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -166,13 +166,14 @@ export default function WebLoginScreen() {
   if (!isDesktop) {
     return (
       <View style={styles.mobileRoot}>
-        {/* Hero illustration — contained in top region */}
+        {/* Hero illustration — sits in the navy top region with headroom above
+            the head (paddingTop clears the logo bar) and rises into the card. */}
         <View style={styles.mobileIllustrationWrap}>
           <Image
             source={LOGIN_HERO}
-            style={StyleSheet.absoluteFill}
+            style={styles.mobileHeroImg as object}
             contentFit="contain"
-            contentPosition="top center"
+            contentPosition="bottom center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -224,30 +225,34 @@ const styles = StyleSheet.create({
   // ── Mobile ─────────────────────────────────────────────────────────────
   mobileRoot: {
     minHeight: '100dvh',
+    flexDirection: 'column',
     backgroundColor: COLORS.beige,
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '42vh',
-    minHeight: 240,
-    maxHeight: 420,
+    height: '38vh',
+    minHeight: 220,
+    maxHeight: 360,
+    flexShrink: 0,
     backgroundColor: COLORS.navy,
+    // Clear the floating logo bar and leave breathing room above the head.
+    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
+  } as object,
+  // Portrait fills the area below the headroom padding, anchored to the bottom
+  // so it rises into the card with navy space above its head.
+  mobileHeroImg: {
+    flex: 1,
+    width: '100%',
   } as object,
   mobileScrim: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    height: '55%',
-    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 65%, ${COLORS.beige} 100%)`,
-  } as object,
-  mobileLogo: {
-    position: 'absolute',
-    top: 'calc(20px + env(safe-area-inset-top))',
-    left: 20,
-    zIndex: 10,
+    height: '45%',
+    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 70%, ${COLORS.beige} 100%)`,
   } as object,
   cardAccent: {
     width: 40,
@@ -255,18 +260,18 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     backgroundColor: COLORS.orange,
     alignSelf: 'center',
-    marginBottom: 24,
+    marginBottom: 16,
     opacity: 0.7,
   },
   mobileCard: {
-    flexGrow: 1,
-    marginTop: -44,
+    flex: 1,
+    marginTop: -40,
     backgroundColor: COLORS.beige,
     borderTopLeftRadius: 28,
     borderTopRightRadius: 28,
     paddingHorizontal: 28,
-    paddingTop: 24,
-    paddingBottom: 'calc(40px + env(safe-area-inset-bottom))',
+    paddingTop: 18,
+    paddingBottom: 'calc(28px + env(safe-area-inset-bottom))',
   } as object,
   // ── Desktop ────────────────────────────────────────────────────────────
   desktopRoot: {
@@ -380,8 +385,8 @@ const styles = StyleSheet.create({
   input: {
     backgroundColor: 'white',
     borderRadius: 10,
-    padding: 14,
-    marginBottom: 14,
+    padding: 13,
+    marginBottom: 10,
     fontFamily: 'Nunito_400Regular',
     fontSize: 15,
     color: COLORS.navy,
@@ -419,7 +424,7 @@ const styles = StyleSheet.create({
   } as object,
   forgotWrap: {
     alignSelf: 'flex-end',
-    marginBottom: 16,
+    marginBottom: 12,
     paddingVertical: 4,
     cursor: 'pointer',
   },
@@ -432,9 +437,9 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: COLORS.orange,
     borderRadius: 12,
-    paddingVertical: 17,
+    paddingVertical: 15,
     alignItems: 'center',
-    marginBottom: 18,
+    marginBottom: 14,
     boxShadow: '0 4px 18px rgba(231,115,51,0.32)',
     cursor: 'pointer',
     transition: 'opacity 0.15s ease',
@@ -468,7 +473,7 @@ const styles = StyleSheet.create({
     textDecorationLine: 'underline',
   },
   guestRow: {
-    marginTop: 16,
+    marginTop: 10,
     alignItems: 'center',
     cursor: 'pointer',
   } as object,

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -189,8 +189,8 @@ export default function WebSignupScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="cover"
-            contentPosition="top center"
+            contentFit="contain"
+            contentPosition="center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -246,12 +246,12 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '34vh',
-    minHeight: 210,
-    maxHeight: 340,
+    height: '38vh',
+    minHeight: 240,
+    maxHeight: 380,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
-    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
+    paddingTop: 'calc(env(safe-area-inset-top) + 12px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -189,8 +189,8 @@ export default function WebSignupScreen() {
           <Image
             source={LOGIN_HERO}
             style={styles.mobileHeroImg as object}
-            contentFit="contain"
-            contentPosition="bottom center"
+            contentFit="cover"
+            contentPosition="top center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -246,12 +246,12 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '32vh',
-    minHeight: 200,
-    maxHeight: 320,
+    height: '34vh',
+    minHeight: 210,
+    maxHeight: 340,
     flexShrink: 0,
     backgroundColor: COLORS.navy,
-    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
+    paddingTop: 'calc(env(safe-area-inset-top) + 80px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
   } as object,

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -196,10 +196,7 @@ export default function WebSignupScreen() {
           <View style={styles.mobileScrim as object} pointerEvents="none" />
         </View>
 
-        {/* Logo — floats top-left over illustration */}
-        <View style={styles.mobileLogo}>
-          <HeroLogo iconSize={36} fontSize={28} color={COLORS.beige} gap={10} />
-        </View>
+        {/* Logo is provided by the shared logo-only TopBar (see _layout.web.tsx). */}
 
         {/* Form card — rises from bottom */}
         <View style={styles.mobileCard}>

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -184,13 +184,13 @@ export default function WebSignupScreen() {
   if (!isDesktop) {
     return (
       <View style={styles.mobileRoot}>
-        {/* Hero illustration — contained in top region */}
+        {/* Hero illustration — navy top region with headroom above the head. */}
         <View style={styles.mobileIllustrationWrap}>
           <Image
             source={LOGIN_HERO}
-            style={StyleSheet.absoluteFill}
+            style={styles.mobileHeroImg as object}
             contentFit="contain"
-            contentPosition="top center"
+            contentPosition="bottom center"
           />
           {/* Scrim fades bottom of illustration into card */}
           <View style={styles.mobileScrim as object} pointerEvents="none" />
@@ -246,20 +246,26 @@ const styles = StyleSheet.create({
   } as object,
   mobileIllustrationWrap: {
     position: 'relative',
-    height: '42vh',
-    minHeight: 240,
-    maxHeight: 420,
+    height: '32vh',
+    minHeight: 200,
+    maxHeight: 320,
+    flexShrink: 0,
     backgroundColor: COLORS.navy,
+    paddingTop: 'calc(env(safe-area-inset-top) + 86px)',
     backgroundImage: 'radial-gradient(circle, rgba(245,235,220,0.07) 1.5px, transparent 1.5px)',
     backgroundSize: '24px 24px',
+  } as object,
+  mobileHeroImg: {
+    flex: 1,
+    width: '100%',
   } as object,
   mobileScrim: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    height: '55%',
-    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 65%, ${COLORS.beige} 100%)`,
+    height: '45%',
+    backgroundImage: `linear-gradient(to bottom, transparent 0%, ${COLORS.navy} 70%, ${COLORS.beige} 100%)`,
   } as object,
   mobileLogo: {
     position: 'absolute',

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -32,6 +32,7 @@ import { TodaysMatchup as TodaysMatchupCard } from '../../src/components/web/hom
 import { getTodaysMatchup, type TodaysMatchup } from '../../src/lib/matchup';
 import { TOPBAR_HEIGHT } from '../../src/components/web/TopBar';
 import { useWebCanvas } from '../../src/hooks/useWebCanvas';
+import { useChromeColors, ChromeSentinel } from '../../src/contexts/WebChromeContext';
 import { PulseTicker } from '../../src/components/web/home/PulseTicker';
 import { StatPods } from '../../src/components/web/home/StatPods';
 import {
@@ -1141,6 +1142,9 @@ export default function WebHomeScreen() {
   // Document scroll so content bleeds edge-to-edge under the iOS Safari toolbar.
   // Explore opens and closes on the deep-navy stage/footer, so the canvas is navy.
   useWebCanvas(COLORS.deepNavy);
+  // Adaptive top chrome: deep-navy over the dark stage, beige over the carousels.
+  // The <ChromeSentinel /> at the stage→canvas boundary flips it at the seam.
+  useChromeColors(COLORS.deepNavy, COLORS.beige);
 
   // 1. MATCH THE ACCORDION_SCALES EXACTLY
   const optimalPoolSize = width >= 1280 ? 8 : width >= 900 ? 6 : 3;
@@ -1337,6 +1341,10 @@ export default function WebHomeScreen() {
             heroCount={totalHeroCount ?? 0}
             newlyAddedCount={homeData.newlyAdded?.length ?? 0}
           />
+
+          {/* Adaptive-chrome seam: once this marker (the dark→beige boundary)
+              scrolls under the top bar, the chrome flips from navy to beige. */}
+          <ChromeSentinel />
 
           {/* Beige canvas — owns the carousel surface so the dark scroll
               background only shows on the dark stage and on overscroll. */}

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -32,7 +32,7 @@ import { TodaysMatchup as TodaysMatchupCard } from '../../src/components/web/hom
 import { getTodaysMatchup, type TodaysMatchup } from '../../src/lib/matchup';
 import { TOPBAR_HEIGHT } from '../../src/components/web/TopBar';
 import { useWebCanvas } from '../../src/hooks/useWebCanvas';
-import { useChromeColors, ChromeSentinel } from '../../src/contexts/WebChromeContext';
+import { useChromeColor } from '../../src/contexts/WebChromeContext';
 import { PulseTicker } from '../../src/components/web/home/PulseTicker';
 import { StatPods } from '../../src/components/web/home/StatPods';
 import {
@@ -1142,9 +1142,8 @@ export default function WebHomeScreen() {
   // Document scroll so content bleeds edge-to-edge under the iOS Safari toolbar.
   // Explore opens and closes on the deep-navy stage/footer, so the canvas is navy.
   useWebCanvas(COLORS.deepNavy);
-  // Adaptive top chrome: deep-navy over the dark stage, beige over the carousels.
-  // The <ChromeSentinel /> at the stage→canvas boundary flips it at the seam.
-  useChromeColors(COLORS.deepNavy, COLORS.beige);
+  // Top chrome (status bar + top bar) locks to the deep-navy stage at the top.
+  useChromeColor(COLORS.deepNavy);
 
   // 1. MATCH THE ACCORDION_SCALES EXACTLY
   const optimalPoolSize = width >= 1280 ? 8 : width >= 900 ? 6 : 3;
@@ -1341,10 +1340,6 @@ export default function WebHomeScreen() {
             heroCount={totalHeroCount ?? 0}
             newlyAddedCount={homeData.newlyAdded?.length ?? 0}
           />
-
-          {/* Adaptive-chrome seam: once this marker (the dark→beige boundary)
-              scrolls under the top bar, the chrome flips from navy to beige. */}
-          <ChromeSentinel />
 
           {/* Beige canvas — owns the carousel surface so the dark scroll
               background only shows on the dark stage and on overscroll. */}

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../src/hooks/useAuth';
 import { LogoLoader } from '../src/components/ui/LogoLoader';
 import { TopBar, TOPBAR_HEIGHT } from '../src/components/web/TopBar';
 import { SearchProvider } from '../src/contexts/SearchContext';
+import { WebChromeProvider, AdaptiveStatusBarCover } from '../src/contexts/WebChromeContext';
 import { queryClient } from '../src/lib/query/queryClient';
 import { COLORS } from '../src/constants/colors';
 
@@ -69,27 +70,28 @@ function WebAuthGate() {
 
   return (
     <SearchProvider>
-      <View style={styles.root}>
-        {showNav && <TopBar />}
-        <View
-          style={
-            [
-              styles.content,
-              showNav &&
-                !bleedBehindNav && {
-                  paddingTop: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top))`,
-                },
-            ] as object
-          }
-        >
-          <Stack screenOptions={{ headerShown: false }} />
+      <WebChromeProvider>
+        <View style={styles.root}>
+          {showNav && <TopBar />}
+          <View
+            style={
+              [
+                styles.content,
+                showNav &&
+                  !bleedBehindNav && {
+                    paddingTop: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top))`,
+                  },
+              ] as object
+            }
+          >
+            <Stack screenOptions={{ headerShown: false }} />
+          </View>
+          {/* Opaque strip over the iOS status-bar inset, painted the current
+              chrome colour so it fuses seamlessly with the system status bar and
+              tracks it dark→light as the page scrolls. */}
+          <AdaptiveStatusBarCover />
         </View>
-        {/* Safe-area top cover (glow technique): a frosted strip exactly the
-            height of the iOS status-bar inset, pinned above everything. Content
-            scrolls edge-to-edge behind it; the status-bar zone reads as one clean
-            frosted strip instead of a bare band. env() → 0 where no safe area. */}
-        <View pointerEvents="none" style={styles.statusBarCover} />
-      </View>
+      </WebChromeProvider>
     </SearchProvider>
   );
 }
@@ -102,20 +104,8 @@ export default function WebRootLayout() {
     if (typeof document === 'undefined') return;
     document.documentElement.style.backgroundColor = '#0b1820';
     document.body.style.backgroundColor = '#0b1820';
-    // Pin the iOS Safari status-bar tint to the deep-navy backdrop. Expo's single
-    // web output ignores app/+html.tsx, so the theme-color meta there never ships;
-    // without it Safari samples the page background to tint the status bar, which
-    // turns beige on every beige-canvas screen (login, search, profile…) while
-    // staying navy on the navy-canvas Discover screen — an inconsistent strip up
-    // top. A fixed navy theme-color makes the system bar cohesive everywhere; it
-    // only governs the top strip, so the beige bottom-toolbar blur is unaffected.
-    let themeMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
-    if (!themeMeta) {
-      themeMeta = document.createElement('meta');
-      themeMeta.name = 'theme-color';
-      document.head.appendChild(themeMeta);
-    }
-    themeMeta.content = '#0b1820';
+    // The iOS Safari status-bar tint (theme-color meta) is owned by
+    // WebChromeProvider, which tracks it to the page's current top colour.
     // iOS Safari 16+ ignores maximum-scale=1 in the viewport meta tag and still
     // auto-zooms when a focused input has font-size < 16 px.  Enforce the 16 px
     // floor globally so every text field — search bars, auth forms, filters — is
@@ -153,15 +143,4 @@ const styles = StyleSheet.create({
   // header and on overscroll. Every screen paints its own canvas on top of it.
   root: { flex: 1, backgroundColor: COLORS.deepNavy },
   content: { flex: 1 },
-  statusBarCover: {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 'env(safe-area-inset-top)',
-    backgroundColor: 'rgba(11,24,32,0.6)',
-    backdropFilter: 'blur(12px)',
-    WebkitBackdropFilter: 'blur(12px)',
-    zIndex: 9999,
-  } as object,
 });

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -72,7 +72,9 @@ function WebAuthGate() {
     <SearchProvider>
       <WebChromeProvider>
         <View style={styles.root}>
-          {showNav && <TopBar />}
+          {/* Full nav on content routes; a logo-only bar on auth (mobile) so the
+              brand sits in the same place app-wide. Hidden only on the bare root. */}
+          {!isRoot && <TopBar logoOnly={inAuthGroup} />}
           <View
             style={
               [

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -102,6 +102,20 @@ export default function WebRootLayout() {
     if (typeof document === 'undefined') return;
     document.documentElement.style.backgroundColor = '#0b1820';
     document.body.style.backgroundColor = '#0b1820';
+    // Pin the iOS Safari status-bar tint to the deep-navy backdrop. Expo's single
+    // web output ignores app/+html.tsx, so the theme-color meta there never ships;
+    // without it Safari samples the page background to tint the status bar, which
+    // turns beige on every beige-canvas screen (login, search, profile…) while
+    // staying navy on the navy-canvas Discover screen — an inconsistent strip up
+    // top. A fixed navy theme-color makes the system bar cohesive everywhere; it
+    // only governs the top strip, so the beige bottom-toolbar blur is unaffected.
+    let themeMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    if (!themeMeta) {
+      themeMeta = document.createElement('meta');
+      themeMeta.name = 'theme-color';
+      document.head.appendChild(themeMeta);
+    }
+    themeMeta.content = '#0b1820';
     // iOS Safari 16+ ignores maximum-scale=1 in the viewport meta tag and still
     // auto-zooms when a focused input has font-size < 16 px.  Enforce the 16 px
     // floor globally so every text field — search bars, auth forms, filters — is

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -985,7 +985,7 @@ export default function WebCharacterScreen() {
                     source={heroImage}
                     contentFit="cover"
                     contentPosition="top"
-                    style={StyleSheet.absoluteFill}
+                    style={styles.mHeroImg}
                     cachePolicy="memory-disk"
                     recyclingKey={id}
                   />
@@ -2365,6 +2365,16 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     backgroundColor: COLORS.deepNavy,
   },
+  // Inset the portrait from the very top so the deep-navy backdrop shows above
+  // the hero's head — breathing room under the status bar / back button instead
+  // of the head sitting flush against the top edge.
+  mHeroImg: {
+    position: 'absolute',
+    top: 'calc(env(safe-area-inset-top) + 34px)',
+    left: 0,
+    right: 0,
+    bottom: 0,
+  } as object,
   mScrimTop: {
     position: 'absolute',
     top: 0,

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -2375,9 +2375,9 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    height: 'calc(env(safe-area-inset-top) + 150px)',
+    height: 'calc(env(safe-area-inset-top) + 210px)',
     backgroundImage:
-      'linear-gradient(to bottom, #0b1820 0%, rgba(11,24,32,0.82) 34%, rgba(11,24,32,0.4) 68%, transparent 100%)',
+      'linear-gradient(to bottom, #0b1820 0%, #0b1820 24%, rgba(11,24,32,0.72) 52%, rgba(11,24,32,0.32) 78%, transparent 100%)',
   } as object,
   mScrimBottom: {
     position: 'absolute',

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -123,7 +123,7 @@ export default function WebCharacterScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { width, height: winHeight } = useWindowDimensions();
-  const mHeroHeight = Math.round(winHeight * 0.75);
+  const mHeroHeight = Math.round(winHeight * 0.9);
   const isDesktop = width >= 700;
 
   // Document scroll so the page bleeds edge-to-edge under the iOS Safari toolbar.

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -985,7 +985,7 @@ export default function WebCharacterScreen() {
                     source={heroImage}
                     contentFit="cover"
                     contentPosition="top"
-                    style={styles.mHeroImg}
+                    style={StyleSheet.absoluteFill}
                     cachePolicy="memory-disk"
                     recyclingKey={id}
                   />
@@ -2365,24 +2365,20 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     backgroundColor: COLORS.deepNavy,
   },
-  // Inset the portrait from the very top so the deep-navy backdrop shows above
-  // the hero's head — breathing room under the status bar / back button instead
-  // of the head sitting flush against the top edge.
-  mHeroImg: {
-    position: 'absolute',
-    top: 'calc(env(safe-area-inset-top) + 34px)',
-    left: 0,
-    right: 0,
-    bottom: 0,
-  } as object,
+  // Deep-navy vignette over the top of the full-bleed portrait: opaque navy
+  // through the status bar + back-button zone, easing to transparent below. It
+  // fuses the navy status bar into the portrait (no hard cut), gives the head
+  // breathing room as it emerges from the gradient, and reads as one seamless
+  // surface from the system bar down into the art.
   mScrimTop: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    height: 140,
-    backgroundImage: 'linear-gradient(to bottom, rgba(18,26,30,0.55), transparent)',
-  },
+    height: 'calc(env(safe-area-inset-top) + 150px)',
+    backgroundImage:
+      'linear-gradient(to bottom, #0b1820 0%, rgba(11,24,32,0.82) 34%, rgba(11,24,32,0.4) 68%, transparent 100%)',
+  } as object,
   mScrimBottom: {
     position: 'absolute',
     left: 0,

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -123,7 +123,7 @@ export default function WebCharacterScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { width, height: winHeight } = useWindowDimensions();
-  const mHeroHeight = Math.round(winHeight * 0.62);
+  const mHeroHeight = Math.round(winHeight * 0.7);
   const isDesktop = width >= 700;
 
   // Document scroll so the page bleeds edge-to-edge under the iOS Safari toolbar.
@@ -2370,14 +2370,17 @@ const styles = StyleSheet.create({
   // fuses the navy status bar into the portrait (no hard cut), gives the head
   // breathing room as it emerges from the gradient, and reads as one seamless
   // surface from the system bar down into the art.
+  // Short, soft deep-navy cap: just enough to fuse the navy status-bar cover and
+  // the floating bar into the top of the portrait, then clear quickly so the
+  // hero's head/crown stays fully visible (the taller hero gives the headroom).
   mScrimTop: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    height: 'calc(env(safe-area-inset-top) + 210px)',
+    height: 'calc(env(safe-area-inset-top) + 96px)',
     backgroundImage:
-      'linear-gradient(to bottom, #0b1820 0%, #0b1820 24%, rgba(11,24,32,0.72) 52%, rgba(11,24,32,0.32) 78%, transparent 100%)',
+      'linear-gradient(to bottom, #0b1820 0%, rgba(11,24,32,0.55) 46%, rgba(11,24,32,0.18) 76%, transparent 100%)',
   } as object,
   mScrimBottom: {
     position: 'absolute',

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -123,7 +123,7 @@ export default function WebCharacterScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { width, height: winHeight } = useWindowDimensions();
-  const mHeroHeight = Math.round(winHeight * 0.7);
+  const mHeroHeight = Math.round(winHeight * 0.75);
   const isDesktop = width >= 700;
 
   // Document scroll so the page bleeds edge-to-edge under the iOS Safari toolbar.

--- a/src/components/web/HeroLogo.tsx
+++ b/src/components/web/HeroLogo.tsx
@@ -41,5 +41,7 @@ const styles = StyleSheet.create({
   },
   wordmark: {
     fontFamily: 'Righteous_400Regular',
-  },
+    // Web: ease the colour when the adaptive top chrome flips dark↔light.
+    transition: 'color 300ms ease',
+  } as object,
 });

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -233,7 +233,10 @@ const c = StyleSheet.create({
   // Scrolled frost: a stack of blur layers, each masked to a band, so the blur
   // is heaviest at the top (all three stacked, behind the icons) and tapers to
   // zero by the bottom — a graduated blur with no hard edge where sharp content
-  // would otherwise snap back. A light tint rides on top purely for icon contrast.
+  // would otherwise snap back. A heavy navy tint rides on top so the bar reads
+  // as a dark translucent surface (iOS dark-mode nav style) — the system status
+  // bar is locked dark navy, so only a dark bar flows seamlessly out of it; a
+  // light frosted bar would clash at the status-bar edge.
   frost: {
     position: 'absolute',
     top: 0,
@@ -263,7 +266,7 @@ const c = StyleSheet.create({
   } as object,
   frostTint: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.5) 0%, rgba(11,24,32,0.26) 52%, transparent 86%)',
+      'linear-gradient(to bottom, rgba(11,24,32,0.92) 0%, rgba(11,24,32,0.82) 46%, rgba(11,24,32,0.4) 74%, transparent 100%)',
   } as object,
   layerHidden: { opacity: 0 } as object,
   layerShown: { opacity: 1 } as object,

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -134,9 +134,7 @@ export function TopBar() {
       {/* On scroll: progressive frost — stacked blur layers tapering from strong
           (top, behind the icons) to none (bottom), so it dissolves with no edge. */}
       <View
-        style={
-          [c.frost, isMobile && (c.frostTall as object), scrolled && (c.layerShown as object)] as object
-        }
+        style={[c.frost, scrolled && (c.layerShown as object)] as object}
         pointerEvents="none"
       >
         <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
@@ -258,11 +256,6 @@ const c = StyleSheet.create({
     opacity: 0,
     transition: 'opacity 220ms ease',
   } as object,
-  // Mobile gets a longer tail so the dark frost has more room to ease out into
-  // the content below — a gentler, more flowing dissolve than the desktop bar.
-  frostTall: {
-    height: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top) + 56px)`,
-  } as object,
   frostA: {
     backdropFilter: 'blur(16px) saturate(150%)',
     WebkitBackdropFilter: 'blur(16px) saturate(150%)',
@@ -281,14 +274,12 @@ const c = StyleSheet.create({
     maskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
     WebkitMaskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
   } as object,
-  // Mobile: opaque navy through the status-cap + icon row (identical to the
-  // system bar, so the cap→bar boundary disappears), then a many-stop ease-out
-  // curve that decelerates smoothly to transparent — no visible kink or banding
-  // at any single stop, so the dark bar dissolves into content as one flowing
-  // gradient rather than a few stepped bands.
+  // Mobile: opaque navy only across the status-cap zone (so the cap→bar boundary
+  // disappears and the system bar flows in), then ease out quickly so it's a
+  // slim bridge from the status bar — not a heavy band sitting over the content.
   frostTintMobile: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,1) 36%, rgba(11,24,32,0.94) 48%, rgba(11,24,32,0.8) 60%, rgba(11,24,32,0.58) 71%, rgba(11,24,32,0.34) 81%, rgba(11,24,32,0.15) 90%, rgba(11,24,32,0.05) 96%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(11,24,32,0.96) 0%, rgba(11,24,32,0.72) 30%, rgba(11,24,32,0.4) 54%, rgba(11,24,32,0.14) 78%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -133,7 +133,12 @@ export function TopBar() {
       <View style={[c.topScrim, scrolled && (c.layerHidden as object)] as object} pointerEvents="none" />
       {/* On scroll: progressive frost — stacked blur layers tapering from strong
           (top, behind the icons) to none (bottom), so it dissolves with no edge. */}
-      <View style={[c.frost, scrolled && (c.layerShown as object)] as object} pointerEvents="none">
+      <View
+        style={
+          [c.frost, isMobile && (c.frostTall as object), scrolled && (c.layerShown as object)] as object
+        }
+        pointerEvents="none"
+      >
         <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
@@ -253,6 +258,11 @@ const c = StyleSheet.create({
     opacity: 0,
     transition: 'opacity 220ms ease',
   } as object,
+  // Mobile gets a longer tail so the dark frost has more room to ease out into
+  // the content below — a gentler, more flowing dissolve than the desktop bar.
+  frostTall: {
+    height: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top) + 56px)`,
+  } as object,
   frostA: {
     backdropFilter: 'blur(16px) saturate(150%)',
     WebkitBackdropFilter: 'blur(16px) saturate(150%)',
@@ -272,11 +282,13 @@ const c = StyleSheet.create({
     WebkitMaskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
   } as object,
   // Mobile: opaque navy through the status-cap + icon row (identical to the
-  // system bar, so the cap→bar boundary disappears), then a long ease-out so the
-  // bottom edge melts into content with no hard line.
+  // system bar, so the cap→bar boundary disappears), then a many-stop ease-out
+  // curve that decelerates smoothly to transparent — no visible kink or banding
+  // at any single stop, so the dark bar dissolves into content as one flowing
+  // gradient rather than a few stepped bands.
   frostTintMobile: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,1) 40%, rgba(11,24,32,0.6) 66%, rgba(11,24,32,0.22) 86%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,1) 36%, rgba(11,24,32,0.94) 48%, rgba(11,24,32,0.8) 60%, rgba(11,24,32,0.58) 71%, rgba(11,24,32,0.34) 81%, rgba(11,24,32,0.15) 90%, rgba(11,24,32,0.05) 96%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -299,13 +299,13 @@ const c = StyleSheet.create({
     backgroundImage:
       'linear-gradient(to bottom, rgba(245,235,220,0.96) 0%, rgba(245,235,220,0.74) 32%, rgba(245,235,220,0.38) 60%, rgba(245,235,220,0.12) 82%, transparent 100%)',
   } as object,
-  // Mobile dark-topped pages: a translucent dark-navy glass — dark enough to
-  // stay seamless with the navy status bar and keep light icons legible, but
-  // never fully opaque, so the content blurs through it (glass, not a slab) and
-  // it eases out at the bottom into the page.
+  // Mobile dark-topped pages: a dark-navy glass that's opaque at the very top so
+  // it fuses seamlessly with the navy status-bar cover (no beige bleed-through,
+  // no step at the boundary), holds through the icon row for legibility, then
+  // eases out — translucent lower down so content still blurs through it.
   frostTintDark: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.88) 0%, rgba(11,24,32,0.68) 42%, rgba(11,24,32,0.4) 70%, rgba(11,24,32,0.14) 90%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(11,24,32,0.99) 0%, rgba(11,24,32,0.9) 28%, rgba(11,24,32,0.6) 58%, rgba(11,24,32,0.26) 82%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -38,10 +38,9 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
   const { width } = useWindowDimensions();
   const isMobile = width < 768;
 
-  // Adaptive chrome (mobile): the bar matches the page colour under it — a dark
-  // scrim over the hero, a light frosted bar over the content — and the icons
-  // flip for contrast. Desktop keeps the classic dark scrim → light frost keyed
-  // on scroll, so `isLight` only steers the mobile bar.
+  // The bar is locked to the page's top colour (status bar + bar always match,
+  // so the top edge is seamless). `isLight` flips the icons/tints to dark on the
+  // rare light-topped screen; every current page is dark-topped → dark chrome.
   const { isLight } = useWebChrome();
   const lightChrome = isMobile && isLight;
 
@@ -145,11 +144,18 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
   // Desktop auth keeps its own branding; the logo-only bar is a mobile affordance.
   if (logoOnly && !isMobile) return null;
 
-  // Dark scrim shows over the hero (mobile header mode / desktop at-top); the
-  // frosted bar shows over content (mobile light mode / desktop scrolled). On
-  // mobile the frost is tinted to the page (beige); desktop keeps its light tint.
-  const darkScrimShown = isMobile ? !isLight : !scrolled;
-  const frostShown = isMobile ? isLight : scrolled;
+  // At the very top the bar is a soft scrim over the hero; once scrolled it
+  // becomes a frosted bar over the content. Both stay the chrome colour (dark
+  // for navy-topped pages), so the bar never clashes with the status bar.
+  const darkScrimShown = !scrolled;
+  const frostShown = scrolled;
+  // Frost tint: light-glass on a light-topped page, otherwise a dark glass on
+  // mobile / the classic light-navy frost on desktop.
+  const frostTint = lightChrome
+    ? c.frostTintLight
+    : isMobile
+      ? c.frostTintDark
+      : c.frostTintDesktop;
 
   const bar = (
     <View style={c.bar as object} pointerEvents="box-none">
@@ -169,11 +175,7 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
         <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
-        <View
-          style={
-            [StyleSheet.absoluteFill, lightChrome ? c.frostTintLight : c.frostTintDesktop] as object
-          }
-        />
+        <View style={[StyleSheet.absoluteFill, frostTint] as object} />
       </View>
       <View style={[c.inner, { paddingHorizontal: isMobile ? 16 : 28 }] as object} pointerEvents="box-none">
         <Pressable onPress={() => router.push('/explore')} style={c.logo}>
@@ -296,6 +298,14 @@ const c = StyleSheet.create({
   frostTintLight: {
     backgroundImage:
       'linear-gradient(to bottom, rgba(245,235,220,0.96) 0%, rgba(245,235,220,0.74) 32%, rgba(245,235,220,0.38) 60%, rgba(245,235,220,0.12) 82%, transparent 100%)',
+  } as object,
+  // Mobile dark-topped pages: a translucent dark-navy glass — dark enough to
+  // stay seamless with the navy status bar and keep light icons legible, but
+  // never fully opaque, so the content blurs through it (glass, not a slab) and
+  // it eases out at the bottom into the page.
+  frostTintDark: {
+    backgroundImage:
+      'linear-gradient(to bottom, rgba(11,24,32,0.88) 0%, rgba(11,24,32,0.68) 42%, rgba(11,24,32,0.4) 70%, rgba(11,24,32,0.14) 90%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -144,39 +144,36 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
   // Desktop auth keeps its own branding; the logo-only bar is a mobile affordance.
   if (logoOnly && !isMobile) return null;
 
-  // At the very top the bar is a soft scrim over the hero; once scrolled it
-  // becomes a frosted bar over the content. Both stay the chrome colour (dark
-  // for navy-topped pages), so the bar never clashes with the status bar.
-  const darkScrimShown = !scrolled;
-  const frostShown = scrolled;
-  // Frost tint: light-glass on a light-topped page, otherwise a dark glass on
-  // mobile / the classic light-navy frost on desktop.
-  const frostTint = lightChrome
-    ? c.frostTintLight
-    : isMobile
-      ? c.frostTintDark
-      : c.frostTintDesktop;
+  // Mobile keeps ONE consistent scrim at every scroll position — opaque navy at
+  // the top so it fuses with the status bar, easing into the page below — so the
+  // bar never restyles as you scroll. Desktop keeps the classic transparent
+  // scrim-over-hero → frosted-bar-on-scroll.
+  const mobileScrim = lightChrome ? c.frostTintLight : c.frostTintDark;
 
   const bar = (
     <View style={c.bar as object} pointerEvents="box-none">
-      {/* Soft dark gradient for light-icon legibility over the hero. */}
-      <View
-        style={[c.topScrim, !darkScrimShown && (c.layerHidden as object)] as object}
-        pointerEvents="none"
-      />
-      {/* Frosted bar over content: stacked blur layers tapering from strong (top,
-          behind the icons) to none (bottom) so it dissolves with no edge, plus a
-          tint that's opaque at the very top — matching the status-bar cover — and
-          eases out into the content below. */}
-      <View
-        style={[c.frost, frostShown && (c.layerShown as object)] as object}
-        pointerEvents="none"
-      >
-        <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
-        <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
-        <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
-        <View style={[StyleSheet.absoluteFill, frostTint] as object} />
-      </View>
+      {isMobile ? (
+        // Consistent scrim — same at the top and when scrolled.
+        <View style={[c.scrim, mobileScrim] as object} pointerEvents="none" />
+      ) : (
+        <>
+          {/* Desktop: soft dark gradient over the hero at the top… */}
+          <View
+            style={[c.topScrim, scrolled && (c.layerHidden as object)] as object}
+            pointerEvents="none"
+          />
+          {/* …becoming a frosted bar once content scrolls up behind it. */}
+          <View
+            style={[c.frost, scrolled && (c.layerShown as object)] as object}
+            pointerEvents="none"
+          >
+            <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
+            <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
+            <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
+            <View style={[StyleSheet.absoluteFill, c.frostTintDesktop] as object} />
+          </View>
+        </>
+      )}
       <View style={[c.inner, { paddingHorizontal: isMobile ? 16 : 28 }] as object} pointerEvents="box-none">
         <Pressable onPress={() => router.push('/explore')} style={c.logo}>
           <HeroLogo iconSize={24} fontSize={19} color={foreground} gap={8} />
@@ -244,6 +241,16 @@ const c = StyleSheet.create({
     // collapse), position:fixed elements scroll with the page. Forcing a GPU
     // compositing layer via will-change makes them truly fixed again.
     willChange: 'transform',
+  } as object,
+  // Consistent mobile scrim container — the gradient (frostTintDark/Light) is
+  // applied on top. Spans the bar + a short tail so the tint reaches transparent
+  // by the bar's bottom edge, easing into the page.
+  scrim: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top) + 30px)`,
   } as object,
   // Dark scrim: holds near-solid navy across the status-bar inset + icon row (so
   // it fuses with the navy status-bar cover and bright hero art never bleeds

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -299,13 +299,13 @@ const c = StyleSheet.create({
     backgroundImage:
       'linear-gradient(to bottom, rgba(245,235,220,0.96) 0%, rgba(245,235,220,0.74) 32%, rgba(245,235,220,0.38) 60%, rgba(245,235,220,0.12) 82%, transparent 100%)',
   } as object,
-  // Mobile dark-topped pages: a dark-navy glass that's opaque at the very top so
-  // it fuses seamlessly with the navy status-bar cover (no beige bleed-through,
-  // no step at the boundary), holds through the icon row for legibility, then
-  // eases out — translucent lower down so content still blurs through it.
+  // Mobile dark-topped pages: opaque deep-navy at the very top so it's identical
+  // to the navy status-bar cover above it (one continuous surface), then a
+  // many-stop ease-out that decelerates smoothly to transparent — an elegant,
+  // edgeless fade from the dark top section down into the content.
   frostTintDark: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.99) 0%, rgba(11,24,32,0.9) 28%, rgba(11,24,32,0.6) 58%, rgba(11,24,32,0.26) 82%, transparent 100%)',
+      'linear-gradient(to bottom, #0b1820 0%, #0b1820 20%, rgba(11,24,32,0.92) 36%, rgba(11,24,32,0.74) 52%, rgba(11,24,32,0.5) 66%, rgba(11,24,32,0.28) 80%, rgba(11,24,32,0.12) 91%, rgba(11,24,32,0.04) 97%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -153,8 +153,16 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
   const bar = (
     <View style={c.bar as object} pointerEvents="box-none">
       {isMobile ? (
-        // Consistent scrim — same at the top and when scrolled.
-        <View style={[c.scrim, mobileScrim] as object} pointerEvents="none" />
+        // One consistent frosted scrim at every scroll position — graduated blur
+        // (also the GPU-compositing layer that keeps the fixed bar from scrolling
+        // on iOS) under a tint that's opaque navy at the top, fused with the
+        // status bar, easing into the page below.
+        <View style={c.scrim as object} pointerEvents="none">
+          <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
+          <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
+          <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
+          <View style={[StyleSheet.absoluteFill, mobileScrim] as object} />
+        </View>
       ) : (
         <>
           {/* Desktop: soft dark gradient over the hero at the top… */}

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -26,7 +26,10 @@ const NAV: { key: string; path: string; icon: IoniconName; iconOutline: IoniconN
 
 // Transparent floating top bar with a top-down scrim. Logo left, nav icons
 // centre (desktop), avatar / sign-in right. Used on every web page, all widths.
-export function TopBar() {
+// `logoOnly` (auth screens) drops the nav/account controls — just the brand over
+// the page's own hero — and renders nothing on desktop, where auth has its own
+// split-panel branding.
+export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
   const router = useRouter();
   const pathname = usePathname();
   const { user } = useAuth();
@@ -139,6 +142,9 @@ export function TopBar() {
   // that ancestor React Native / React Navigation containers might apply, which
   // would otherwise make `position: fixed` relative to that container instead
   // of the viewport and cause the bar to scroll with the page content.
+  // Desktop auth keeps its own branding; the logo-only bar is a mobile affordance.
+  if (logoOnly && !isMobile) return null;
+
   // Dark scrim shows over the hero (mobile header mode / desktop at-top); the
   // frosted bar shows over content (mobile light mode / desktop scrolled). On
   // mobile the frost is tinted to the page (beige); desktop keeps its light tint.
@@ -174,8 +180,9 @@ export function TopBar() {
           <HeroLogo iconSize={24} fontSize={19} color={foreground} gap={8} />
         </Pressable>
 
-        {!isMobile && <View style={c.center}>{NAV.map(renderItem)}</View>}
+        {!isMobile && !logoOnly && <View style={c.center}>{NAV.map(renderItem)}</View>}
 
+        {!logoOnly && (
         <View style={c.right}>
           {isMobile && NAV.filter((it) => it.key !== 'home').map(renderItem)}
           {user ? (
@@ -206,8 +213,9 @@ export function TopBar() {
             </Pressable>
           )}
         </View>
+        )}
       </View>
-      {!isMobile && <SearchPalette />}
+      {!isMobile && !logoOnly && <SearchPalette />}
     </View>
   );
 

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -121,9 +121,14 @@ export function TopBar() {
         }
       >
         {it.key === 'versus' ? (
-          <MaterialCommunityIcons name="sword-cross" size={22} color={tint} />
+          <MaterialCommunityIcons name="sword-cross" size={22} color={tint} style={c.iconTint} />
         ) : (
-          <Ionicons name={active ? it.icon : it.iconOutline} size={22} color={tint} />
+          <Ionicons
+            name={active ? it.icon : it.iconOutline}
+            size={22}
+            color={tint}
+            style={c.iconTint}
+          />
         )}
       </Pressable>
     );
@@ -197,7 +202,7 @@ export function TopBar() {
                 [c.item, hovered && hoverStyle] as object
               }
             >
-              <Ionicons name="person-outline" size={20} color={foreground} />
+              <Ionicons name="person-outline" size={20} color={foreground} style={c.iconTint} />
             </Pressable>
           )}
         </View>
@@ -242,7 +247,7 @@ const c = StyleSheet.create({
     backgroundImage:
       'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,0.85) 30%, rgba(11,24,32,0.45) 62%, rgba(11,24,32,0.14) 84%, transparent 100%)',
     opacity: 1,
-    transition: 'opacity 220ms ease',
+    transition: 'opacity 300ms ease',
   } as object,
   // Scrolled frost: a stack of blur layers, each masked to a band, so the blur
   // is heaviest at the top (all three stacked, behind the icons) and tapers to
@@ -256,7 +261,7 @@ const c = StyleSheet.create({
     right: 0,
     height: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top) + 28px)`,
     opacity: 0,
-    transition: 'opacity 220ms ease',
+    transition: 'opacity 300ms ease',
   } as object,
   frostA: {
     backdropFilter: 'blur(16px) saturate(150%)',
@@ -291,6 +296,9 @@ const c = StyleSheet.create({
   } as object,
   layerHidden: { opacity: 0 } as object,
   layerShown: { opacity: 1 } as object,
+  // Ease icon/glyph colour when the chrome flips dark↔light, in step with the
+  // background cross-fade and the status-bar tint.
+  iconTint: { transition: 'color 300ms ease' } as object,
   inner: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -122,6 +122,13 @@ export function TopBar() {
   // of the viewport and cause the bar to scroll with the page content.
   const bar = (
     <View style={c.bar as object} pointerEvents="box-none">
+      {/* Solid navy cap over exactly the iOS status-bar inset. In a Safari tab
+          the system status bar is a flat opaque fill (theme-color #0b1820) that
+          can't be made transparent; matching it pixel-for-pixel here — and never
+          letting hero art bleed through this zone — fuses the system bar and the
+          page into one seamless dark cap. Persists on scroll so the status bar
+          stays solid even when beige content sits underneath. */}
+      <View style={c.statusCap as object} pointerEvents="none" />
       {/* At top: a soft gradient for icon legibility over the hero. */}
       <View style={[c.topScrim, scrolled && (c.layerHidden as object)] as object} pointerEvents="none" />
       {/* On scroll: progressive frost — stacked blur layers tapering from strong
@@ -198,9 +205,20 @@ const c = StyleSheet.create({
     // compositing layer via will-change makes them truly fixed again.
     willChange: 'transform',
   } as object,
-  // At-top scrim: a soft gradient with a long tail, just enough to keep light
-  // icons legible over the hero (incl. bright art under the right-side avatar).
-  // Navy-over-navy reads as seamless on the dark headers.
+  // Solid #0b1820 fill spanning just the status-bar inset, matching the
+  // theme-color the system bar uses. env() resolves to 0 where there's no safe
+  // area, so this is a no-op on Android/desktop.
+  statusCap: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 'env(safe-area-inset-top)',
+    backgroundColor: '#0b1820',
+  } as object,
+  // At-top scrim: picks up where the cap ends, holding solid navy through the
+  // icon row (so bright hero art never bleeds behind the logo/avatar) before a
+  // long fade to transparent. Navy-over-navy reads as seamless on dark headers.
   topScrim: {
     position: 'absolute',
     top: 0,
@@ -208,7 +226,7 @@ const c = StyleSheet.create({
     right: 0,
     height: `calc(${TOPBAR_HEIGHT}px + env(safe-area-inset-top) + 30px)`,
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.85) 0%, rgba(11,24,32,0.5) 42%, rgba(11,24,32,0.16) 76%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,0.85) 30%, rgba(11,24,32,0.45) 62%, rgba(11,24,32,0.14) 84%, transparent 100%)',
     opacity: 1,
     transition: 'opacity 220ms ease',
   } as object,

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -137,7 +137,16 @@ export function TopBar() {
         <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
-        <View style={[StyleSheet.absoluteFill, c.frostTint] as object} />
+        {/* Mobile: a dark tint that's fully opaque at the very top (matching the
+            status cap + system bar exactly, so there's no step) before fading,
+            making the bar flow out of the locked dark status bar. Desktop keeps
+            the original light frosted glass — there's no system status bar to
+            blend with there. */}
+        <View
+          style={
+            [StyleSheet.absoluteFill, isMobile ? c.frostTintMobile : c.frostTintDesktop] as object
+          }
+        />
       </View>
       <View style={[c.inner, { paddingHorizontal: isMobile ? 16 : 28 }] as object} pointerEvents="box-none">
         <Pressable onPress={() => router.push('/explore')} style={c.logo}>
@@ -233,10 +242,8 @@ const c = StyleSheet.create({
   // Scrolled frost: a stack of blur layers, each masked to a band, so the blur
   // is heaviest at the top (all three stacked, behind the icons) and tapers to
   // zero by the bottom — a graduated blur with no hard edge where sharp content
-  // would otherwise snap back. A heavy navy tint rides on top so the bar reads
-  // as a dark translucent surface (iOS dark-mode nav style) — the system status
-  // bar is locked dark navy, so only a dark bar flows seamlessly out of it; a
-  // light frosted bar would clash at the status-bar edge.
+  // would otherwise snap back. The tint that rides on top is platform-specific
+  // (see frostTintMobile / frostTintDesktop below).
   frost: {
     position: 'absolute',
     top: 0,
@@ -264,9 +271,17 @@ const c = StyleSheet.create({
     maskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
     WebkitMaskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
   } as object,
-  frostTint: {
+  // Mobile: opaque navy through the status-cap + icon row (identical to the
+  // system bar, so the cap→bar boundary disappears), then a long ease-out so the
+  // bottom edge melts into content with no hard line.
+  frostTintMobile: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.92) 0%, rgba(11,24,32,0.82) 46%, rgba(11,24,32,0.4) 74%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,1) 40%, rgba(11,24,32,0.6) 66%, rgba(11,24,32,0.22) 86%, transparent 100%)',
+  } as object,
+  // Desktop: the original light frosted glass — no system status bar to match.
+  frostTintDesktop: {
+    backgroundImage:
+      'linear-gradient(to bottom, rgba(11,24,32,0.5) 0%, rgba(11,24,32,0.26) 52%, transparent 86%)',
   } as object,
   layerHidden: { opacity: 0 } as object,
   layerShown: { opacity: 1 } as object,

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -6,6 +6,7 @@ import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/colors';
 import { useAuth } from '../../hooks/useAuth';
 import { useSearch } from '../../contexts/SearchContext';
+import { useWebChrome } from '../../contexts/WebChromeContext';
 import { HeroLogo } from './HeroLogo';
 import { SearchPalette } from './search/SearchPalette';
 
@@ -33,6 +34,13 @@ export function TopBar() {
   const initial = user?.email?.charAt(0).toUpperCase() ?? '';
   const { width } = useWindowDimensions();
   const isMobile = width < 768;
+
+  // Adaptive chrome (mobile): the bar matches the page colour under it — a dark
+  // scrim over the hero, a light frosted bar over the content — and the icons
+  // flip for contrast. Desktop keeps the classic dark scrim → light frost keyed
+  // on scroll, so `isLight` only steers the mobile bar.
+  const { isLight } = useWebChrome();
+  const lightChrome = isMobile && isLight;
 
   // Desktop: the search icon opens a command palette; mobile routes to /search.
   const openSearch = () => (isMobile ? router.push('/search') : setSearchFocused(true));
@@ -90,9 +98,15 @@ export function TopBar() {
         : pathname === path;
   const go = (path: string) => router.push(path as Parameters<typeof router.push>[0]);
 
+  // Icon/text colour flips with the chrome: dark glyphs on the light bar, light
+  // glyphs on the dark scrim. Active stays orange in both.
+  const inactiveTint = lightChrome ? 'rgba(41,60,67,0.78)' : 'rgba(245,235,220,0.7)';
+  const foreground = lightChrome ? COLORS.navy : COLORS.beige;
+  const hoverStyle = lightChrome ? (c.itemHoverLight as object) : (c.itemHover as object);
+
   const renderItem = (it: (typeof NAV)[number]) => {
     const active = navActive(it.key, it.path);
-    const tint = active ? COLORS.orange : 'rgba(245,235,220,0.7)';
+    const tint = active ? COLORS.orange : inactiveTint;
     return (
       <Pressable
         key={it.key}
@@ -102,7 +116,7 @@ export function TopBar() {
           [
             c.item,
             active && (c.itemActive as object),
-            !active && hovered && (c.itemHover as object),
+            !active && hovered && hoverStyle,
           ] as object
         }
       >
@@ -120,40 +134,39 @@ export function TopBar() {
   // that ancestor React Native / React Navigation containers might apply, which
   // would otherwise make `position: fixed` relative to that container instead
   // of the viewport and cause the bar to scroll with the page content.
+  // Dark scrim shows over the hero (mobile header mode / desktop at-top); the
+  // frosted bar shows over content (mobile light mode / desktop scrolled). On
+  // mobile the frost is tinted to the page (beige); desktop keeps its light tint.
+  const darkScrimShown = isMobile ? !isLight : !scrolled;
+  const frostShown = isMobile ? isLight : scrolled;
+
   const bar = (
     <View style={c.bar as object} pointerEvents="box-none">
-      {/* Solid navy cap over exactly the iOS status-bar inset. In a Safari tab
-          the system status bar is a flat opaque fill (theme-color #0b1820) that
-          can't be made transparent; matching it pixel-for-pixel here — and never
-          letting hero art bleed through this zone — fuses the system bar and the
-          page into one seamless dark cap. Persists on scroll so the status bar
-          stays solid even when beige content sits underneath. */}
-      <View style={c.statusCap as object} pointerEvents="none" />
-      {/* At top: a soft gradient for icon legibility over the hero. */}
-      <View style={[c.topScrim, scrolled && (c.layerHidden as object)] as object} pointerEvents="none" />
-      {/* On scroll: progressive frost — stacked blur layers tapering from strong
-          (top, behind the icons) to none (bottom), so it dissolves with no edge. */}
+      {/* Soft dark gradient for light-icon legibility over the hero. */}
       <View
-        style={[c.frost, scrolled && (c.layerShown as object)] as object}
+        style={[c.topScrim, !darkScrimShown && (c.layerHidden as object)] as object}
+        pointerEvents="none"
+      />
+      {/* Frosted bar over content: stacked blur layers tapering from strong (top,
+          behind the icons) to none (bottom) so it dissolves with no edge, plus a
+          tint that's opaque at the very top — matching the status-bar cover — and
+          eases out into the content below. */}
+      <View
+        style={[c.frost, frostShown && (c.layerShown as object)] as object}
         pointerEvents="none"
       >
         <View style={[StyleSheet.absoluteFill, c.frostA] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostB] as object} />
         <View style={[StyleSheet.absoluteFill, c.frostC] as object} />
-        {/* Mobile: a dark tint that's fully opaque at the very top (matching the
-            status cap + system bar exactly, so there's no step) before fading,
-            making the bar flow out of the locked dark status bar. Desktop keeps
-            the original light frosted glass — there's no system status bar to
-            blend with there. */}
         <View
           style={
-            [StyleSheet.absoluteFill, isMobile ? c.frostTintMobile : c.frostTintDesktop] as object
+            [StyleSheet.absoluteFill, lightChrome ? c.frostTintLight : c.frostTintDesktop] as object
           }
         />
       </View>
       <View style={[c.inner, { paddingHorizontal: isMobile ? 16 : 28 }] as object} pointerEvents="box-none">
         <Pressable onPress={() => router.push('/explore')} style={c.logo}>
-          <HeroLogo iconSize={24} fontSize={19} color={COLORS.beige} gap={8} />
+          <HeroLogo iconSize={24} fontSize={19} color={foreground} gap={8} />
         </Pressable>
 
         {!isMobile && <View style={c.center}>{NAV.map(renderItem)}</View>}
@@ -165,7 +178,7 @@ export function TopBar() {
               aria-label="Profile"
               onPress={() => router.push('/profile')}
               style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
-                [c.item, hovered && (c.itemHover as object)] as object
+                [c.item, hovered && hoverStyle] as object
               }
             >
               <View style={c.avatar}>
@@ -181,10 +194,10 @@ export function TopBar() {
               }}
               onPress={() => router.push('/(auth)/login')}
               style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
-                [c.item, hovered && (c.itemHover as object)] as object
+                [c.item, hovered && hoverStyle] as object
               }
             >
-              <Ionicons name="person-outline" size={20} color={COLORS.beige} />
+              <Ionicons name="person-outline" size={20} color={foreground} />
             </Pressable>
           )}
         </View>
@@ -217,20 +230,9 @@ const c = StyleSheet.create({
     // compositing layer via will-change makes them truly fixed again.
     willChange: 'transform',
   } as object,
-  // Solid #0b1820 fill spanning just the status-bar inset, matching the
-  // theme-color the system bar uses. env() resolves to 0 where there's no safe
-  // area, so this is a no-op on Android/desktop.
-  statusCap: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 'env(safe-area-inset-top)',
-    backgroundColor: '#0b1820',
-  } as object,
-  // At-top scrim: picks up where the cap ends, holding solid navy through the
-  // icon row (so bright hero art never bleeds behind the logo/avatar) before a
-  // long fade to transparent. Navy-over-navy reads as seamless on dark headers.
+  // Dark scrim: holds near-solid navy across the status-bar inset + icon row (so
+  // it fuses with the navy status-bar cover and bright hero art never bleeds
+  // behind the logo/avatar) before a long fade to transparent.
   topScrim: {
     position: 'absolute',
     top: 0,
@@ -246,7 +248,7 @@ const c = StyleSheet.create({
   // is heaviest at the top (all three stacked, behind the icons) and tapers to
   // zero by the bottom — a graduated blur with no hard edge where sharp content
   // would otherwise snap back. The tint that rides on top is platform-specific
-  // (see frostTintMobile / frostTintDesktop below).
+  // (see frostTintLight / frostTintDesktop below).
   frost: {
     position: 'absolute',
     top: 0,
@@ -274,12 +276,13 @@ const c = StyleSheet.create({
     maskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
     WebkitMaskImage: 'linear-gradient(to bottom, #000 0%, #000 52%, transparent 94%)',
   } as object,
-  // Mobile: opaque navy only across the status-cap zone (so the cap→bar boundary
-  // disappears and the system bar flows in), then ease out quickly so it's a
-  // slim bridge from the status bar — not a heavy band sitting over the content.
-  frostTintMobile: {
+  // Mobile light mode: a beige tint, opaque at the very top (matching the beige
+  // status-bar cover exactly, so there's no step) then easing out into the
+  // content — the bar reads as one frosted-beige surface flowing off the status
+  // bar, with dark icons on top.
+  frostTintLight: {
     backgroundImage:
-      'linear-gradient(to bottom, rgba(11,24,32,0.96) 0%, rgba(11,24,32,0.72) 30%, rgba(11,24,32,0.4) 54%, rgba(11,24,32,0.14) 78%, transparent 100%)',
+      'linear-gradient(to bottom, rgba(245,235,220,0.96) 0%, rgba(245,235,220,0.74) 32%, rgba(245,235,220,0.38) 60%, rgba(245,235,220,0.12) 82%, transparent 100%)',
   } as object,
   // Desktop: the original light frosted glass — no system status bar to match.
   frostTintDesktop: {
@@ -308,6 +311,7 @@ const c = StyleSheet.create({
   } as object,
   itemActive: { backgroundColor: 'rgba(231,115,51,0.16)' } as object,
   itemHover: { backgroundColor: 'rgba(255,255,255,0.08)' } as object,
+  itemHoverLight: { backgroundColor: 'rgba(41,60,67,0.08)' } as object,
   // Both account states (avatar / logged-out icon) sit inside the shared `item`
   // hover container, so the whole top bar hovers identically.
   avatar: {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -246,8 +246,10 @@ const c = StyleSheet.create({
     zIndex: 100,
     justifyContent: 'center',
     // iOS Safari bug: when body has overflow:visible (needed for toolbar
-    // collapse), position:fixed elements scroll with the page. Forcing a GPU
-    // compositing layer via will-change makes them truly fixed again.
+    // collapse), position:fixed elements drift/scroll with the page. A real
+    // transform (not just the will-change hint, which Safari may ignore) forces
+    // a dedicated GPU compositing layer and keeps the bar reliably pinned.
+    transform: 'translateZ(0)',
     willChange: 'transform',
   } as object,
   // Consistent mobile scrim container — the gradient (frostTintDark/Light) is

--- a/src/contexts/WebChromeContext.tsx
+++ b/src/contexts/WebChromeContext.tsx
@@ -148,6 +148,10 @@ const coverStyles = StyleSheet.create({
     right: 0,
     height: 'env(safe-area-inset-top)',
     zIndex: 9999,
+    // Force a GPU compositing layer so the fixed strip stays pinned on iOS
+    // (body overflow:visible otherwise lets fixed elements drift on scroll).
+    transform: 'translateZ(0)',
+    willChange: 'transform',
     transition: `background-color ${CHROME_FADE_MS}ms ease`,
   } as object,
 });

--- a/src/contexts/WebChromeContext.tsx
+++ b/src/contexts/WebChromeContext.tsx
@@ -71,6 +71,13 @@ function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
   };
 }
 
+// iOS Safari only honours *hex* theme-color values for the status-bar tint — it
+// silently ignores rgb(), so the animated frames must be hex too.
+function rgbToHex(r: number, g: number, b: number): string {
+  const h = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
 // Duration of the chrome colour cross-fade. Shared by the status-bar tint
 // animation here and the CSS transitions on the bar/cover, so the whole top
 // edge changes colour as one synchronised motion.
@@ -137,7 +144,7 @@ export function WebChromeProvider({ children }: { children: ReactNode }) {
       const g = Math.round(from.g + (to.g - from.g) * e);
       const b = Math.round(from.b + (to.b - from.b) * e);
       themeRgbRef.current = { r, g, b };
-      meta!.content = `rgb(${r}, ${g}, ${b})`;
+      meta!.content = rgbToHex(r, g, b);
       if (t < 1) raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);

--- a/src/contexts/WebChromeContext.tsx
+++ b/src/contexts/WebChromeContext.tsx
@@ -9,48 +9,35 @@ import {
   type ReactNode,
 } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { usePathname } from 'expo-router';
 import { COLORS } from '../constants/colors';
 
 /**
- * Adaptive web top-chrome.
+ * Web top-chrome colour.
  *
- * Every mobile-web page is shaped the same way: a dark hero header at the very
- * top, then a light (beige) content canvas below. A single static chrome can
- * only ever match one of those, so the status bar / top bar always clashes with
- * the other. This context makes the chrome adaptive instead: a page declares its
- * two colours (the header tint at the top, the content tint once scrolled) and
- * drops a <ChromeSentinel /> at the bottom edge of its dark header. As that
- * sentinel scrolls under the bar we flip `mode`, and everything that paints the
- * top — the floating top bar, its icon colours, the status-bar cover, and the
- * iOS `theme-color` meta that tints the system status bar — derives from the
- * single resolved `color`, so the whole top edge stays seamless at every scroll
- * position on every page.
+ * In a Safari tab the iOS system status bar can't be reliably re-tinted on
+ * scroll (dynamic theme-color updates don't repaint it), so rather than let the
+ * status bar and the top bar drift apart we keep them locked together: the top
+ * bar, the status-bar cover, and the theme-color meta all match a single colour
+ * the page declares — the tint at the very top of that screen. The result is a
+ * top edge that's always seamless (status bar → cover → bar read as one piece),
+ * consistent across every page.
  */
 
-type ChromeMode = 'header' | 'content';
-
 interface WebChromeValue {
-  /** The colour the chrome is currently matching (header tint or content tint). */
+  /** The colour the chrome matches — the tint at the very top of the screen. */
   color: string;
   /** True when `color` is light enough to need dark icons/text on top of it. */
   isLight: boolean;
-  /** Declare this screen's header tint (top) and content tint (scrolled). */
-  setColors: (header: string, content: string) => void;
-  /** Sentinels report whether the dark header still covers the top bar. */
-  setHeaderCovering: (covering: boolean) => void;
+  /** Declare this screen's top colour. */
+  setColor: (color: string) => void;
 }
 
-const DEFAULTS: { header: string; content: string } = {
-  header: COLORS.deepNavy,
-  content: COLORS.beige,
-};
+const DEFAULT_COLOR: string = COLORS.deepNavy;
 
 const WebChromeContext = createContext<WebChromeValue>({
-  color: DEFAULTS.header,
+  color: DEFAULT_COLOR,
   isLight: false,
-  setColors: () => {},
-  setHeaderCovering: () => {},
+  setColor: () => {},
 });
 
 // Perceived luminance (sRGB weights). Above the threshold the surface is light
@@ -79,44 +66,26 @@ function rgbToHex(r: number, g: number, b: number): string {
 }
 
 // Duration of the chrome colour cross-fade. Shared by the status-bar tint
-// animation here and the CSS transitions on the bar/cover, so the whole top
-// edge changes colour as one synchronised motion.
+// animation here and the CSS transition on the cover, so the whole top edge
+// changes colour as one synchronised motion when a new page declares a new tint.
 const CHROME_FADE_MS = 300;
 
 export function WebChromeProvider({ children }: { children: ReactNode }) {
-  const [colors, setColorsState] = useState(DEFAULTS);
-  // Default to header mode: a fresh route always opens at the top, over its hero.
-  const [mode, setMode] = useState<ChromeMode>('header');
+  const [color, setColorState] = useState(DEFAULT_COLOR);
 
-  const setColors = useCallback((header: string, content: string) => {
-    setColorsState((prev) =>
-      prev.header === header && prev.content === content ? prev : { header, content }
-    );
-  }, []);
-
-  const setHeaderCovering = useCallback(
-    (covering: boolean) => setMode(covering ? 'header' : 'content'),
+  const setColor = useCallback(
+    (next: string) => setColorState((prev) => (prev === next ? prev : next)),
     []
   );
 
-  // Every route opens at the top, over its header — reset to header mode on
-  // navigation so a page left in content mode doesn't bleed into the next one
-  // before its sentinel re-measures.
-  const pathname = usePathname();
-  useEffect(() => setMode('header'), [pathname]);
-
-  const color = mode === 'header' ? colors.header : colors.content;
   const isLight = isLightColor(color);
 
   // Drive the iOS Safari status-bar tint. Expo's single web output ignores
-  // app/+html.tsx, so we own the theme-color meta at runtime; pointing it at the
-  // current chrome colour makes the system status bar track the page as it
-  // scrolls — dark over the hero, light over the content. iOS has no CSS
-  // transition for theme-color, so we interpolate the value ourselves over
-  // CHROME_FADE_MS to match the bar/cover cross-fade — the system bar eases
-  // between colours instead of snapping. The current value is tracked in a ref
-  // (not read back from the meta) so each fade starts from wherever the last one
-  // left off, even mid-animation.
+  // app/+html.tsx, so we own the theme-color meta at runtime. iOS has no CSS
+  // transition for theme-color, so we interpolate it ourselves over
+  // CHROME_FADE_MS (hex only — rgb() is ignored) to match the cover's CSS fade,
+  // tracking the current value in a ref so a new fade starts wherever the last
+  // one left off.
   const themeRgbRef = useRef<{ r: number; g: number; b: number } | null>(null);
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -151,10 +120,7 @@ export function WebChromeProvider({ children }: { children: ReactNode }) {
     return () => cancelAnimationFrame(raf);
   }, [color]);
 
-  const value = useMemo(
-    () => ({ color, isLight, setColors, setHeaderCovering }),
-    [color, isLight, setColors, setHeaderCovering]
-  );
+  const value = useMemo(() => ({ color, isLight, setColor }), [color, isLight, setColor]);
 
   return <WebChromeContext.Provider value={value}>{children}</WebChromeContext.Provider>;
 }
@@ -166,9 +132,8 @@ export function useWebChrome() {
 /**
  * Opaque strip over exactly the iOS status-bar inset, painted the current chrome
  * colour so it's identical to the system status bar above it (same value the
- * theme-color meta uses) — the two fuse into one seamless cap. Tracks the colour
- * as the page scrolls, so the cap goes dark over the hero and light over the
- * content. env() → 0 on Android/desktop, so it collapses to nothing there.
+ * theme-color meta uses) — the two fuse into one seamless cap. env() → 0 on
+ * Android/desktop, so it collapses to nothing there.
  */
 export function AdaptiveStatusBarCover() {
   const { color } = useWebChrome();
@@ -188,66 +153,14 @@ const coverStyles = StyleSheet.create({
 });
 
 /**
- * Declare the current screen's chrome colours for as long as it's mounted.
- * `header` is the tint at the very top (under the status bar), `content` is the
- * canvas once scrolled past the header. Pages with no dark header pass the same
- * colour for both. Defaults match the app's deep-navy hero → beige content shape.
+ * Declare the current screen's top colour for as long as it's mounted — the tint
+ * at the very top, under the status bar. The top bar, status-bar cover and iOS
+ * status-bar tint all lock to it. Defaults to the app's deep-navy hero backdrop.
  */
-export function useChromeColors(
-  header: string = DEFAULTS.header,
-  content: string = DEFAULTS.content
-) {
-  const { setColors } = useWebChrome();
+export function useChromeColor(color: string = DEFAULT_COLOR) {
+  const { setColor } = useWebChrome();
   useEffect(() => {
-    setColors(header, content);
-    return () => setColors(DEFAULTS.header, DEFAULTS.content);
-  }, [header, content, setColors]);
+    setColor(color);
+    return () => setColor(DEFAULT_COLOR);
+  }, [color, setColor]);
 }
-
-// Top bar height (kept in sync with TOPBAR_HEIGHT in TopBar.tsx). Declared here
-// too so the sentinel doesn't have to import TopBar — that would be a cycle,
-// since TopBar consumes this context.
-const TOPBAR_HEIGHT = 64;
-
-/**
- * Invisible 1px marker a page renders at the bottom edge of its dark header.
- * While it sits below the top bar the chrome is in header (dark) mode; once it
- * scrolls up under the bar we flip to content (light) mode. Using the real
- * element position — rather than a guessed scroll threshold — keeps the switch
- * exactly aligned to where the hero actually ends, on every page.
- */
-export function ChromeSentinel() {
-  const { setHeaderCovering } = useWebChrome();
-  const ref = useRef<View>(null);
-
-  useEffect(() => {
-    const el = ref.current as unknown as HTMLElement | null;
-    if (!el || typeof IntersectionObserver === 'undefined') return;
-
-    // Push the observation boundary down past the bar + status-bar inset, so the
-    // sentinel reads as "uncovered" the instant it slides beneath the bar.
-    const probe = document.createElement('div');
-    probe.style.cssText = 'position:fixed;top:0;height:env(safe-area-inset-top);visibility:hidden';
-    document.body.appendChild(probe);
-    const inset = probe.getBoundingClientRect().height;
-    probe.remove();
-
-    const barBottom = TOPBAR_HEIGHT + inset;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        // The header still covers the bar while the seam sits *below* the bar's
-        // bottom edge. `isIntersecting` alone can't tell "below the fold" (still
-        // header) from "scrolled above the bar" (now content) — both read false —
-        // so compare the seam's actual position to the bar instead.
-        setHeaderCovering(entry.boundingClientRect.top > barBottom);
-      },
-      { rootMargin: `-${barBottom}px 0px 0px 0px`, threshold: 0 }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [setHeaderCovering]);
-
-  return <View ref={ref} style={SENTINEL_STYLE} pointerEvents="none" />;
-}
-
-const SENTINEL_STYLE = { width: '100%', height: 1 } as const;

--- a/src/contexts/WebChromeContext.tsx
+++ b/src/contexts/WebChromeContext.tsx
@@ -1,0 +1,199 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { View, StyleSheet } from 'react-native';
+import { usePathname } from 'expo-router';
+import { COLORS } from '../constants/colors';
+
+/**
+ * Adaptive web top-chrome.
+ *
+ * Every mobile-web page is shaped the same way: a dark hero header at the very
+ * top, then a light (beige) content canvas below. A single static chrome can
+ * only ever match one of those, so the status bar / top bar always clashes with
+ * the other. This context makes the chrome adaptive instead: a page declares its
+ * two colours (the header tint at the top, the content tint once scrolled) and
+ * drops a <ChromeSentinel /> at the bottom edge of its dark header. As that
+ * sentinel scrolls under the bar we flip `mode`, and everything that paints the
+ * top — the floating top bar, its icon colours, the status-bar cover, and the
+ * iOS `theme-color` meta that tints the system status bar — derives from the
+ * single resolved `color`, so the whole top edge stays seamless at every scroll
+ * position on every page.
+ */
+
+type ChromeMode = 'header' | 'content';
+
+interface WebChromeValue {
+  /** The colour the chrome is currently matching (header tint or content tint). */
+  color: string;
+  /** True when `color` is light enough to need dark icons/text on top of it. */
+  isLight: boolean;
+  /** Declare this screen's header tint (top) and content tint (scrolled). */
+  setColors: (header: string, content: string) => void;
+  /** Sentinels report whether the dark header still covers the top bar. */
+  setHeaderCovering: (covering: boolean) => void;
+}
+
+const DEFAULTS: { header: string; content: string } = {
+  header: COLORS.deepNavy,
+  content: COLORS.beige,
+};
+
+const WebChromeContext = createContext<WebChromeValue>({
+  color: DEFAULTS.header,
+  isLight: false,
+  setColors: () => {},
+  setHeaderCovering: () => {},
+});
+
+// Perceived luminance (sRGB weights). Above the threshold the surface is light
+// enough that chrome sitting on it must switch to dark icons/text for contrast.
+function isLightColor(hex: string): boolean {
+  const c = hex.replace('#', '');
+  if (c.length < 6) return false;
+  const r = parseInt(c.slice(0, 2), 16);
+  const g = parseInt(c.slice(2, 4), 16);
+  const b = parseInt(c.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b > 140;
+}
+
+export function WebChromeProvider({ children }: { children: ReactNode }) {
+  const [colors, setColorsState] = useState(DEFAULTS);
+  // Default to header mode: a fresh route always opens at the top, over its hero.
+  const [mode, setMode] = useState<ChromeMode>('header');
+
+  const setColors = useCallback((header: string, content: string) => {
+    setColorsState((prev) =>
+      prev.header === header && prev.content === content ? prev : { header, content }
+    );
+  }, []);
+
+  const setHeaderCovering = useCallback(
+    (covering: boolean) => setMode(covering ? 'header' : 'content'),
+    []
+  );
+
+  // Every route opens at the top, over its header — reset to header mode on
+  // navigation so a page left in content mode doesn't bleed into the next one
+  // before its sentinel re-measures.
+  const pathname = usePathname();
+  useEffect(() => setMode('header'), [pathname]);
+
+  const color = mode === 'header' ? colors.header : colors.content;
+  const isLight = isLightColor(color);
+
+  // Drive the iOS Safari status-bar tint. Expo's single web output ignores
+  // app/+html.tsx, so we own the theme-color meta at runtime; pointing it at the
+  // current chrome colour makes the system status bar track the page as it
+  // scrolls — dark over the hero, light over the content — with no seam.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.name = 'theme-color';
+      document.head.appendChild(meta);
+    }
+    meta.content = color;
+  }, [color]);
+
+  const value = useMemo(
+    () => ({ color, isLight, setColors, setHeaderCovering }),
+    [color, isLight, setColors, setHeaderCovering]
+  );
+
+  return <WebChromeContext.Provider value={value}>{children}</WebChromeContext.Provider>;
+}
+
+export function useWebChrome() {
+  return useContext(WebChromeContext);
+}
+
+/**
+ * Opaque strip over exactly the iOS status-bar inset, painted the current chrome
+ * colour so it's identical to the system status bar above it (same value the
+ * theme-color meta uses) — the two fuse into one seamless cap. Tracks the colour
+ * as the page scrolls, so the cap goes dark over the hero and light over the
+ * content. env() → 0 on Android/desktop, so it collapses to nothing there.
+ */
+export function AdaptiveStatusBarCover() {
+  const { color } = useWebChrome();
+  return <View pointerEvents="none" style={[coverStyles.cover, { backgroundColor: color }]} />;
+}
+
+const coverStyles = StyleSheet.create({
+  cover: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 'env(safe-area-inset-top)',
+    zIndex: 9999,
+    transition: 'background-color 240ms ease',
+  } as object,
+});
+
+/**
+ * Declare the current screen's chrome colours for as long as it's mounted.
+ * `header` is the tint at the very top (under the status bar), `content` is the
+ * canvas once scrolled past the header. Pages with no dark header pass the same
+ * colour for both. Defaults match the app's deep-navy hero → beige content shape.
+ */
+export function useChromeColors(
+  header: string = DEFAULTS.header,
+  content: string = DEFAULTS.content
+) {
+  const { setColors } = useWebChrome();
+  useEffect(() => {
+    setColors(header, content);
+    return () => setColors(DEFAULTS.header, DEFAULTS.content);
+  }, [header, content, setColors]);
+}
+
+// Top bar height (kept in sync with TOPBAR_HEIGHT in TopBar.tsx). Declared here
+// too so the sentinel doesn't have to import TopBar — that would be a cycle,
+// since TopBar consumes this context.
+const TOPBAR_HEIGHT = 64;
+
+/**
+ * Invisible 1px marker a page renders at the bottom edge of its dark header.
+ * While it sits below the top bar the chrome is in header (dark) mode; once it
+ * scrolls up under the bar we flip to content (light) mode. Using the real
+ * element position — rather than a guessed scroll threshold — keeps the switch
+ * exactly aligned to where the hero actually ends, on every page.
+ */
+export function ChromeSentinel() {
+  const { setHeaderCovering } = useWebChrome();
+  const ref = useRef<View>(null);
+
+  useEffect(() => {
+    const el = ref.current as unknown as HTMLElement | null;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    // Push the observation boundary down past the bar + status-bar inset, so the
+    // sentinel reads as "uncovered" the instant it slides beneath the bar.
+    const probe = document.createElement('div');
+    probe.style.cssText = 'position:fixed;top:0;height:env(safe-area-inset-top);visibility:hidden';
+    document.body.appendChild(probe);
+    const inset = probe.getBoundingClientRect().height;
+    probe.remove();
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setHeaderCovering(entry.isIntersecting),
+      { rootMargin: `-${TOPBAR_HEIGHT + inset}px 0px 0px 0px`, threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [setHeaderCovering]);
+
+  return <View ref={ref} style={SENTINEL_STYLE} pointerEvents="none" />;
+}
+
+const SENTINEL_STYLE = { width: '100%', height: 1 } as const;

--- a/src/contexts/WebChromeContext.tsx
+++ b/src/contexts/WebChromeContext.tsx
@@ -56,13 +56,25 @@ const WebChromeContext = createContext<WebChromeValue>({
 // Perceived luminance (sRGB weights). Above the threshold the surface is light
 // enough that chrome sitting on it must switch to dark icons/text for contrast.
 function isLightColor(hex: string): boolean {
-  const c = hex.replace('#', '');
-  if (c.length < 6) return false;
-  const r = parseInt(c.slice(0, 2), 16);
-  const g = parseInt(c.slice(2, 4), 16);
-  const b = parseInt(c.slice(4, 6), 16);
-  return 0.299 * r + 0.587 * g + 0.114 * b > 140;
+  const rgb = hexToRgb(hex);
+  if (!rgb) return false;
+  return 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b > 140;
 }
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const c = hex.replace('#', '');
+  if (c.length < 6) return null;
+  return {
+    r: parseInt(c.slice(0, 2), 16),
+    g: parseInt(c.slice(2, 4), 16),
+    b: parseInt(c.slice(4, 6), 16),
+  };
+}
+
+// Duration of the chrome colour cross-fade. Shared by the status-bar tint
+// animation here and the CSS transitions on the bar/cover, so the whole top
+// edge changes colour as one synchronised motion.
+const CHROME_FADE_MS = 300;
 
 export function WebChromeProvider({ children }: { children: ReactNode }) {
   const [colors, setColorsState] = useState(DEFAULTS);
@@ -92,7 +104,13 @@ export function WebChromeProvider({ children }: { children: ReactNode }) {
   // Drive the iOS Safari status-bar tint. Expo's single web output ignores
   // app/+html.tsx, so we own the theme-color meta at runtime; pointing it at the
   // current chrome colour makes the system status bar track the page as it
-  // scrolls — dark over the hero, light over the content — with no seam.
+  // scrolls — dark over the hero, light over the content. iOS has no CSS
+  // transition for theme-color, so we interpolate the value ourselves over
+  // CHROME_FADE_MS to match the bar/cover cross-fade — the system bar eases
+  // between colours instead of snapping. The current value is tracked in a ref
+  // (not read back from the meta) so each fade starts from wherever the last one
+  // left off, even mid-animation.
+  const themeRgbRef = useRef<{ r: number; g: number; b: number } | null>(null);
   useEffect(() => {
     if (typeof document === 'undefined') return;
     let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
@@ -101,7 +119,29 @@ export function WebChromeProvider({ children }: { children: ReactNode }) {
       meta.name = 'theme-color';
       document.head.appendChild(meta);
     }
-    meta.content = color;
+    const to = hexToRgb(color);
+    const from = themeRgbRef.current;
+    // First paint (no prior value) snaps; thereafter we always have a from→to.
+    if (!to || !from) {
+      themeRgbRef.current = to;
+      meta.content = color;
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / CHROME_FADE_MS);
+      // easeInOutQuad — gentle in and out, no abrupt edges.
+      const e = t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+      const r = Math.round(from.r + (to.r - from.r) * e);
+      const g = Math.round(from.g + (to.g - from.g) * e);
+      const b = Math.round(from.b + (to.b - from.b) * e);
+      themeRgbRef.current = { r, g, b };
+      meta!.content = `rgb(${r}, ${g}, ${b})`;
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
   }, [color]);
 
   const value = useMemo(
@@ -136,7 +176,7 @@ const coverStyles = StyleSheet.create({
     right: 0,
     height: 'env(safe-area-inset-top)',
     zIndex: 9999,
-    transition: 'background-color 240ms ease',
+    transition: `background-color ${CHROME_FADE_MS}ms ease`,
   } as object,
 });
 
@@ -185,9 +225,16 @@ export function ChromeSentinel() {
     const inset = probe.getBoundingClientRect().height;
     probe.remove();
 
+    const barBottom = TOPBAR_HEIGHT + inset;
     const observer = new IntersectionObserver(
-      ([entry]) => setHeaderCovering(entry.isIntersecting),
-      { rootMargin: `-${TOPBAR_HEIGHT + inset}px 0px 0px 0px`, threshold: 0 }
+      ([entry]) => {
+        // The header still covers the bar while the seam sits *below* the bar's
+        // bottom edge. `isIntersecting` alone can't tell "below the fold" (still
+        // header) from "scrolled above the bar" (now content) — both read false —
+        // so compare the seam's actual position to the bar instead.
+        setHeaderCovering(entry.boundingClientRect.top > barBottom);
+      },
+      { rootMargin: `-${barBottom}px 0px 0px 0px`, threshold: 0 }
     );
     observer.observe(el);
     return () => observer.disconnect();


### PR DESCRIPTION
## Summary

Makes the mobile-web (Safari) experience feel edge-to-edge and seamless, and polishes the character and auth screens.

### Top chrome (status bar + top bar)
- New `WebChromeProvider` / `useChromeColor` (`src/contexts/WebChromeContext.tsx`): the top bar, the status-bar inset cover, and the iOS `theme-color` meta all lock to a single colour the page declares (the tint at the very top of that screen), so the system status bar and the bar read as one seamless piece. Expo's single web output ignores `app/+html.tsx`, so the provider owns `theme-color` at runtime (hex only — iOS ignores `rgb()`), with a short cross-fade when the colour changes.
- The mobile top bar shows **one consistent frosted scrim** at every scroll position (opaque deep-navy at the top, easing into the page) — no per-scroll restyle. Desktop keeps its classic transparent-over-hero → frosted-on-scroll behaviour.
- Fixed-positioning hardening: a real `transform: translateZ(0)` on the bar and status-bar cover forces a GPU compositing layer so they stay reliably pinned while the body scrolls (`overflow: visible` for Safari toolbar collapse).

### Character screen (mobile web)
- Deep-navy top vignette fuses the status bar into the full-bleed portrait with no hard cut, and the hero height was raised so the composition sits lower with more of the portrait on show.

### Auth screens (mobile web)
- The shared top bar now renders in a logo-only mode over the auth hero (nothing on desktop, which keeps its split-panel branding); each screen's bespoke mobile logo was removed.
- Reworked the hero region (the art is 2048² square, so `contain` is used at a large size) and tightened form spacing so login fits without scrolling. Same treatment on signup/forgot-password.

All 225 tests pass (`yarn test:ci`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaAY1SGHmHRQQCcDqU71uH)_