### PR TITLE
Surface famous-franchise characters across Explore

### DIFF
--- a/__tests__/lib/db/heroes.test.ts
+++ b/__tests__/lib/db/heroes.test.ts
@@ -28,7 +28,10 @@ import {
 //
 
 // eslint-disable-next-line prefer-const
-let mockResolveWith: { data: unknown; error: unknown; count?: number | null } = { data: null, error: null };
+let mockResolveWith: { data: unknown; error: unknown; count?: number | null } = {
+  data: null,
+  error: null,
+};
 
 jest.mock('../../../src/lib/supabase', () => {
   const chainMethods = [
@@ -214,6 +217,8 @@ describe('heroRowToCharacterData', () => {
     wikidata_candidates: null,
     wikidata_enriched_at: null,
     narrative_status: 'pending',
+    added_at: '2026-04-04T00:00:00Z',
+    franchise: null,
   } satisfies Hero;
 
   it('maps powerstats to string values', () => {
@@ -399,6 +404,8 @@ const baseHero: HeroRow = {
   wikidata_candidates: null,
   wikidata_enriched_at: null,
   narrative_status: 'pending',
+  added_at: '2026-04-04T00:00:00Z',
+  franchise: null,
 };
 
 describe('heroRowToCharacterData — powers mapping', () => {
@@ -599,7 +606,10 @@ describe('getTopHeroByStat', () => {
   });
 
   it('passes the correct stat field to the query chain', async () => {
-    mockResolveWith = { data: { id: 297, name: 'Brainiac', strength: 28, intelligence: 100, speed: 42 }, error: null };
+    mockResolveWith = {
+      data: { id: 297, name: 'Brainiac', strength: 28, intelligence: 100, speed: 42 },
+      error: null,
+    };
 
     await getTopHeroByStat('intelligence');
 
@@ -653,7 +663,12 @@ describe('getFirstAppearanceCovers', () => {
           first_appearance: 'Detective Comics #27',
           first_issue_image_url: 'https://x/dc27.jpg',
         },
-        { id: '1', name: 'Blank', first_appearance: null, first_issue_image_url: 'https://x/blank.png' },
+        {
+          id: '1',
+          name: 'Blank',
+          first_appearance: null,
+          first_issue_image_url: 'https://x/blank.png',
+        },
         { id: '2', name: 'NoHttp', first_appearance: null, first_issue_image_url: '/relative.jpg' },
       ],
       error: null,

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -41,6 +41,8 @@ import {
   getXMen,
   getHeroesByPublisher,
   getHeroesByStatRanking,
+  getFranchiseIcons,
+  getHeroesByMediaTag,
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
@@ -94,6 +96,10 @@ export default function HomeScreen() {
   const [strongest, setStrongest] = useState<Hero[]>([]);
   const [mostIntelligent, setMostIntelligent] = useState<Hero[]>([]);
   const [newlyAdded, setNewlyAdded] = useState<Hero[]>([]);
+  const [franchiseIcons, setFranchiseIcons] = useState<Hero[]>([]);
+  const [anime, setAnime] = useState<Hero[]>([]);
+  const [videoGames, setVideoGames] = useState<Hero[]>([]);
+  const [horror, setHorror] = useState<Hero[]>([]);
 
   const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
@@ -149,6 +155,18 @@ export default function HomeScreen() {
     getNewlyAddedCV(20)
       .then(setNewlyAdded)
       .catch(() => {});
+    getFranchiseIcons(20)
+      .then(setFranchiseIcons)
+      .catch(() => {});
+    getHeroesByMediaTag('anime', 20)
+      .then(setAnime)
+      .catch(() => {});
+    getHeroesByMediaTag('video-game', 20)
+      .then(setVideoGames)
+      .catch(() => {});
+    getHeroesByMediaTag('horror-icon', 20)
+      .then(setHorror)
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -199,11 +217,25 @@ export default function HomeScreen() {
       route: '/category/most-iconic',
     },
     {
+      key: 'franchise',
+      label: 'Shows · Movies · Games',
+      title: 'Beyond the Comics',
+      heroes: franchiseIcons,
+      route: '/category/franchise-icons',
+    },
+    {
       key: 'villains',
       label: 'The Dark Side',
       title: 'Villains',
       heroes: villains,
       route: '/category/villain',
+    },
+    {
+      key: 'horror',
+      label: 'Movie Nightmares',
+      title: 'Horror Icons',
+      heroes: horror,
+      route: '/category/horror',
     },
     {
       key: 'marvel',
@@ -233,6 +265,20 @@ export default function HomeScreen() {
       title: 'X-Men',
       heroes: xmen,
       route: '/category/xmen',
+    },
+    {
+      key: 'anime',
+      label: 'Anime & Manga',
+      title: 'Anime Legends',
+      heroes: anime,
+      route: '/category/anime',
+    },
+    {
+      key: 'games',
+      label: 'Video Games',
+      title: 'Video Game Heroes',
+      heroes: videoGames,
+      route: '/category/video-games',
     },
     {
       key: 'minds',
@@ -274,6 +320,10 @@ export default function HomeScreen() {
     xmen,
     mostIntelligent,
     newlyAdded,
+    franchiseIcons,
+    anime,
+    videoGames,
+    horror,
   ]);
 
   const keyExtractor = useCallback(

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -17,6 +17,8 @@ import {
   getNewlyAddedCV,
   getHeroesByPublisher,
   getHeroesByStatRanking,
+  getFranchiseIcons,
+  getHeroesByMediaTag,
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
@@ -1170,6 +1172,10 @@ export default function WebHomeScreen() {
     strongest: Hero[];
     mostIntelligent: Hero[];
     newlyAdded: Hero[];
+    franchiseIcons: Hero[];
+    anime: Hero[];
+    videoGames: Hero[];
+    horror: Hero[];
     strongestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     smartestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     fastestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
@@ -1232,6 +1238,18 @@ export default function WebHomeScreen() {
     getNewlyAddedCV(25)
       .then(set('newlyAdded'))
       .catch(() => {});
+    getFranchiseIcons(25)
+      .then(set('franchiseIcons'))
+      .catch(() => {});
+    getHeroesByMediaTag('anime', 25)
+      .then(set('anime'))
+      .catch(() => {});
+    getHeroesByMediaTag('video-game', 25)
+      .then(set('videoGames'))
+      .catch(() => {});
+    getHeroesByMediaTag('horror-icon', 25)
+      .then(set('horror'))
+      .catch(() => {});
     getFirstAppearanceCovers(14)
       .then(set('covers'))
       .catch(() => {});
@@ -1293,27 +1311,29 @@ export default function WebHomeScreen() {
                Renders at all widths; each child handles its own responsive
                layout. The stage clears the floating header via its own
                paddingTop so the screen owns its clearance (bleedBehindNav). */}
-          <View style={[styles.darkStage, isMobile && (styles.darkStageMobile as object)] as object}>
-              {(homeData.spotlight?.length ?? 0) > 0 && (
-                <PortraitStripSpotlight
-                  heroes={homeData.spotlight!.slice(
-                    0,
-                    Math.min(optimalPoolSize, homeData.spotlight!.length),
-                  )}
-                  onViewProfile={handlePress}
-                />
-              )}
-              <PublisherPods
-                onNavigate={(path) => router.push(path as Parameters<typeof router.push>[0])}
+          <View
+            style={[styles.darkStage, isMobile && (styles.darkStageMobile as object)] as object}
+          >
+            {(homeData.spotlight?.length ?? 0) > 0 && (
+              <PortraitStripSpotlight
+                heroes={homeData.spotlight!.slice(
+                  0,
+                  Math.min(optimalPoolSize, homeData.spotlight!.length),
+                )}
+                onViewProfile={handlePress}
               />
-              {homeData.matchup === undefined ? (
-                <TodaysMatchupSkeleton />
-              ) : homeData.matchup ? (
-                <TodaysMatchupCard
-                  matchup={homeData.matchup}
-                  onOpen={(path) => router.push(path as Parameters<typeof router.push>[0])}
-                />
-              ) : null}
+            )}
+            <PublisherPods
+              onNavigate={(path) => router.push(path as Parameters<typeof router.push>[0])}
+            />
+            {homeData.matchup === undefined ? (
+              <TodaysMatchupSkeleton />
+            ) : homeData.matchup ? (
+              <TodaysMatchupCard
+                matchup={homeData.matchup}
+                onOpen={(path) => router.push(path as Parameters<typeof router.push>[0])}
+              />
+            ) : null}
           </View>
 
           {/* ── Orange ticker strip ────────────────────────────────────────── */}
@@ -1342,6 +1362,13 @@ export default function WebHomeScreen() {
               onViewAll={() => router.push('/category/most-iconic')}
             />
             <HomeRow
+              label="Shows · Movies · Games"
+              title="Beyond the Comics"
+              heroes={homeData.franchiseIcons ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/franchise-icons')}
+            />
+            <HomeRow
               label="Marvel Comics"
               title="Marvel Universe"
               heroes={homeData.marvel ?? []}
@@ -1362,10 +1389,25 @@ export default function WebHomeScreen() {
               onPress={handlePress}
               onViewAll={() => router.push('/category/xmen')}
             />
+            <HomeRow
+              label="Anime & Manga"
+              title="Anime Legends"
+              heroes={homeData.anime ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/anime')}
+            />
+            <HomeRow
+              label="Video Games"
+              title="Video Game Heroes"
+              heroes={homeData.videoGames ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/video-games')}
+            />
 
             {/* ── The Dark Side — one deliberate dark zone ──────────────────── */}
             {((homeData.villains?.length ?? 0) > 0 ||
-              (homeData.antiHeroes?.length ?? 0) > 0) && (
+              (homeData.antiHeroes?.length ?? 0) > 0 ||
+              (homeData.horror?.length ?? 0) > 0) && (
               <View style={styles.darkZone}>
                 <DarkHomeRow
                   grouped
@@ -1374,6 +1416,14 @@ export default function WebHomeScreen() {
                   heroes={homeData.villains ?? []}
                   onPress={handlePress}
                   onViewAll={() => router.push('/category/villain')}
+                />
+                <DarkHomeRow
+                  grouped
+                  label="Movie Nightmares"
+                  title="Horror Icons"
+                  heroes={homeData.horror ?? []}
+                  onPress={handlePress}
+                  onViewAll={() => router.push('/category/horror')}
                 />
                 <DarkHomeRow
                   grouped

--- a/app/category/[slug].tsx
+++ b/app/category/[slug].tsx
@@ -49,6 +49,10 @@ const VALID_SLUGS = new Set<CategorySlug>([
   'strongest',
   'most-intelligent',
   'most-iconic',
+  'franchise-icons',
+  'anime',
+  'video-games',
+  'horror',
 ]);
 
 // A one-line editorial tagline per category — gives the navy header warmth and
@@ -65,6 +69,10 @@ const CATEGORY_TAGLINES: Record<CategorySlug, string> = {
   strongest: 'Raw power at the very top of the scale.',
   'most-intelligent': 'The sharpest minds in comics.',
   'most-iconic': 'The faces that defined the medium.',
+  'franchise-icons': 'Icons from famous shows, movies, games, and anime.',
+  anime: 'Heroes and villains from the biggest anime and manga.',
+  'video-games': 'Legends straight out of video-game history.',
+  horror: 'The slashers and monsters of horror cinema.',
 };
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const NUM_COLUMNS = SCREEN_WIDTH >= 768 ? 4 : 3;

--- a/app/category/[slug].web.tsx
+++ b/app/category/[slug].web.tsx
@@ -48,6 +48,10 @@ const VALID_SLUGS = new Set<CategorySlug>([
   'strongest',
   'most-intelligent',
   'most-iconic',
+  'franchise-icons',
+  'anime',
+  'video-games',
+  'horror',
 ]);
 
 // ── Skeleton card (matches HeroCard layout) ───────────────────────────────────

--- a/src/lib/db/heroes.ts
+++ b/src/lib/db/heroes.ts
@@ -345,6 +345,41 @@ export async function getNewlyAddedCV(limit = 25): Promise<Hero[]> {
     .select(HOME_ROW)
     .like('id', 'cv-%')
     .not('publisher', 'in', '("Non-Fictional","In the Public Domain")')
+    // Order by when the hero entered the catalog, not issue_count — otherwise the
+    // genuinely-new characters (low issue_count) sink below long-running heroes.
+    .order('added_at', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as Hero[];
+}
+
+// ── Franchise / pop-culture cohort (famous shows · movies · games · anime) ────
+// These characters arrive enriched (portraits, summaries, curated stats) but with
+// tiny issue_counts, so every issue_count-ranked row buries them. The franchise
+// column + media tags let the Explore page feature them on their own terms.
+
+/** The marquee "Beyond the Comics" row — characters tagged with a franchise,
+ *  ranked by power so the lineup leads with heavy hitters and reads premium.
+ *  Portrait required (these fill hero cards). */
+export async function getFranchiseIcons(limit = 20): Promise<Hero[]> {
+  const { data, error } = await supabase
+    .from('heroes')
+    .select(HOME_ROW)
+    .not('franchise', 'is', null)
+    .not('portrait_url', 'is', null)
+    .order('powerstats_total', { ascending: false, nullsFirst: false })
+    .limit(limit);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as Hero[];
+}
+
+/** Themed franchise row by media tag (anime / video-game / horror-icon /
+ *  screen-icon / toy-cartoon), ranked by popularity within the theme. */
+export async function getHeroesByMediaTag(tag: string, limit = 20): Promise<Hero[]> {
+  const { data, error } = await supabase
+    .from('heroes')
+    .select(`${HOME_ROW}, hero_tags!inner(tag)`)
+    .eq('hero_tags.tag', tag)
     .order('issue_count', { ascending: false, nullsFirst: false })
     .limit(limit);
   if (error) throw new Error(error.message);
@@ -469,7 +504,19 @@ export type CategorySlug =
   | 'dark-horse'
   | 'strongest'
   | 'most-intelligent'
-  | 'most-iconic';
+  | 'most-iconic'
+  | 'franchise-icons'
+  | 'anime'
+  | 'video-games'
+  | 'horror';
+
+// Category slugs that resolve to a hero_tags media tag rather than a base
+// publisher/alignment predicate. Keyed by slug → tag vocabulary slug.
+export const CATEGORY_MEDIA_TAG: Partial<Record<CategorySlug, string>> = {
+  anime: 'anime',
+  'video-games': 'video-game',
+  horror: 'horror-icon',
+};
 
 export type SortOption = 'popular' | 'az' | 'power';
 export type CategoryPublisher = 'all' | 'marvel' | 'dc';
@@ -486,6 +533,10 @@ export const CATEGORY_LABELS: Record<CategorySlug, string> = {
   strongest: 'Strongest Heroes',
   'most-intelligent': 'Most Intelligent',
   'most-iconic': 'Most Iconic',
+  'franchise-icons': 'Beyond the Comics',
+  anime: 'Anime Legends',
+  'video-games': 'Video Game Heroes',
+  horror: 'Horror Icons',
 };
 
 export const CATEGORY_DESCRIPTIONS: Record<CategorySlug, string> = {
@@ -500,6 +551,10 @@ export const CATEGORY_DESCRIPTIONS: Record<CategorySlug, string> = {
   strongest: 'Ranked by raw physical power',
   'most-intelligent': 'The greatest minds in all of comics',
   'most-iconic': 'Ranked by total comic book appearances',
+  'franchise-icons': 'Icons from famous shows, movies, games, and anime',
+  anime: 'Heroes and villains from the biggest anime and manga',
+  'video-games': 'Legends straight out of video-game history',
+  horror: 'The slashers and monsters of horror cinema',
 };
 
 /** Fetches all rows from a query that may exceed Supabase's 1000-row default cap. */
@@ -592,6 +647,29 @@ export async function getAllHeroesBySlug(slug: CategorySlug): Promise<Hero[]> {
           .not('publisher', 'in', '("Non-Fictional","In the Public Domain","Company-Licensed")')
           .order('issue_count', { ascending: false, nullsFirst: false }),
       );
+    case 'franchise-icons':
+      return fetchAllPages(() =>
+        supabase
+          .from('heroes')
+          .select('*')
+          .not('franchise', 'is', null)
+          .order('issue_count', { ascending: false, nullsFirst: false }),
+      );
+    case 'anime':
+    case 'video-games':
+    case 'horror': {
+      const tag = CATEGORY_MEDIA_TAG[slug]!;
+      return fetchAllPages(
+        () =>
+          supabase
+            .from('heroes')
+            .select('*, hero_tags!inner(tag)')
+            .eq('hero_tags.tag', tag)
+            .order('issue_count', { ascending: false, nullsFirst: false }) as unknown as ReturnType<
+            Parameters<typeof fetchAllPages>[0]
+          >,
+      );
+    }
   }
 }
 
@@ -617,7 +695,10 @@ export async function getCategoryPage(
     tags,
     search,
   } = options;
-  const tagList = tags ?? [];
+  // Media-themed category slugs (anime / video-games / horror) resolve to a
+  // hero_tags tag; fold it into the tag list so the same inner-join path applies.
+  const implicitTag = CATEGORY_MEDIA_TAG[slug];
+  const tagList = [...(implicitTag ? [implicitTag] : []), ...(tags ?? [])];
   const from = page * pageSize;
   const to = from + pageSize - 1;
 
@@ -667,6 +748,11 @@ export async function getCategoryPage(
     case 'most-iconic':
       q = q.not('publisher', 'in', '("Non-Fictional","In the Public Domain","Company-Licensed")');
       break;
+    case 'franchise-icons':
+      q = q.not('franchise', 'is', null);
+      break;
+    // anime / video-games / horror: the implicit media tag (folded into tagList
+    // above) is the filter — no base publisher/alignment predicate.
   }
 
   // Publisher facet

--- a/src/lib/home/rowStyle.ts
+++ b/src/lib/home/rowStyle.ts
@@ -18,12 +18,16 @@ const DEFAULT: RowStyle = {
 // Per-category overrides keyed by the catalog `key` used in explore.tsx.
 const MAP: Record<string, Partial<RowStyle>> = {
   iconic: { feature: true, ranked: true, accent: COLORS.orange },
+  franchise: { feature: true, accent: COLORS.goldAccent },
   villains: { tone: 'dark', accent: COLORS.red },
+  horror: { tone: 'dark', accent: COLORS.red },
   marvel: { accent: COLORS.red },
   dc: { accent: COLORS.blue },
   anti: { tone: 'dark', accent: COLORS.grey },
   strongest: { tone: 'dark', ranked: true, accent: COLORS.yellow },
   xmen: { accent: COLORS.purple },
+  anime: { accent: COLORS.purple },
+  games: { accent: COLORS.green },
   minds: { ranked: true, accent: COLORS.blue },
   new: { accent: COLORS.green },
 };

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -507,6 +507,7 @@ export type Database = {
       }
       heroes: {
         Row: {
+          added_at: string
           ai_stats_status: string | null
           aliases: string[] | null
           alignment: string | null
@@ -527,6 +528,7 @@ export type Database = {
           first_issue_data: Json | null
           first_issue_id: string | null
           first_issue_image_url: string | null
+          franchise: string | null
           friends: string[] | null
           full_name: string | null
           gallery_enriched_at: string | null
@@ -568,6 +570,7 @@ export type Database = {
           wikidata_status: string
         }
         Insert: {
+          added_at?: string
           ai_stats_status?: string | null
           aliases?: string[] | null
           alignment?: string | null
@@ -588,6 +591,7 @@ export type Database = {
           first_issue_data?: Json | null
           first_issue_id?: string | null
           first_issue_image_url?: string | null
+          franchise?: string | null
           friends?: string[] | null
           full_name?: string | null
           gallery_enriched_at?: string | null
@@ -629,6 +633,7 @@ export type Database = {
           wikidata_status?: string
         }
         Update: {
+          added_at?: string
           ai_stats_status?: string | null
           aliases?: string[] | null
           alignment?: string | null
@@ -649,6 +654,7 @@ export type Database = {
           first_issue_data?: Json | null
           first_issue_id?: string | null
           first_issue_image_url?: string | null
+          franchise?: string | null
           friends?: string[] | null
           full_name?: string | null
           gallery_enriched_at?: string | null

--- a/supabase/migrations/20260615160000_add_franchise_metadata.sql
+++ b/supabase/migrations/20260615160000_add_franchise_metadata.sql
@@ -1,0 +1,176 @@
+-- Franchise/pop-culture cohort metadata so the Explore page can surface the
+-- ~90 recently-added characters from famous shows, movies, games and anime.
+-- They arrived enriched (portraits, summaries, curated stats) but were invisible
+-- on Explore: every row ranks by issue_count (where they're tiny), alignment was
+-- null (so they never hit the Villains/Anti rows), and there was no recency
+-- signal for "Recently Added". This migration fixes all three.
+
+-- 1. Columns -----------------------------------------------------------------
+alter table public.heroes add column if not exists franchise text;
+-- Insert-order recency signal so "Recently Added" can sort by when a hero
+-- entered the catalog rather than by issue_count.
+alter table public.heroes add column if not exists added_at timestamptz not null default now();
+
+create index if not exists heroes_franchise_idx
+  on public.heroes (franchise) where franchise is not null;
+create index if not exists heroes_added_at_idx
+  on public.heroes (added_at desc);
+
+-- 2. Media tag vocabulary (new 'media' category) -----------------------------
+insert into public.hero_tag_vocab (slug, label, description, category) values
+  ('anime',        'Anime & Manga', 'From a major anime or manga series.',            'media'),
+  ('video-game',   'Video Game',    'Originates from a video-game franchise.',        'media'),
+  ('horror-icon',  'Horror Icon',   'A slasher/horror-movie icon.',                   'media'),
+  ('screen-icon',  'Screen Icon',   'Defined by a hit live-action film or TV series.','media'),
+  ('toy-cartoon',  'Toys & Cartoons','From a classic toy line / Saturday-morning cartoon.','media')
+on conflict (slug) do nothing;
+
+-- 3. Backfill franchise ------------------------------------------------------
+update public.heroes h set franchise = v.franchise
+from (values
+  ('cv-51106','The Boys'),('cv-40553','The Boys'),('cv-51100','The Boys'),('cv-51107','The Boys'),
+  ('cv-51103','The Boys'),('cv-51105','The Boys'),('cv-40552','The Boys'),('cv-51109','The Boys'),
+  ('cv-59641','The Boys'),('cv-40555','The Boys'),('cv-59640','The Boys'),
+  ('cv-5210','Invincible'),('cv-40550','Invincible'),('cv-40947','Invincible'),('cv-42576','Invincible'),
+  ('cv-41126','Invincible'),('cv-61561','Invincible'),('cv-72505','Invincible'),
+  ('cv-114074','My Hero Academia'),('cv-119564','My Hero Academia'),('cv-119837','My Hero Academia'),
+  ('cv-126533','Demon Slayer'),
+  ('cv-47924','One Piece'),('cv-47925','One Piece'),
+  ('cv-94030','Attack on Titan'),('cv-94029','Attack on Titan'),
+  ('cv-49020','The Witcher'),
+  ('cv-67170','God of War'),
+  ('cv-55028','Star Wars'),('cv-162251','Star Wars'),('cv-165877','Star Wars'),
+  ('cv-42443','The Walking Dead'),('cv-84617','The Walking Dead'),('cv-46819','The Walking Dead'),('cv-42540','The Walking Dead'),
+  ('cv-39812','Teenage Mutant Ninja Turtles'),
+  ('cv-44241','Naruto'),('cv-44260','Naruto'),('cv-44243','Naruto'),
+  ('cv-40743','Dragon Ball'),('cv-40737','Dragon Ball'),('cv-41116','Dragon Ball'),('cv-87138','Dragon Ball'),
+  ('cv-42468','Bleach'),
+  ('cv-48703','Death Note'),
+  ('cv-45359','Fullmetal Alchemist'),
+  ('cv-68163','Hunter x Hunter'),('cv-68164','Hunter x Hunter'),
+  ('cv-93547','One-Punch Man'),
+  ('cv-120011','JoJo''s Bizarre Adventure'),('cv-102819','JoJo''s Bizarre Adventure'),
+  ('cv-159532','Jujutsu Kaisen'),('cv-164910','Jujutsu Kaisen'),
+  ('cv-175957','Spy x Family'),
+  ('cv-164246','Vinland Saga'),
+  ('cv-141927','That Time I Got Reincarnated as a Slime'),
+  ('cv-45527','Berserk'),
+  ('cv-55484','Super Mario'),
+  ('cv-46231','The Legend of Zelda'),
+  ('cv-45343','Sonic the Hedgehog'),
+  ('cv-40491','Tomb Raider'),
+  ('cv-45828','Metal Gear'),
+  ('cv-52213','Pokémon'),('cv-52626','Pokémon'),
+  ('cv-46651','Metroid'),
+  ('cv-50037','Mega Man'),
+  ('cv-42683','Street Fighter'),
+  ('cv-42244','Mortal Kombat'),
+  ('cv-33857','Crash Bandicoot'),
+  ('cv-44471','Kingdom Hearts'),
+  ('cv-13852','The Terminator'),
+  ('cv-28671','RoboCop'),
+  ('cv-61046','Alien'),
+  ('cv-41460','A Nightmare on Elm Street'),
+  ('cv-41459','Friday the 13th'),
+  ('cv-46825','Halloween'),
+  ('cv-51515','Child''s Play'),
+  ('cv-160011','It'),
+  ('cv-41465','Hellraiser'),
+  ('cv-11171','The Sandman'),
+  ('cv-24232','Lucifer'),
+  ('cv-83012','Saga'),('cv-83011','Saga'),
+  ('cv-18319','Witchblade'),
+  ('cv-195090','The Darkness'),
+  ('cv-46763','Tank Girl'),
+  ('cv-6467','Transformers'),
+  ('cv-16423','Masters of the Universe'),('cv-16424','Masters of the Universe'),
+  ('cv-6452','G.I. Joe'),('cv-11034','G.I. Joe')
+) as v(id, franchise)
+where h.id = v.id;
+
+-- 4. Backfill alignment (was null for the whole cohort) ----------------------
+update public.heroes h set alignment = v.al
+from (values
+  ('cv-51106','bad'),('cv-40553','neutral'),('cv-51100','good'),('cv-51107','good'),('cv-51103','neutral'),
+  ('cv-51105','neutral'),('cv-40552','good'),('cv-51109','bad'),('cv-59641','bad'),('cv-40555','good'),('cv-59640','bad'),
+  ('cv-5210','good'),('cv-40550','neutral'),('cv-40947','good'),('cv-42576','neutral'),('cv-41126','neutral'),
+  ('cv-61561','bad'),('cv-72505','bad'),
+  ('cv-114074','good'),('cv-119564','good'),('cv-119837','good'),
+  ('cv-126533','good'),
+  ('cv-47924','good'),('cv-47925','good'),
+  ('cv-94030','neutral'),('cv-94029','good'),
+  ('cv-49020','neutral'),
+  ('cv-67170','neutral'),
+  ('cv-55028','good'),('cv-162251','good'),('cv-165877','good'),
+  ('cv-42443','good'),('cv-84617','bad'),('cv-46819','good'),('cv-42540','good'),
+  ('cv-39812','good'),
+  ('cv-44241','neutral'),('cv-44260','neutral'),('cv-44243','good'),
+  ('cv-40743','good'),('cv-40737','bad'),('cv-41116','bad'),('cv-87138','neutral'),
+  ('cv-42468','good'),
+  ('cv-48703','bad'),
+  ('cv-45359','good'),
+  ('cv-68163','good'),('cv-68164','good'),
+  ('cv-93547','good'),
+  ('cv-120011','good'),('cv-102819','bad'),
+  ('cv-159532','good'),('cv-164910','good'),
+  ('cv-175957','good'),
+  ('cv-164246','neutral'),
+  ('cv-141927','good'),
+  ('cv-45527','neutral'),
+  ('cv-55484','good'),('cv-46231','good'),('cv-45343','good'),('cv-40491','good'),('cv-45828','good'),
+  ('cv-52213','good'),('cv-52626','neutral'),('cv-46651','good'),('cv-50037','good'),('cv-42683','good'),
+  ('cv-42244','neutral'),('cv-33857','good'),('cv-44471','good'),
+  ('cv-13852','neutral'),('cv-28671','good'),('cv-61046','bad'),('cv-41460','bad'),('cv-41459','bad'),
+  ('cv-46825','bad'),('cv-51515','bad'),('cv-160011','bad'),('cv-41465','bad'),
+  ('cv-11171','neutral'),('cv-24232','neutral'),
+  ('cv-83012','good'),('cv-83011','good'),
+  ('cv-18319','good'),('cv-195090','neutral'),('cv-46763','neutral'),
+  ('cv-6467','good'),('cv-16423','good'),('cv-16424','bad'),('cv-6452','good'),('cv-11034','bad')
+) as v(id, al)
+where h.id = v.id and h.alignment is null;
+
+-- 5. Recency: stamp the franchise cohort as the newest arrivals --------------
+-- Existing catalog is baselined to a fixed past date. We deliberately do NOT key
+-- off *_enriched_at: the enrichment pipeline keeps bumping those timestamps, which
+-- would repeatedly push long-standing heroes above the cohort. Nothing writes
+-- added_at after insert (new rows default to now()), so the cohort — and any
+-- genuinely new inserts — stay at the top of "Recently Added".
+update public.heroes set added_at = timestamptz '2026-01-01' where franchise is null;
+update public.heroes set added_at = now() where franchise is not null;
+
+-- 6. Backfill media tags -----------------------------------------------------
+insert into public.hero_tags (hero_id, tag)
+select id, 'anime' from unnest(array[
+  'cv-114074','cv-119564','cv-119837','cv-126533','cv-47924','cv-47925','cv-94030','cv-94029',
+  'cv-44241','cv-44260','cv-44243','cv-40743','cv-40737','cv-41116','cv-87138','cv-42468','cv-48703',
+  'cv-45359','cv-68163','cv-68164','cv-93547','cv-120011','cv-102819','cv-159532','cv-164910',
+  'cv-175957','cv-164246','cv-141927','cv-45527'
+]) as id
+on conflict do nothing;
+
+insert into public.hero_tags (hero_id, tag)
+select id, 'video-game' from unnest(array[
+  'cv-49020','cv-67170','cv-55484','cv-46231','cv-45343','cv-40491','cv-45828','cv-52213','cv-52626',
+  'cv-46651','cv-50037','cv-42683','cv-42244','cv-33857','cv-44471'
+]) as id
+on conflict do nothing;
+
+insert into public.hero_tags (hero_id, tag)
+select id, 'horror-icon' from unnest(array[
+  'cv-61046','cv-41460','cv-41459','cv-46825','cv-51515','cv-160011','cv-41465'
+]) as id
+on conflict do nothing;
+
+insert into public.hero_tags (hero_id, tag)
+select id, 'screen-icon' from unnest(array[
+  'cv-51106','cv-40553','cv-51100','cv-51107','cv-51103','cv-51105','cv-40552','cv-51109','cv-59641','cv-40555','cv-59640',
+  'cv-42443','cv-84617','cv-46819','cv-42540','cv-55028','cv-162251','cv-165877',
+  'cv-13852','cv-28671','cv-11171','cv-24232','cv-5210','cv-40550','cv-40947','cv-42576','cv-41126','cv-61561','cv-72505','cv-46763'
+]) as id
+on conflict do nothing;
+
+insert into public.hero_tags (hero_id, tag)
+select id, 'toy-cartoon' from unnest(array[
+  'cv-6467','cv-16423','cv-16424','cv-6452','cv-11034','cv-39812'
+]) as id
+on conflict do nothing;


### PR DESCRIPTION
## Why

The ~90 recently-added pop-culture characters (The Boys, Star Wars, the horror slashers, all the anime, and the video-game / toy-line icons) arrived enriched with portraits, summaries and curated stats — but were the **least** visible characters on Explore:

- **Every row ranks by `issue_count`**, where these characters are tiny, so they sank below 3,000 comic characters and never appeared in the top ~20 rendered.
- **`alignment` was NULL for all 91**, so villains like Homelander, Frieza and the slashers never reached the Villains / Anti-Heroes rows.
- **"Recently Added"** sorted by `issue_count` too — the genuinely-new characters were buried in the very row meant to feature them.

## What this does

**Database** — `migration 20260615160000_add_franchise_metadata.sql` (applied via Supabase MCP, `database.generated.ts` regenerated):
- Adds a `franchise` column + backfills all **91 characters across 54 franchises**.
- Adds a `media` tag category (`anime`, `video-game`, `horror-icon`, `screen-icon`, `toy-cartoon`) to `hero_tag_vocab` and backfills `hero_tags` (87 tag rows).
- Backfills `alignment` for the whole cohort (20 now register as villains).
- Adds an `added_at` recency column and baselines the catalog so the cohort tops "Recently Added" (deliberately **not** keyed off `*_enriched_at`, which the enrichment pipeline keeps bumping).

**Query layer** (`src/lib/db/heroes.ts`):
- `getFranchiseIcons()` (marquee, ranked by power) and `getHeroesByMediaTag()` (themed rows).
- `getNewlyAddedCV()` now sorts by `added_at`, not `issue_count`.
- New category slugs (`franchise-icons`, `anime`, `video-games`, `horror`) wired through `getCategoryPage` / `getAllHeroesBySlug` / labels / descriptions.

**Explore + category screens** (native **and** web):
- A marquee **"Beyond the Comics"** row, plus **"Anime Legends"**, **"Video Game Heroes"**, and a dark-side **"Horror Icons"** row — each linking to its category page, with matching `rowStyle` accents.
- New category pages registered in both native and web `[slug]` screens.

One deliberate non-change: the Spotlight billboard's portrait-only gate is left intact (square `image_url` looks broken at half-screen), and the portrait-bearing cohort already qualifies for its existing pools.

## Testing
- `yarn test:ci` — **317 passed**.
- `yarn typecheck` — changed files clean (remaining errors are pre-existing in unrelated admin/compare/profile files).
- Verified against the live DB that the marquee (Thragg, Saitama, Frieza, Lucifer…) and themed rows (29 anime / 15 video-game / 7 horror) return strong lineups, and that "Recently Added" now leads with the cohort.

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_