### PR TITLE
Add &quot;what's on screen now&quot; rails to Explore (Phase 1)

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -46,6 +46,7 @@ import {
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
+import { getTrendingHeroes, type TrendingHero } from '../../src/lib/db/trending';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -100,6 +101,9 @@ export default function HomeScreen() {
   const [anime, setAnime] = useState<Hero[]>([]);
   const [videoGames, setVideoGames] = useState<Hero[]>([]);
   const [horror, setHorror] = useState<Hero[]>([]);
+  const [onScreen, setOnScreen] = useState<TrendingHero[]>([]);
+  const [comingSoon, setComingSoon] = useState<TrendingHero[]>([]);
+  const [streaming, setStreaming] = useState<TrendingHero[]>([]);
 
   const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
@@ -167,6 +171,15 @@ export default function HomeScreen() {
     getHeroesByMediaTag('horror-icon', 20)
       .then(setHorror)
       .catch(() => {});
+    getTrendingHeroes('on_screen', 20)
+      .then(setOnScreen)
+      .catch(() => {});
+    getTrendingHeroes('coming_soon', 20)
+      .then(setComingSoon)
+      .catch(() => {});
+    getTrendingHeroes('streaming', 20)
+      .then(setStreaming)
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -209,6 +222,24 @@ export default function HomeScreen() {
     heroes: Hero[];
     route?: Href;
   }[] = [
+    {
+      key: 'onscreen',
+      label: 'In Theaters & Recent',
+      title: 'On the Big Screen',
+      heroes: onScreen as unknown as Hero[],
+    },
+    {
+      key: 'comingsoon',
+      label: 'Releasing Soon',
+      title: 'Coming Soon',
+      heroes: comingSoon as unknown as Hero[],
+    },
+    {
+      key: 'streaming',
+      label: 'Now Streaming',
+      title: 'Streaming Now',
+      heroes: streaming as unknown as Hero[],
+    },
     {
       key: 'iconic',
       label: 'By Appearances',
@@ -324,6 +355,9 @@ export default function HomeScreen() {
     anime,
     videoGames,
     horror,
+    onScreen,
+    comingSoon,
+    streaming,
   ]);
 
   const keyExtractor = useCallback(

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -22,6 +22,7 @@ import {
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
+import { getTrendingHeroes, type TrendingHero } from '../../src/lib/db/trending';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -1176,6 +1177,9 @@ export default function WebHomeScreen() {
     anime: Hero[];
     videoGames: Hero[];
     horror: Hero[];
+    onScreen: TrendingHero[];
+    comingSoon: TrendingHero[];
+    streaming: TrendingHero[];
     strongestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     smartestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     fastestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
@@ -1249,6 +1253,15 @@ export default function WebHomeScreen() {
       .catch(() => {});
     getHeroesByMediaTag('horror-icon', 25)
       .then(set('horror'))
+      .catch(() => {});
+    getTrendingHeroes('on_screen', 25)
+      .then(set('onScreen'))
+      .catch(() => {});
+    getTrendingHeroes('coming_soon', 25)
+      .then(set('comingSoon'))
+      .catch(() => {});
+    getTrendingHeroes('streaming', 25)
+      .then(set('streaming'))
       .catch(() => {});
     getFirstAppearanceCovers(14)
       .then(set('covers'))
@@ -1350,6 +1363,26 @@ export default function WebHomeScreen() {
               label="Personal"
               title="Jump Back In"
               heroes={recentlyViewed}
+              onPress={handlePress}
+            />
+
+            {/* ── On Screen Now — keep Explore tied to the real-world slate ─── */}
+            <HomeRow
+              label="In Theaters & Recent"
+              title="On the Big Screen"
+              heroes={(homeData.onScreen ?? []) as unknown as Hero[]}
+              onPress={handlePress}
+            />
+            <HomeRow
+              label="Releasing Soon"
+              title="Coming Soon"
+              heroes={(homeData.comingSoon ?? []) as unknown as Hero[]}
+              onPress={handlePress}
+            />
+            <HomeRow
+              label="Now Streaming"
+              title="Streaming Now"
+              heroes={(homeData.streaming ?? []) as unknown as Hero[]}
               onPress={handlePress}
             />
 

--- a/src/lib/db/trending.ts
+++ b/src/lib/db/trending.ts
@@ -1,0 +1,36 @@
+import { supabase } from '../supabase';
+
+// "Always feel current" rails — characters tied to the real-world film/TV slate,
+// served by the get_trending_heroes RPC over the TMDB-backed titles table and the
+// hero_media_appearances graph. Read-only; the RPC does the join, dedup and
+// ordering so the client just renders cards.
+
+export type TrendingBucket = 'on_screen' | 'coming_soon' | 'streaming';
+
+export interface TrendingHero {
+  id: string;
+  name: string;
+  image_url: string | null;
+  portrait_url: string | null;
+  /** The title that put this character on the rail (e.g. "Superman"). */
+  context_title: string | null;
+  media_type: string | null;
+  release_date: string | null;
+  /** US streaming service for the `streaming` bucket (e.g. "Disney Plus"). */
+  provider: string | null;
+}
+
+export async function getTrendingHeroes(
+  bucket: TrendingBucket,
+  limit = 20,
+): Promise<TrendingHero[]> {
+  const { data, error } = await supabase.rpc('get_trending_heroes', {
+    p_bucket: bucket,
+    p_limit: limit,
+  });
+  if (error) {
+    console.warn('[getTrendingHeroes] error:', error.message);
+    return [];
+  }
+  return (data ?? []) as TrendingHero[];
+}

--- a/src/lib/home/rowStyle.ts
+++ b/src/lib/home/rowStyle.ts
@@ -17,6 +17,9 @@ const DEFAULT: RowStyle = {
 
 // Per-category overrides keyed by the catalog `key` used in explore.tsx.
 const MAP: Record<string, Partial<RowStyle>> = {
+  onscreen: { feature: true, accent: COLORS.orange },
+  comingsoon: { accent: COLORS.gold },
+  streaming: { accent: COLORS.blue },
   iconic: { feature: true, ranked: true, accent: COLORS.orange },
   franchise: { feature: true, accent: COLORS.goldAccent },
   villains: { tone: 'dark', accent: COLORS.red },

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1017,6 +1017,19 @@ export type Database = {
           cross_universe: boolean
         }[]
       }
+      get_trending_heroes: {
+        Args: { p_bucket?: string; p_limit?: number }
+        Returns: {
+          context_title: string
+          id: string
+          image_url: string
+          media_type: string
+          name: string
+          portrait_url: string
+          provider: string
+          release_date: string
+        }[]
+      }
       heroes_aliases_text: { Args: { arr: string[] }; Returns: string }
       mark_hero_unresolved: { Args: { p_hero_id: string }; Returns: undefined }
       rebuild_hero_relationships: { Args: never; Returns: undefined }

--- a/supabase/migrations/20260615170000_trending_heroes_rpc.sql
+++ b/supabase/migrations/20260615170000_trending_heroes_rpc.sql
@@ -1,0 +1,55 @@
+-- Phase 1 of the "always feel current" Explore work: surface characters tied to
+-- the real-world film/TV slate, straight from the TMDB-backed titles table and
+-- the hero_media_appearances graph. Read-only; no external calls. Three buckets:
+--   on_screen   — released in the last year (recent theatrical / TV)
+--   coming_soon — releasing in the future
+--   streaming   — recent + currently on a US streaming service (flatrate)
+-- One row per hero (their most relevant title), with a context title + provider
+-- the UI can show as a badge. Recency is the primary order so the feed leads
+-- with the most recent release; ties break by the character's popularity
+-- (issue_count) so marquee names lead within each title rather than bit players.
+create or replace function public.get_trending_heroes(
+  p_bucket text default 'on_screen',
+  p_limit integer default 20
+)
+returns table (
+  id text, name text, image_url text, portrait_url text,
+  context_title text, media_type text, release_date date, provider text
+)
+language sql
+stable
+as $$
+  select s.id, s.name, s.image_url, s.portrait_url,
+         s.context_title, s.media_type, s.release_date, s.provider
+  from (
+    select distinct on (h.id)
+      h.id, h.name, h.image_url, h.portrait_url, h.issue_count,
+      t.title as context_title, t.media_type, t.release_date,
+      (t.watch_providers::jsonb #>> '{US,flatrate,0,provider_name}') as provider
+    from public.hero_media_appearances a
+    join public.heroes h on h.id = a.hero_id
+    join public.titles t on t.id = a.title_id
+    where t.media_type in ('film', 'tv')
+      and (h.portrait_url is not null or h.image_url is not null)
+      and case p_bucket
+        when 'on_screen'   then t.release_date between current_date - 365 and current_date
+        when 'coming_soon' then t.release_date > current_date
+        when 'streaming'   then t.release_date between current_date - 540 and current_date
+                                and (t.watch_providers::jsonb #>> '{US,flatrate,0,provider_name}') is not null
+        else false
+      end
+    -- distinct on requires h.id first; pick each hero's most relevant title.
+    order by h.id,
+      case when p_bucket = 'coming_soon' then t.release_date end asc,
+      case when p_bucket <> 'coming_soon' then t.release_date end desc,
+      a.rank asc nulls last
+  ) s
+  order by
+    case when p_bucket = 'coming_soon' then s.release_date end asc nulls last,
+    case when p_bucket <> 'coming_soon' then s.release_date end desc nulls last,
+    s.issue_count desc nulls last,
+    s.context_title
+  limit p_limit;
+$$;
+
+grant execute on function public.get_trending_heroes(text, integer) to anon, authenticated, service_role;


### PR DESCRIPTION
## Why

Keeps Explore tied to the real-world film/TV slate so it feels current, using the TMDB-backed `titles` table and the `hero_media_appearances` graph that already link **698 characters to 1,274 titles** — **no new external API calls**.

## What this does

- **`get_trending_heroes(p_bucket, p_limit)` RPC** (read-only) — three buckets:
  - `on_screen` — released in the last year (recent theatrical / TV)
  - `coming_soon` — future releases
  - `streaming` — recent + currently on a US streaming service (flatrate)
  - One row per character (their most relevant title), ordered by recency with a popularity (`issue_count`) tiebreaker so marquee names lead over bit players. Returns a `context_title` + `provider` for future badges.
- **`src/lib/db/trending.ts`** — typed client wrapper.
- **Explore (native + web)** — three new top-of-feed rows: **On the Big Screen**, **Coming Soon**, **Streaming Now**, with `rowStyle` accents.

Surfaces *Masters of the Universe* (just out), upcoming *Supergirl* and *Spider-Man: Brand New Day*, and the streaming catalogue (*Superman*, *Fantastic Four*, *Thunderbolts*…).

## Known limitation (→ Phase 2)
The rails are only as current as the `titles` snapshot, which isn't continuously refreshed — so the theatrical window is widened to a year to stay full. Phase 2 (TMDB `popularity` / `/trending` ingestion on a daily cron + a time-decayed score) makes it genuinely real-time.

## Testing
- `yarn test:ci` — **317 passed**.
- `yarn typecheck` — changed files clean (pre-existing unrelated errors only).
- Verified live: On Screen leads with *Masters of the Universe*; Coming Soon shows *Supergirl* / *Spider-Man: Brand New Day*.

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_