### PR TITLE
Phase 3: editorial campaigns, personalized trending & spotlight injection

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -43,10 +43,18 @@ import {
   getHeroesByStatRanking,
   getFranchiseIcons,
   getHeroesByMediaTag,
+  getTrendingSpotlightHeroes,
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
-import { getTrendingTitles, type TrendingTitle } from '../../src/lib/db/trending';
+import {
+  getTrendingTitles,
+  getActiveCampaigns,
+  getTrendingForUser,
+  type TrendingTitle,
+  type Campaign,
+  type TrendingTitleCharacter,
+} from '../../src/lib/db/trending';
 import { TrendingShelf } from '../../src/components/home/TrendingShelf';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
@@ -113,6 +121,8 @@ export default function HomeScreen() {
   const [onScreen, setOnScreen] = useState<TrendingTitle[]>([]);
   const [comingSoon, setComingSoon] = useState<TrendingTitle[]>([]);
   const [streaming, setStreaming] = useState<TrendingTitle[]>([]);
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [trendingForUser, setTrendingForUser] = useState<TrendingTitleCharacter[]>([]);
 
   const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
@@ -134,12 +144,26 @@ export default function HomeScreen() {
   // arrive. getSpotlightHeroes gates on portraits + enrichment and rotates a
   // mostly-marquee, partly-discovery lineup, so the billboard always looks right.
   useEffect(() => {
-    getSpotlightHeroes(SPOTLIGHT_POOL)
-      .then((heroes) => {
-        setSpotlight(heroes);
+    // Lead the billboard with up to 2 characters who are on screen right now,
+    // then fill with the curated spotlight pool (deduped).
+    Promise.all([getSpotlightHeroes(SPOTLIGHT_POOL), getTrendingSpotlightHeroes(2)])
+      .then(([base, trend]) => {
+        const seen = new Set<string>();
+        const merged: Hero[] = [];
+        for (const h of [...trend, ...base]) {
+          if (!seen.has(h.id)) {
+            seen.add(h.id);
+            merged.push(h);
+          }
+        }
+        setSpotlight(merged.slice(0, SPOTLIGHT_POOL));
         setInitialLoaded(true);
       })
       .catch(() => setInitialLoaded(true));
+
+    getActiveCampaigns()
+      .then(setCampaigns)
+      .catch(() => {});
 
     getIconicHeroes(20)
       .then(setIconic)
@@ -198,6 +222,9 @@ export default function HomeScreen() {
       .catch(() => {});
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
+      .catch(() => {});
+    getTrendingForUser(user.id)
+      .then(setTrendingForUser)
       .catch(() => {});
   }, [user?.id]);
 
@@ -325,6 +352,18 @@ export default function HomeScreen() {
   const rows = useMemo<FeedRow[]>(() => {
     const out: FeedRow[] = [];
     if (spotlightPool.length > 0) out.push({ type: 'spotlight', heroes: spotlightPool });
+    // Editorial campaign (premiere / event / launch) — the top scheduled moment,
+    // right under the billboard.
+    const campaign = campaigns[0];
+    if (campaign && campaign.characters.length > 0) {
+      out.push({
+        type: 'curated',
+        key: 'campaign',
+        label: campaign.label,
+        title: campaign.headline,
+        heroes: campaign.characters as unknown as Hero[],
+      });
+    }
     // "What's current" zone — directly under the billboard so Explore leads with
     // the real-world slate. Grouped by title (poster + cast), not flat cards.
     const trendingShelves = [
@@ -352,6 +391,17 @@ export default function HomeScreen() {
     ];
     for (const sh of trendingShelves) {
       if (sh.titles.length > 0) out.push({ type: 'trending', ...sh });
+    }
+    // Personalized: current characters sharing a publisher/franchise with the
+    // user's favourites + history. Hidden when signed-out or affinity-less.
+    if (trendingForUser.length > 0) {
+      out.push({
+        type: 'curated',
+        key: 'youruniverse',
+        label: 'For You',
+        title: 'Trending in Your Universe',
+        heroes: trendingForUser as unknown as Hero[],
+      });
     }
     if (recentlyViewed.length > 0)
       out.push({ type: 'recent', heroes: recentlyViewed.map(toRowHero) });
@@ -385,6 +435,8 @@ export default function HomeScreen() {
     onScreen,
     comingSoon,
     streaming,
+    campaigns,
+    trendingForUser,
   ]);
 
   const keyExtractor = useCallback(

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -19,10 +19,18 @@ import {
   getHeroesByStatRanking,
   getFranchiseIcons,
   getHeroesByMediaTag,
+  getTrendingSpotlightHeroes,
   type Hero,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
-import { getTrendingTitles, type TrendingTitle } from '../../src/lib/db/trending';
+import {
+  getTrendingTitles,
+  getActiveCampaigns,
+  getTrendingForUser,
+  type TrendingTitle,
+  type Campaign,
+  type TrendingTitleCharacter,
+} from '../../src/lib/db/trending';
 import { TrendingShelf } from '../../src/components/web/home/TrendingShelf';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
@@ -1181,6 +1189,8 @@ export default function WebHomeScreen() {
     onScreen: TrendingTitle[];
     comingSoon: TrendingTitle[];
     streaming: TrendingTitle[];
+    campaigns: Campaign[];
+    trendingForUser: TrendingTitleCharacter[];
     strongestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     smartestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     fastestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
@@ -1209,12 +1219,25 @@ export default function WebHomeScreen() {
       (val: HomeData[K]) =>
         setHomeData((d) => ({ ...d, [key]: val }));
 
-    getSpotlightHeroes(10)
-      .then((v) => {
-        set('spotlight')(v);
+    // Lead the billboard with characters on screen right now, then the pool.
+    Promise.all([getSpotlightHeroes(10), getTrendingSpotlightHeroes(2)])
+      .then(([base, trend]) => {
+        const seen = new Set<string>();
+        const merged: Hero[] = [];
+        for (const h of [...trend, ...base]) {
+          if (!seen.has(h.id)) {
+            seen.add(h.id);
+            merged.push(h);
+          }
+        }
+        set('spotlight')(merged);
         setHomeStarted(true);
       })
       .catch(() => setHomeStarted(true));
+
+    getActiveCampaigns()
+      .then(set('campaigns'))
+      .catch(() => {});
 
     getIconicHeroes(25)
       .then(set('iconic'))
@@ -1302,6 +1325,9 @@ export default function WebHomeScreen() {
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
       .catch(() => {});
+    getTrendingForUser(user.id)
+      .then((v) => setHomeData((d) => ({ ...d, trendingForUser: v })))
+      .catch(() => {});
   }, [user?.id]);
 
   const handlePress = useCallback(
@@ -1374,6 +1400,16 @@ export default function WebHomeScreen() {
               onPress={handlePress}
             />
 
+            {/* ── Editorial campaign — the top scheduled moment ─────────────── */}
+            {(homeData.campaigns?.[0]?.characters.length ?? 0) > 0 && (
+              <HomeRow
+                label={homeData.campaigns![0].label}
+                title={homeData.campaigns![0].headline}
+                heroes={homeData.campaigns![0].characters as unknown as Hero[]}
+                onPress={handlePress}
+              />
+            )}
+
             {/* ── What's current — grouped by title (poster + cast) ─────────── */}
             <TrendingShelf
               label="In Theaters & Recent"
@@ -1399,6 +1435,16 @@ export default function WebHomeScreen() {
               onHeroPress={handlePress}
               onTitlePress={handleTitlePress}
             />
+
+            {/* ── Personalized — current characters in the user's universe ──── */}
+            {(homeData.trendingForUser?.length ?? 0) > 0 && (
+              <HomeRow
+                label="For You"
+                title="Trending in Your Universe"
+                heroes={(homeData.trendingForUser ?? []) as unknown as Hero[]}
+                onPress={handlePress}
+              />
+            )}
 
             {/* ── The Universe — the marquee browse ─────────────────────────── */}
             <HomeRow

--- a/src/lib/db/heroes.ts
+++ b/src/lib/db/heroes.ts
@@ -339,6 +339,36 @@ export async function getSpotlightHeroes(limit = 5): Promise<Hero[]> {
   return sampleN([...famous, ...discovery], limit);
 }
 
+/**
+ * Billboard-ready heroes who are currently on screen — the top of the on_screen
+ * trending bucket, filtered to those that satisfy the spotlight's gates (portrait
+ * + summary + real powerstats). Prepended to the spotlight pool so the billboard
+ * leads with characters audiences are seeing in theaters right now.
+ */
+export async function getTrendingSpotlightHeroes(limit = 2): Promise<Hero[]> {
+  const { data: trend, error: trendErr } = await supabase.rpc('get_trending_heroes', {
+    p_bucket: 'on_screen',
+    p_limit: 40,
+  });
+  if (trendErr || !trend?.length) return [];
+  const ids = (trend as { id: string }[]).map((t) => t.id);
+  const { data, error } = await supabase
+    .from('heroes')
+    .select(HOME_SPOT)
+    .in('id', ids)
+    .not('portrait_url', 'is', null)
+    .not('summary', 'is', null)
+    .gte('powerstats_total', SPOT_MIN_POWERSTATS);
+  if (error) {
+    console.warn('[getTrendingSpotlightHeroes] error:', error.message);
+    return [];
+  }
+  const order = new Map(ids.map((id, i) => [id, i]));
+  return ((data ?? []) as unknown as Hero[])
+    .sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0))
+    .slice(0, limit);
+}
+
 export async function getNewlyAddedCV(limit = 25): Promise<Hero[]> {
   const { data, error } = await supabase
     .from('heroes')

--- a/src/lib/db/trending.ts
+++ b/src/lib/db/trending.ts
@@ -112,6 +112,87 @@ export async function getTrendingTitles(
   return [...byTitle.values()];
 }
 
+// ── Editorial campaigns (Phase 3) ────────────────────────────────────────────
+
+export interface Campaign {
+  id: string;
+  label: string;
+  headline: string;
+  blurb: string | null;
+  accent: string | null;
+  characters: TrendingTitleCharacter[];
+}
+
+/** Active editorial campaigns (premieres, events, launches) resolved to their
+ *  characters. Empty when nothing is scheduled for right now. */
+export async function getActiveCampaigns(limit = 3, chars = 16): Promise<Campaign[]> {
+  const { data, error } = await supabase.rpc('get_active_campaigns', {
+    p_limit: limit,
+    p_chars: chars,
+  });
+  if (error) {
+    console.warn('[getActiveCampaigns] error:', error.message);
+    return [];
+  }
+  const byId = new Map<string, Campaign>();
+  for (const r of (data ?? []) as {
+    campaign_id: string;
+    label: string;
+    headline: string;
+    blurb: string | null;
+    accent: string | null;
+    hero_id: string;
+    hero_name: string;
+    hero_image_url: string | null;
+    hero_portrait_url: string | null;
+  }[]) {
+    let c = byId.get(r.campaign_id);
+    if (!c) {
+      c = {
+        id: r.campaign_id,
+        label: r.label,
+        headline: r.headline,
+        blurb: r.blurb,
+        accent: r.accent,
+        characters: [],
+      };
+      byId.set(r.campaign_id, c);
+    }
+    c.characters.push({
+      id: r.hero_id,
+      name: r.hero_name,
+      image_url: r.hero_image_url,
+      portrait_url: r.hero_portrait_url,
+    });
+  }
+  return [...byId.values()];
+}
+
+// ── Personalized trending (Phase 3) ──────────────────────────────────────────
+
+/** Characters from the current film/TV window that share a publisher or franchise
+ *  with what the user has favourited or recently viewed. Empty for signed-out or
+ *  affinity-less users (the caller hides the row). */
+export async function getTrendingForUser(
+  userId: string,
+  limit = 20,
+): Promise<TrendingTitleCharacter[]> {
+  const { data, error } = await supabase.rpc('get_trending_for_user', {
+    p_user_id: userId,
+    p_limit: limit,
+  });
+  if (error) {
+    console.warn('[getTrendingForUser] error:', error.message);
+    return [];
+  }
+  return ((data ?? []) as TrendingTitleCharacter[]).map((r) => ({
+    id: r.id,
+    name: r.name,
+    image_url: r.image_url,
+    portrait_url: r.portrait_url,
+  }));
+}
+
 /** A short meta line for a trending title — provider, upcoming date, or year. */
 export function trendingTitleMeta(t: TrendingTitle): string | null {
   if (t.provider) return `On ${t.provider}`;

--- a/src/lib/home/rowStyle.ts
+++ b/src/lib/home/rowStyle.ts
@@ -17,6 +17,8 @@ const DEFAULT: RowStyle = {
 
 // Per-category overrides keyed by the catalog `key` used in explore.tsx.
 const MAP: Record<string, Partial<RowStyle>> = {
+  campaign: { feature: true, accent: COLORS.orange },
+  youruniverse: { feature: true, accent: COLORS.skin },
   onscreen: { feature: true, accent: COLORS.orange },
   comingsoon: { accent: COLORS.gold },
   streaming: { accent: COLORS.blue },

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -179,6 +179,59 @@ export type Database = {
         }
         Relationships: []
       }
+      featured_campaigns: {
+        Row: {
+          accent: string | null
+          blurb: string | null
+          created_at: string
+          ends_at: string
+          franchise: string | null
+          headline: string
+          hero_ids: string[] | null
+          id: string
+          label: string
+          priority: number
+          starts_at: string
+          title_id: string | null
+        }
+        Insert: {
+          accent?: string | null
+          blurb?: string | null
+          created_at?: string
+          ends_at: string
+          franchise?: string | null
+          headline: string
+          hero_ids?: string[] | null
+          id?: string
+          label: string
+          priority?: number
+          starts_at?: string
+          title_id?: string | null
+        }
+        Update: {
+          accent?: string | null
+          blurb?: string | null
+          created_at?: string
+          ends_at?: string
+          franchise?: string | null
+          headline?: string
+          hero_ids?: string[] | null
+          id?: string
+          label?: string
+          priority?: number
+          starts_at?: string
+          title_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "featured_campaigns_title_id_fkey"
+            columns: ["title_id"]
+            isOneToOne: false
+            referencedRelation: "titles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       hero_facts: {
         Row: {
           hero_id: string
@@ -921,6 +974,22 @@ export type Database = {
         Args: { p_enabled: boolean; p_jobname: string }
         Returns: string
       }
+      admin_upsert_campaign: {
+        Args: {
+          p_accent?: string
+          p_blurb?: string
+          p_ends_at: string
+          p_franchise?: string
+          p_headline: string
+          p_hero_ids?: string[]
+          p_id?: string
+          p_label: string
+          p_priority?: number
+          p_starts_at?: string
+          p_title_id?: string
+        }
+        Returns: string
+      }
       cache_hero_comicvine_data: {
         Args: { p_id: string; p_powers: string[]; p_summary: string }
         Returns: undefined
@@ -937,6 +1006,20 @@ export type Database = {
           p_slug: string
         }
         Returns: Json
+      }
+      get_active_campaigns: {
+        Args: { p_chars?: number; p_limit?: number }
+        Returns: {
+          accent: string
+          blurb: string
+          campaign_id: string
+          headline: string
+          hero_id: string
+          hero_image_url: string
+          hero_name: string
+          hero_portrait_url: string
+          label: string
+        }[]
       }
       get_era_timeline: {
         Args: { per_era?: number }
@@ -1018,6 +1101,16 @@ export type Database = {
           b_portrait_url: string
           b_publisher: string
           cross_universe: boolean
+        }[]
+      }
+      get_trending_for_user: {
+        Args: { p_limit?: number; p_user_id: string }
+        Returns: {
+          context_title: string
+          id: string
+          image_url: string
+          name: string
+          portrait_url: string
         }[]
       }
       get_trending_heroes: {

--- a/supabase/migrations/20260615190000_phase3_campaigns_and_personal_trending.sql
+++ b/supabase/migrations/20260615190000_phase3_campaigns_and_personal_trending.sql
@@ -1,0 +1,166 @@
+-- Phase 3: editorial campaigns + personalized trending.
+
+-- ── 1. featured_campaigns ───────────────────────────────────────────────────
+-- Admin-scheduled editorial moments TMDB popularity can't see (premieres,
+-- Comic-Con, game launches). A start/end window; targets a set of characters by
+-- explicit ids, a franchise, or a title.
+create table if not exists public.featured_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  label text not null,                 -- eyebrow, e.g. "In Theaters"
+  headline text not null,              -- row title, e.g. "Masters of the Universe"
+  blurb text,
+  accent text,                         -- optional hex accent
+  franchise text,
+  title_id text references public.titles(id) on delete set null,
+  hero_ids text[],
+  priority integer not null default 0,
+  starts_at timestamptz not null default now(),
+  ends_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists featured_campaigns_window_idx
+  on public.featured_campaigns (ends_at, starts_at, priority desc);
+
+alter table public.featured_campaigns enable row level security;
+drop policy if exists "featured_campaigns_public_read" on public.featured_campaigns;
+create policy "featured_campaigns_public_read"
+  on public.featured_campaigns for select using (true);
+-- Writes go through the admin-gated security-definer RPC only.
+
+-- Active campaigns (window contains now), highest priority first, resolved to
+-- hero cards. Resolution precedence: explicit hero_ids > franchise > title.
+create or replace function public.get_active_campaigns(
+  p_limit integer default 3,
+  p_chars integer default 16
+)
+returns table (
+  campaign_id uuid, label text, headline text, blurb text, accent text,
+  hero_id text, hero_name text, hero_image_url text, hero_portrait_url text
+)
+language sql
+stable
+as $$
+  with active as (
+    select * from public.featured_campaigns
+    where now() between starts_at and ends_at
+    order by priority desc, starts_at desc
+    limit p_limit
+  ),
+  resolved as (
+    select c.id as campaign_id, c.label, c.headline, c.blurb, c.accent,
+           c.priority, c.starts_at,
+           h.id as hero_id, h.name as hero_name,
+           h.image_url as hero_image_url, h.portrait_url as hero_portrait_url,
+           row_number() over (
+             partition by c.id order by h.issue_count desc nulls last
+           ) as rn
+    from active c
+    join public.heroes h on (
+      (c.hero_ids is not null and h.id = any(c.hero_ids))
+      or (c.hero_ids is null and c.franchise is not null and h.franchise = c.franchise)
+      or (c.hero_ids is null and c.franchise is null and c.title_id is not null
+          and exists (
+            select 1 from public.hero_media_appearances a
+            where a.title_id = c.title_id and a.hero_id = h.id
+          ))
+    )
+    where (h.portrait_url is not null or h.image_url is not null)
+  )
+  select campaign_id, label, headline, blurb, accent,
+         hero_id, hero_name, hero_image_url, hero_portrait_url
+  from resolved
+  where rn <= p_chars
+  order by priority desc, starts_at desc, rn;
+$$;
+grant execute on function public.get_active_campaigns(integer, integer) to anon, authenticated, service_role;
+
+-- Admin upsert (insert when p_id is null, else update). is_admin gated.
+create or replace function public.admin_upsert_campaign(
+  p_label text,
+  p_headline text,
+  p_ends_at timestamptz,
+  p_id uuid default null,
+  p_blurb text default null,
+  p_accent text default null,
+  p_franchise text default null,
+  p_title_id text default null,
+  p_hero_ids text[] default null,
+  p_priority integer default 0,
+  p_starts_at timestamptz default now()
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare v_id uuid;
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  if p_id is null then
+    insert into public.featured_campaigns
+      (label, headline, blurb, accent, franchise, title_id, hero_ids, priority, starts_at, ends_at)
+    values
+      (p_label, p_headline, p_blurb, p_accent, p_franchise, p_title_id, p_hero_ids, p_priority, p_starts_at, p_ends_at)
+    returning id into v_id;
+  else
+    update public.featured_campaigns set
+      label = p_label, headline = p_headline, blurb = p_blurb, accent = p_accent,
+      franchise = p_franchise, title_id = p_title_id, hero_ids = p_hero_ids,
+      priority = p_priority, starts_at = p_starts_at, ends_at = p_ends_at
+    where id = p_id
+    returning id into v_id;
+  end if;
+  return v_id;
+end $$;
+grant execute on function public.admin_upsert_campaign(text, text, timestamptz, uuid, text, text, text, text, text[], integer, timestamptz) to authenticated, service_role;
+
+-- Seed one live campaign so the row renders immediately (Masters of the Universe
+-- just hit cinemas; its franchise was tagged in the Phase-1 migration).
+insert into public.featured_campaigns (label, headline, blurb, accent, franchise, priority, ends_at)
+values ('In Theaters Now', 'Masters of the Universe',
+        'He-Man and Skeletor clash on the big screen — meet the cast of Eternia.',
+        '#E77333', 'Masters of the Universe', 100, now() + interval '45 days');
+
+-- ── 2. Personalized trending ────────────────────────────────────────────────
+-- Characters from the current film/TV window whose publisher or franchise
+-- matches what the user has favourited or recently viewed — "Trending in your
+-- universe". Public hero data only; ranked by recency then fame.
+create or replace function public.get_trending_for_user(
+  p_user_id uuid,
+  p_limit integer default 20
+)
+returns table (
+  id text, name text, image_url text, portrait_url text, context_title text
+)
+language sql
+stable
+as $$
+  with aff as (
+    select distinct h.publisher, h.franchise
+    from (
+      select hero_id from public.user_favourites where user_id = p_user_id
+      union
+      select hero_id from public.user_view_history where user_id = p_user_id
+    ) u
+    join public.heroes h on h.id = u.hero_id
+    where h.publisher is not null or h.franchise is not null
+  )
+  select s.id, s.name, s.image_url, s.portrait_url, s.context_title
+  from (
+    select distinct on (h.id)
+      h.id, h.name, h.image_url, h.portrait_url, t.title as context_title, t.release_date
+    from public.titles t
+    join public.hero_media_appearances a on a.title_id = t.id
+    join public.heroes h on h.id = a.hero_id
+    join aff on (aff.publisher = h.publisher or aff.franchise = h.franchise)
+    where t.media_type in ('film', 'tv')
+      and t.release_date between current_date - 540 and current_date + 120
+      and (h.portrait_url is not null or h.image_url is not null)
+    order by h.id, t.release_date desc nulls last, h.issue_count desc nulls last
+  ) s
+  order by s.release_date desc nulls last
+  limit p_limit;
+$$;
+grant execute on function public.get_trending_for_user(uuid, integer) to anon, authenticated, service_role;


### PR DESCRIPTION
## What this does

Three additions that keep Explore feeling current **and** personal.

### 1. Spotlight injection
The billboard now leads with up to **2 characters who are on screen right now** (top of the `on_screen` bucket, filtered to the spotlight's portrait + summary + stats gates), then fills with the curated pool — deduped. So when *Masters of the Universe* is in cinemas, He-Man can headline the billboard.

### 2. Editorial campaigns
A `featured_campaigns` table for moments TMDB popularity can't see — **premieres, Comic-Con, game launches** — with admin-scheduled `starts_at`/`ends_at` windows and priority. Targets characters by **explicit ids, a franchise, or a title**.
- `get_active_campaigns` resolves live campaigns to hero cards.
- `admin_upsert_campaign` (is_admin gated, security definer) manages them.
- Renders as a featured row at the top of Explore (native + web), under the billboard.
- **Seeded** with a live *"Masters of the Universe — In Theaters Now"* campaign (resolves to He-Man / Skeletor) so the row is visible immediately.

### 3. Trending in your universe
`get_trending_for_user` returns current film/TV characters that share a **publisher or franchise** with the user's favourites + view history — rendered as a "Trending in Your Universe" row. Hidden for signed-out / affinity-less users.

## Files
- DB: `migration 20260615190000` (table + public-read RLS + 3 RPCs + seed); types regenerated.
- Client: `getActiveCampaigns` / `getTrendingForUser` (`src/lib/db/trending.ts`), `getTrendingSpotlightHeroes` (`src/lib/db/heroes.ts`).
- UI: campaign + personalized rows reuse the existing `HomeHeroRow` / `HomeRow`; new `rowStyle` accents.

## Notes
Campaign management ships as an RPC (`admin_upsert_campaign`) — a dedicated admin screen in the command center is a natural follow-up, but campaigns are fully usable via the RPC today.

## Testing
- `yarn test:ci` — **318 passed**.
- `yarn typecheck` — changed files clean.
- Verified live: `get_active_campaigns` → He-Man / Skeletor; personalization RPC runs clean (empty for users with no affinity).

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_