### PR TITLE
Phase 4: campaign admin screen + TMDB trending wired live

### DIFF
--- a/__tests__/components/admin/health/format.test.ts
+++ b/__tests__/components/admin/health/format.test.ts
@@ -10,6 +10,7 @@ describe('DOMAINS', () => {
       'command',
       'catalog',
       'pipelines',
+      'campaigns',
       'spend',
       'users',
       'traffic',
@@ -30,7 +31,7 @@ describe('DOMAINS', () => {
   });
 
   it('primaryDomainKeys excludes placeholders (mobile bottom bar set)', () => {
-    expect(primaryDomainKeys()).toEqual(['command', 'catalog', 'pipelines', 'spend']);
+    expect(primaryDomainKeys()).toEqual(['command', 'catalog', 'pipelines', 'campaigns', 'spend']);
   });
 });
 

--- a/app/admin/health.web.tsx
+++ b/app/admin/health.web.tsx
@@ -25,6 +25,7 @@ import { PipelinesDomain } from '../../src/components/admin/health/domains/Pipel
 import { BuildBoard } from '../../src/components/admin/health/BuildBoard';
 import { HeroConsole } from '../../src/components/admin/health/HeroConsole';
 import { SpendDomain } from '../../src/components/admin/health/domains/SpendDomain';
+import { CampaignsDomain } from '../../src/components/admin/health/domains/CampaignsDomain';
 import { PlaceholderDomain } from '../../src/components/admin/health/domains/PlaceholderDomain';
 import {
   useActivityLog,
@@ -66,16 +67,31 @@ export default function AdminHealthScreen() {
     if (gateResolved && !isAdmin) router.replace('/explore');
   }, [gateResolved, isAdmin, router]);
 
-  const { healthQ, gapsQ, runsQ, cronQ, heroSearchQ, pingQ, usageQ, distQ, snapsQ, spendQ, ambiguousQ, enrichProgressQ, statsPendingQ, portraitsPendingQ, recentEnrichedQ } =
-    useCatalogQueries({
-      enabled: gateResolved && isAdmin,
-      metric,
-      page,
-      pubFilter,
-      heroQuery,
-      historyLimit,
-      ambiguousLimit,
-    });
+  const {
+    healthQ,
+    gapsQ,
+    runsQ,
+    cronQ,
+    heroSearchQ,
+    pingQ,
+    usageQ,
+    distQ,
+    snapsQ,
+    spendQ,
+    ambiguousQ,
+    enrichProgressQ,
+    statsPendingQ,
+    portraitsPendingQ,
+    recentEnrichedQ,
+  } = useCatalogQueries({
+    enabled: gateResolved && isAdmin,
+    metric,
+    page,
+    pubFilter,
+    heroQuery,
+    historyLimit,
+    ambiguousLimit,
+  });
 
   const drainJob = cronQ.data?.find((j) => j.jobname === DRAIN_CRON);
   const cronOn = !!drainJob?.active;
@@ -226,7 +242,10 @@ export default function AdminHealthScreen() {
   // not yet fully enriched, and not terminally failed / awaiting review / unresolvable.
   const ep = enrichProgressQ.data;
   const actionable = ep
-    ? Math.max(0, ep.heroesTotal - ep.enriched - (h?.cvStatus.failed ?? 0) - ep.ambiguous - ep.unresolved)
+    ? Math.max(
+        0,
+        ep.heroesTotal - ep.enriched - (h?.cvStatus.failed ?? 0) - ep.ambiguous - ep.unresolved,
+      )
     : pendingNow;
   const etaMin = perMin > 0 ? actionable / perMin : 0;
   const etaLabel =
@@ -367,6 +386,7 @@ export default function AdminHealthScreen() {
             narrow={narrow}
           />
         )}
+        {domain === 'campaigns' && <CampaignsDomain />}
         {domain === 'spend' && <SpendDomain spend={spendQ.data} loading={spendQ.isLoading} />}
         {domain === 'users' && (
           <PlaceholderDomain

--- a/src/components/admin/health/domains/CampaignsDomain.tsx
+++ b/src/components/admin/health/domains/CampaignsDomain.tsx
@@ -1,0 +1,372 @@
+// Command-center domain: schedule & manage Explore's editorial campaigns
+// (premieres, events, launches). List + create/edit form + delete, all through
+// the is_admin-gated RPCs. Web-only, like the rest of the command center.
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Panel } from '../Panel';
+import { COLORS } from '../../../../constants/colors';
+import {
+  listCampaigns,
+  upsertCampaign,
+  deleteCampaign,
+  campaignStatus,
+  type Campaign,
+  type CampaignInput,
+  type CampaignStatus,
+} from '../../../../lib/db/campaigns';
+
+type TargetType = 'franchise' | 'title' | 'heroes';
+
+interface FormState {
+  id: string | null;
+  label: string;
+  headline: string;
+  blurb: string;
+  accent: string;
+  priority: string;
+  startsAt: string;
+  endsAt: string;
+  targetType: TargetType;
+  targetValue: string;
+}
+
+const EMPTY: FormState = {
+  id: null,
+  label: '',
+  headline: '',
+  blurb: '',
+  accent: '#E77333',
+  priority: '0',
+  startsAt: '',
+  endsAt: '',
+  targetType: 'franchise',
+  targetValue: '',
+};
+
+const STATUS_COLOR: Record<CampaignStatus, string> = {
+  live: COLORS.green,
+  scheduled: COLORS.gold,
+  ended: COLORS.grey,
+};
+
+const TARGET_HINT: Record<TargetType, string> = {
+  franchise: 'Franchise name, e.g. "The Boys"',
+  title: 'Title id, e.g. "tmdb:454639"',
+  heroes: 'Comma-separated hero ids, e.g. "cv-16423, 69"',
+};
+
+export function CampaignsDomain() {
+  const qc = useQueryClient();
+  const campaignsQ = useQuery({ queryKey: ['campaigns'], queryFn: listCampaigns });
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const set =
+    <K extends keyof FormState>(k: K) =>
+    (v: FormState[K]) =>
+      setForm((f) => ({ ...f, [k]: v }));
+
+  const editRow = (c: Campaign) => {
+    const tt: TargetType = c.hero_ids?.length ? 'heroes' : c.title_id ? 'title' : 'franchise';
+    setForm({
+      id: c.id,
+      label: c.label,
+      headline: c.headline,
+      blurb: c.blurb ?? '',
+      accent: c.accent ?? '#E77333',
+      priority: String(c.priority),
+      startsAt: c.starts_at ? c.starts_at.slice(0, 10) : '',
+      endsAt: c.ends_at.slice(0, 10),
+      targetType: tt,
+      targetValue:
+        tt === 'heroes'
+          ? (c.hero_ids ?? []).join(', ')
+          : tt === 'title'
+            ? (c.title_id ?? '')
+            : (c.franchise ?? ''),
+    });
+    setErr(null);
+  };
+
+  const save = async () => {
+    setErr(null);
+    if (!form.label.trim() || !form.headline.trim() || !form.endsAt.trim()) {
+      setErr('Label, headline and end date are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const v = form.targetValue.trim();
+      const input: CampaignInput = {
+        id: form.id,
+        label: form.label.trim(),
+        headline: form.headline.trim(),
+        blurb: form.blurb.trim() || null,
+        accent: form.accent.trim() || null,
+        priority: Number(form.priority) || 0,
+        starts_at: form.startsAt ? new Date(form.startsAt).toISOString() : undefined,
+        ends_at: new Date(`${form.endsAt}T23:59:59`).toISOString(),
+        franchise: form.targetType === 'franchise' ? v || null : null,
+        title_id: form.targetType === 'title' ? v || null : null,
+        hero_ids:
+          form.targetType === 'heroes'
+            ? v
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+            : null,
+      };
+      await upsertCampaign(input);
+      setForm(EMPTY);
+      qc.invalidateQueries({ queryKey: ['campaigns'] });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setErr(null);
+    try {
+      await deleteCampaign(id);
+      if (form.id === id) setForm(EMPTY);
+      qc.invalidateQueries({ queryKey: ['campaigns'] });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Delete failed');
+    }
+  };
+
+  const campaigns = campaignsQ.data ?? [];
+
+  return (
+    <View style={s.wrap}>
+      <Panel
+        title={form.id ? 'Edit campaign' : 'New campaign'}
+        hint="Schedule an editorial moment — it surfaces at the top of Explore while live."
+      >
+        <View style={s.formGrid}>
+          <Field
+            label="Label (eyebrow)"
+            value={form.label}
+            onChange={set('label')}
+            placeholder="In Theaters Now"
+          />
+          <Field
+            label="Headline"
+            value={form.headline}
+            onChange={set('headline')}
+            placeholder="Masters of the Universe"
+          />
+        </View>
+        <Field
+          label="Blurb (optional)"
+          value={form.blurb}
+          onChange={set('blurb')}
+          placeholder="One-line description"
+        />
+        <View style={s.formGrid}>
+          <Field
+            label="Accent (hex)"
+            value={form.accent}
+            onChange={set('accent')}
+            placeholder="#E77333"
+          />
+          <Field
+            label="Priority"
+            value={form.priority}
+            onChange={set('priority')}
+            placeholder="0"
+          />
+        </View>
+        <View style={s.formGrid}>
+          <Field
+            label="Start date (optional)"
+            value={form.startsAt}
+            onChange={set('startsAt')}
+            placeholder="YYYY-MM-DD"
+          />
+          <Field
+            label="End date"
+            value={form.endsAt}
+            onChange={set('endsAt')}
+            placeholder="YYYY-MM-DD"
+          />
+        </View>
+
+        <Text style={s.fieldLabel}>Target</Text>
+        <View style={s.targetRow}>
+          {(['franchise', 'title', 'heroes'] as TargetType[]).map((t) => (
+            <Pressable
+              key={t}
+              onPress={() => setForm((f) => ({ ...f, targetType: t }))}
+              style={[s.chip, form.targetType === t && s.chipOn] as object}
+            >
+              <Text style={[s.chipText, form.targetType === t && s.chipTextOn] as object}>{t}</Text>
+            </Pressable>
+          ))}
+        </View>
+        <Field
+          label=""
+          value={form.targetValue}
+          onChange={set('targetValue')}
+          placeholder={TARGET_HINT[form.targetType]}
+        />
+
+        {!!err && <Text style={s.err}>{err}</Text>}
+
+        <View style={s.actions}>
+          <Pressable onPress={save} disabled={saving} style={[s.btn, s.btnPrimary] as object}>
+            <Text style={s.btnPrimaryText}>
+              {saving ? 'Saving…' : form.id ? 'Update campaign' : 'Create campaign'}
+            </Text>
+          </Pressable>
+          {form.id && (
+            <Pressable onPress={() => setForm(EMPTY)} style={s.btn as object}>
+              <Text style={s.btnText}>Cancel edit</Text>
+            </Pressable>
+          )}
+        </View>
+      </Panel>
+
+      <Panel title="Campaigns" hint={`${campaigns.length} total`}>
+        {campaignsQ.isLoading ? (
+          <Text style={s.muted}>Loading…</Text>
+        ) : campaigns.length === 0 ? (
+          <Text style={s.muted}>No campaigns yet — create one above.</Text>
+        ) : (
+          <View style={{ gap: 8 }}>
+            {campaigns.map((c) => {
+              const status = campaignStatus(c);
+              const target = c.hero_ids?.length
+                ? `${c.hero_ids.length} heroes`
+                : c.title_id
+                  ? `title ${c.title_id}`
+                  : c.franchise
+                    ? c.franchise
+                    : '—';
+              return (
+                <View key={c.id} style={s.row}>
+                  <View style={[s.statusDot, { backgroundColor: STATUS_COLOR[status] }]} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={s.rowTitle} numberOfLines={1}>
+                      {c.headline}
+                      <Text style={s.rowMeta}>{`   ·   ${c.label}`}</Text>
+                    </Text>
+                    <Text style={s.rowSub} numberOfLines={1}>
+                      {`${status.toUpperCase()} · P${c.priority} · ${target} · ends ${c.ends_at.slice(0, 10)}`}
+                    </Text>
+                  </View>
+                  <Pressable onPress={() => editRow(c)} style={s.smallBtn as object}>
+                    <Text style={s.smallBtnText}>Edit</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => remove(c.id)}
+                    style={[s.smallBtn, s.smallBtnDanger] as object}
+                  >
+                    <Text style={[s.smallBtnText, { color: COLORS.red }] as object}>Delete</Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+        )}
+      </Panel>
+    </View>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <View style={{ flex: 1, gap: 4 }}>
+      {!!label && <Text style={s.fieldLabel}>{label}</Text>}
+      <TextInput
+        value={value}
+        onChangeText={onChange}
+        placeholder={placeholder}
+        placeholderTextColor={COLORS.grey}
+        style={s.input as object}
+      />
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: { gap: 14 },
+  formGrid: { flexDirection: 'row', gap: 10, flexWrap: 'wrap' },
+  fieldLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+    marginTop: 8,
+  },
+  input: {
+    backgroundColor: '#f5efe3',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.1)',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.black,
+    marginTop: 4,
+  } as object,
+  targetRow: { flexDirection: 'row', gap: 8, marginTop: 6 },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: '#efe6d6',
+    cursor: 'pointer',
+  } as object,
+  chipOn: { backgroundColor: COLORS.navy } as object,
+  chipText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: COLORS.navy,
+    textTransform: 'capitalize',
+  },
+  chipTextOn: { color: COLORS.beige } as object,
+  err: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.red, marginTop: 10 },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 14 },
+  btn: {
+    paddingHorizontal: 16,
+    paddingVertical: 9,
+    borderRadius: 8,
+    backgroundColor: '#efe6d6',
+    cursor: 'pointer',
+  } as object,
+  btnText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
+  btnPrimary: { backgroundColor: COLORS.orange } as object,
+  btnPrimaryText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: '#fff' },
+  muted: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey, paddingVertical: 8 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 6 },
+  statusDot: { width: 9, height: 9, borderRadius: 5 },
+  rowTitle: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.black },
+  rowMeta: { fontFamily: 'Nunito_700Bold', fontSize: 11, color: COLORS.grey },
+  rowSub: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: COLORS.grey, marginTop: 1 },
+  smallBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 7,
+    backgroundColor: '#efe6d6',
+    cursor: 'pointer',
+  } as object,
+  smallBtnDanger: { backgroundColor: COLORS.red + '14' } as object,
+  smallBtnText: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.navy },
+});

--- a/src/components/admin/health/format.ts
+++ b/src/components/admin/health/format.ts
@@ -140,7 +140,14 @@ export const WORKLIST_LABEL: Record<CoverageMetric, string> = {
 };
 
 // ── Domains (command-center rail) ─────────────────────────────────────────────
-export type DomainKey = 'command' | 'catalog' | 'pipelines' | 'spend' | 'users' | 'traffic';
+export type DomainKey =
+  | 'command'
+  | 'catalog'
+  | 'pipelines'
+  | 'campaigns'
+  | 'spend'
+  | 'users'
+  | 'traffic';
 
 export interface DomainDef {
   key: DomainKey;
@@ -156,6 +163,7 @@ export const DOMAINS: DomainDef[] = [
   { key: 'command', label: 'Overview', icon: 'grid' },
   { key: 'catalog', label: 'Catalog', icon: 'albums', badge: 'pending' },
   { key: 'pipelines', label: 'Build', icon: 'construct-outline' },
+  { key: 'campaigns', label: 'Campaigns', icon: 'megaphone-outline' },
   { key: 'spend', label: 'Spend', icon: 'cash-outline' },
   { key: 'users', label: 'Users', icon: 'people-outline', placeholder: true },
   { key: 'traffic', label: 'Traffic', icon: 'trending-up-outline', placeholder: true },

--- a/src/lib/db/campaigns.ts
+++ b/src/lib/db/campaigns.ts
@@ -1,0 +1,65 @@
+import { supabase } from '../supabase';
+import type { Tables } from '../../types/database.generated';
+
+// Editorial campaigns — admin CRUD for the command center. Reads hit the
+// public-read table directly; writes go through the is_admin-gated RPCs.
+export type Campaign = Tables<'featured_campaigns'>;
+
+export interface CampaignInput {
+  id?: string | null;
+  label: string;
+  headline: string;
+  ends_at: string; // ISO timestamp
+  starts_at?: string | null;
+  blurb?: string | null;
+  accent?: string | null;
+  franchise?: string | null;
+  title_id?: string | null;
+  hero_ids?: string[] | null;
+  priority?: number;
+}
+
+/** All campaigns (active, scheduled, and expired), priority-first. */
+export async function listCampaigns(): Promise<Campaign[]> {
+  const { data, error } = await supabase
+    .from('featured_campaigns')
+    .select('*')
+    .order('priority', { ascending: false })
+    .order('starts_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Campaign[];
+}
+
+/** Insert (no id) or update (with id) a campaign; returns the row id. */
+export async function upsertCampaign(input: CampaignInput): Promise<string> {
+  const { data, error } = await supabase.rpc('admin_upsert_campaign', {
+    p_label: input.label,
+    p_headline: input.headline,
+    p_ends_at: input.ends_at,
+    p_id: input.id ?? undefined,
+    p_blurb: input.blurb ?? undefined,
+    p_accent: input.accent ?? undefined,
+    p_franchise: input.franchise ?? undefined,
+    p_title_id: input.title_id ?? undefined,
+    p_hero_ids: input.hero_ids ?? undefined,
+    p_priority: input.priority ?? 0,
+    p_starts_at: input.starts_at ?? undefined,
+  });
+  if (error) throw new Error(error.message);
+  return data as string;
+}
+
+export async function deleteCampaign(id: string): Promise<void> {
+  const { error } = await supabase.rpc('admin_delete_campaign', { p_id: id });
+  if (error) throw new Error(error.message);
+}
+
+export type CampaignStatus = 'live' | 'scheduled' | 'ended';
+
+/** Where a campaign sits relative to now — drives the list badge. */
+export function campaignStatus(c: Pick<Campaign, 'starts_at' | 'ends_at'>): CampaignStatus {
+  const now = Date.now();
+  if (new Date(c.ends_at).getTime() < now) return 'ended';
+  if (new Date(c.starts_at).getTime() > now) return 'scheduled';
+  return 'live';
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -954,6 +954,7 @@ export type Database = {
     Functions: {
       admin_add_comicvine_heroes: { Args: { p_heroes: Json }; Returns: number }
       admin_cron_status: { Args: never; Returns: Json }
+      admin_delete_campaign: { Args: { p_id: string }; Returns: number }
       admin_delete_hero: { Args: { p_hero_id: string }; Returns: number }
       admin_reenrich_hero: { Args: { p_id: string }; Returns: string }
       admin_reschedule_cron: {

--- a/supabase/migrations/20260615200000_admin_delete_campaign.sql
+++ b/supabase/migrations/20260615200000_admin_delete_campaign.sql
@@ -1,0 +1,21 @@
+-- Admin: delete a featured campaign by id. is_admin gated; mirrors
+-- admin_delete_hero. Returns rows deleted (0 or 1). Powers the Delete action in
+-- the command center's Campaigns domain.
+create or replace function public.admin_delete_campaign(p_id uuid)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare v_deleted integer;
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  with del as (
+    delete from public.featured_campaigns where id = p_id returning 1
+  )
+  select count(*) into v_deleted from del;
+  return v_deleted;
+end $$;
+grant execute on function public.admin_delete_campaign(uuid) to authenticated, service_role;


### PR DESCRIPTION
## What this does

The two follow-ups: a campaign admin screen, and TMDB trending wired to real popularity.

### 1. Campaign admin screen (command center)
A new **Campaigns** domain in the web command center:
- **List** every campaign with a live / scheduled / ended status dot, priority, target, and end date.
- **Create / edit** form: label, headline, blurb, accent, priority, start/end dates, and a target toggle — **franchise**, **title id**, or **explicit hero ids**.
- **Delete**.
- All writes go through the `is_admin`-gated RPCs (`admin_upsert_campaign` from Phase 3, plus new **`admin_delete_campaign`** — migration `20260615200000`). Client layer in `src/lib/db/campaigns.ts`; registered in the domain rail.

### 2. TMDB trending wired live (ops, applied to the project)
- **Deployed `enrich-tmdb-batch` v5** — the popularity-capturing mappers from Phase 2 — and re-flagged the current title window so the already-active drain **backfilled TMDB `popularity`** on all 13 current titles.
- `get_trending_titles` now ranks by **real attention**: *Masters of the Universe* (popularity **237**, in theaters) leads, then *Superman*, *Fantastic Four*, *Thunderbolts*.
- **Enabled the weekly `refresh-tmdb-trending` cron** so popularity stays fresh.

(The edge-function source itself shipped in Phase 2 / PR #8; this just deployed it and turned the cron on — no code change to the function here.)

## Testing
- `yarn test:ci` — **318 passed** (updated the `DOMAINS` rail-order test for the new domain).
- `yarn typecheck` — changed files clean.
- Verified live: popularity populated 13/13 current titles; trending re-ranked by popularity; campaign list/RPCs working.

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_