### PR TITLE
Phase 5: the "Right Now" Explore redesign

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import {
   View,
+  Text,
   StyleSheet,
   StatusBar,
   type ListRenderItem,
@@ -55,7 +56,7 @@ import {
   type Campaign,
   type TrendingTitleCharacter,
 } from '../../src/lib/db/trending';
-import { TrendingShelf } from '../../src/components/home/TrendingShelf';
+import { RightNowBand } from '../../src/components/home/RightNowBand';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -74,13 +75,14 @@ type FeedRow =
   | { type: 'publishers' }
   | { type: 'favourites'; heroes: RowHero[] }
   | {
-      type: 'trending';
-      key: string;
-      label: string;
-      title: string;
-      accent: string;
-      titles: TrendingTitle[];
+      type: 'rightnow';
+      campaign: Campaign | null;
+      onScreen: TrendingTitle[];
+      comingSoon: TrendingTitle[];
+      streaming: TrendingTitle[];
+      personalized: TrendingTitleCharacter[];
     }
+  | { type: 'browsehead' }
   | {
       type: 'curated';
       key: string;
@@ -352,63 +354,33 @@ export default function HomeScreen() {
   const rows = useMemo<FeedRow[]>(() => {
     const out: FeedRow[] = [];
     if (spotlightPool.length > 0) out.push({ type: 'spotlight', heroes: spotlightPool });
-    // Editorial campaign (premiere / event / launch) — the top scheduled moment,
-    // right under the billboard.
-    const campaign = campaigns[0];
-    if (campaign && campaign.characters.length > 0) {
+    // The "Right Now" band — campaign + trending + personalized, all in one
+    // continuous editorial zone directly under the billboard.
+    if (
+      campaigns[0] ||
+      onScreen.length > 0 ||
+      comingSoon.length > 0 ||
+      streaming.length > 0 ||
+      trendingForUser.length > 0
+    ) {
       out.push({
-        type: 'curated',
-        key: 'campaign',
-        label: campaign.label,
-        title: campaign.headline,
-        heroes: campaign.characters as unknown as Hero[],
-      });
-    }
-    // "What's current" zone — directly under the billboard so Explore leads with
-    // the real-world slate. Grouped by title (poster + cast), not flat cards.
-    const trendingShelves = [
-      {
-        key: 'onscreen',
-        label: 'In Theaters & Recent',
-        title: 'On the Big Screen',
-        accent: COLORS.orange,
-        titles: onScreen,
-      },
-      {
-        key: 'comingsoon',
-        label: 'Releasing Soon',
-        title: 'Coming Soon',
-        accent: COLORS.gold,
-        titles: comingSoon,
-      },
-      {
-        key: 'streaming',
-        label: 'Now Streaming',
-        title: 'Streaming Now',
-        accent: COLORS.blue,
-        titles: streaming,
-      },
-    ];
-    for (const sh of trendingShelves) {
-      if (sh.titles.length > 0) out.push({ type: 'trending', ...sh });
-    }
-    // Personalized: current characters sharing a publisher/franchise with the
-    // user's favourites + history. Hidden when signed-out or affinity-less.
-    if (trendingForUser.length > 0) {
-      out.push({
-        type: 'curated',
-        key: 'youruniverse',
-        label: 'For You',
-        title: 'Trending in Your Universe',
-        heroes: trendingForUser as unknown as Hero[],
+        type: 'rightnow',
+        campaign: campaigns[0] ?? null,
+        onScreen,
+        comingSoon,
+        streaming,
+        personalized: trendingForUser,
       });
     }
     if (recentlyViewed.length > 0)
       out.push({ type: 'recent', heroes: recentlyViewed.map(toRowHero) });
     out.push({ type: 'publishers' });
     if (favourites.length > 0) out.push({ type: 'favourites', heroes: favourites.map(toRowHero) });
-    for (const r of curatedCatalog) {
-      if (r.heroes.length === 0) continue;
+    // "Browse the Universe" — the evergreen library, as its own chapter beneath
+    // the dynamic zone.
+    const curatedRows = curatedCatalog.filter((r) => r.heroes.length > 0);
+    if (curatedRows.length > 0) out.push({ type: 'browsehead' });
+    for (const r of curatedRows) {
       out.push({ type: 'curated', ...r });
     }
     return out;
@@ -440,12 +412,7 @@ export default function HomeScreen() {
   ]);
 
   const keyExtractor = useCallback(
-    (row: FeedRow) =>
-      row.type === 'curated'
-        ? `curated-${row.key}`
-        : row.type === 'trending'
-          ? `trending-${row.key}`
-          : row.type,
+    (row: FeedRow) => (row.type === 'curated' ? `curated-${row.key}` : row.type),
     [],
   );
 
@@ -472,17 +439,25 @@ export default function HomeScreen() {
               disabled={navigating}
             />
           );
-        case 'trending':
+        case 'rightnow':
           return (
-            <TrendingShelf
-              label={item.label}
-              title={item.title}
-              accent={item.accent}
-              titles={item.titles}
+            <RightNowBand
+              campaign={item.campaign}
+              onScreen={item.onScreen}
+              comingSoon={item.comingSoon}
+              streaming={item.streaming}
+              personalized={item.personalized}
               onHeroPress={handlePress}
               onTitlePress={handleTitlePress}
               disabled={navigating}
             />
+          );
+        case 'browsehead':
+          return (
+            <View style={styles.browseHead}>
+              <Text style={styles.browseKicker}>The Library</Text>
+              <Text style={styles.browseTitle}>Browse the Universe</Text>
+            </View>
           );
         case 'publishers':
           return <PublisherGrid onPress={handlePublisherPress} />;
@@ -568,4 +543,15 @@ const styles = StyleSheet.create({
   // Beige content sheet. The spotlight (first row) is opaque navy and covers the
   // beige behind it; the rows below sit on this beige, as the old sheet did.
   content: { flexGrow: 1, backgroundColor: COLORS.beige, paddingBottom: 120 },
+  // "Browse the Universe" chapter break between the dynamic zone and the library.
+  browseHead: { paddingHorizontal: 16, paddingTop: 22, paddingBottom: 4 },
+  browseKicker: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 2.5,
+    textTransform: 'uppercase',
+    color: COLORS.orange,
+    marginBottom: 3,
+  },
+  browseTitle: { fontFamily: 'Flame-Bold', fontSize: 30, color: COLORS.navy, lineHeight: 32 },
 });

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -31,7 +31,7 @@ import {
   type Campaign,
   type TrendingTitleCharacter,
 } from '../../src/lib/db/trending';
-import { TrendingShelf } from '../../src/components/web/home/TrendingShelf';
+import { RightNowBand } from '../../src/components/web/home/RightNowBand';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -1389,6 +1389,18 @@ export default function WebHomeScreen() {
             newlyAddedCount={homeData.newlyAdded?.length ?? 0}
           />
 
+          {/* ── Right Now — the dynamic editorial zone (campaign + trending +
+               personalized), its own dark chapter under the ticker. ───────── */}
+          <RightNowBand
+            campaign={homeData.campaigns?.[0] ?? null}
+            onScreen={homeData.onScreen ?? []}
+            comingSoon={homeData.comingSoon ?? []}
+            streaming={homeData.streaming ?? []}
+            personalized={homeData.trendingForUser ?? []}
+            onHeroPress={handlePress}
+            onTitlePress={handleTitlePress}
+          />
+
           {/* Beige canvas — owns the carousel surface so the dark scroll
               background only shows on the dark stage and on overscroll. */}
           <View style={styles.beigeCanvas}>
@@ -1400,51 +1412,11 @@ export default function WebHomeScreen() {
               onPress={handlePress}
             />
 
-            {/* ── Editorial campaign — the top scheduled moment ─────────────── */}
-            {(homeData.campaigns?.[0]?.characters.length ?? 0) > 0 && (
-              <HomeRow
-                label={homeData.campaigns![0].label}
-                title={homeData.campaigns![0].headline}
-                heroes={homeData.campaigns![0].characters as unknown as Hero[]}
-                onPress={handlePress}
-              />
-            )}
-
-            {/* ── What's current — grouped by title (poster + cast) ─────────── */}
-            <TrendingShelf
-              label="In Theaters & Recent"
-              title="On the Big Screen"
-              accent={COLORS.orange}
-              titles={homeData.onScreen ?? []}
-              onHeroPress={handlePress}
-              onTitlePress={handleTitlePress}
-            />
-            <TrendingShelf
-              label="Releasing Soon"
-              title="Coming Soon"
-              accent={COLORS.gold}
-              titles={homeData.comingSoon ?? []}
-              onHeroPress={handlePress}
-              onTitlePress={handleTitlePress}
-            />
-            <TrendingShelf
-              label="Now Streaming"
-              title="Streaming Now"
-              accent={COLORS.blue}
-              titles={homeData.streaming ?? []}
-              onHeroPress={handlePress}
-              onTitlePress={handleTitlePress}
-            />
-
-            {/* ── Personalized — current characters in the user's universe ──── */}
-            {(homeData.trendingForUser?.length ?? 0) > 0 && (
-              <HomeRow
-                label="For You"
-                title="Trending in Your Universe"
-                heroes={(homeData.trendingForUser ?? []) as unknown as Hero[]}
-                onPress={handlePress}
-              />
-            )}
+            {/* ── Browse the Universe — the evergreen library, its own chapter ─ */}
+            <View style={styles.browseHead}>
+              <Text style={styles.browseKicker as object}>The Library</Text>
+              <Text style={styles.browseTitle as object}>Browse the Universe</Text>
+            </View>
 
             {/* ── The Universe — the marquee browse ─────────────────────────── */}
             <HomeRow
@@ -1602,6 +1574,23 @@ const styles = StyleSheet.create({
     paddingTop: 40,
     paddingBottom: 24,
   },
+
+  // "Browse the Universe" chapter break between the dynamic zone and the library.
+  browseHead: { paddingHorizontal: 32, paddingTop: 8, paddingBottom: 18 } as object,
+  browseKicker: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    letterSpacing: 2.5,
+    textTransform: 'uppercase',
+    color: COLORS.orange,
+    marginBottom: 4,
+  } as object,
+  browseTitle: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 40,
+    color: COLORS.navy,
+    lineHeight: 42,
+  } as object,
 
   // The one deliberate dark moment in the canvas — the "Dark Side" zone holds
   // the villain/grey-morality rows in a single continuous navy band.

--- a/src/components/home/RightNowBand.tsx
+++ b/src/components/home/RightNowBand.tsx
@@ -1,0 +1,365 @@
+// src/components/home/RightNowBand.tsx — the "what's happening now" editorial
+// zone. One continuous dark band that gives the dynamic/personal content its own
+// chapter: a live pulse + freshness cue, a cinematic campaign hero, the trending
+// title shelves (badged), and a personalized "In Your Universe" strip.
+import { useEffect } from 'react';
+import { View, Text, StyleSheet, Pressable, FlatList, Dimensions } from 'react-native';
+import { Image } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  withSequence,
+} from 'react-native-reanimated';
+import { HeroImage } from '../HeroImage';
+import { COLORS } from '../../constants/colors';
+import { TrendingShelf } from './TrendingShelf';
+import type { Campaign, TrendingTitle, TrendingTitleCharacter } from '../../lib/db/trending';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+type HeroPress = (item: {
+  id: string;
+  portrait_url?: string | null;
+  image_url?: string | null;
+}) => void;
+
+export interface RightNowBandProps {
+  campaign?: Campaign | null;
+  onScreen: TrendingTitle[];
+  comingSoon: TrendingTitle[];
+  streaming: TrendingTitle[];
+  personalized: TrendingTitleCharacter[];
+  onHeroPress: HeroPress;
+  onTitlePress: (titleId: string) => void;
+  disabled?: boolean;
+}
+
+function PulseDot() {
+  const v = useSharedValue(1);
+  useEffect(() => {
+    v.value = withRepeat(
+      withSequence(withTiming(0.3, { duration: 800 }), withTiming(1, { duration: 800 })),
+      -1,
+      false,
+    );
+  }, [v]);
+  const style = useAnimatedStyle(() => ({ opacity: v.value }));
+  return <Animated.View style={[bandStyles.pulse, style]} />;
+}
+
+function CampaignHero({
+  campaign,
+  onHeroPress,
+  disabled,
+}: {
+  campaign: Campaign;
+  onHeroPress: HeroPress;
+  disabled?: boolean;
+}) {
+  const accent = campaign.accent ?? COLORS.orange;
+  const top = campaign.characters[0];
+  const bgUri = top?.image_url ?? top?.portrait_url ?? undefined;
+  return (
+    <Pressable
+      style={hero.wrap}
+      onPress={() => top && onHeroPress(top)}
+      disabled={disabled || !top}
+    >
+      {bgUri ? (
+        <Image
+          source={{ uri: bgUri }}
+          contentFit="cover"
+          contentPosition="top"
+          style={StyleSheet.absoluteFill}
+        />
+      ) : (
+        <View style={[StyleSheet.absoluteFill, { backgroundColor: COLORS.navy }]} />
+      )}
+      <LinearGradient
+        colors={['rgba(11,24,32,0.35)', 'rgba(11,24,32,0.96)']}
+        locations={[0, 0.78]}
+        style={StyleSheet.absoluteFill}
+      />
+      <View style={hero.content}>
+        <Text style={[hero.eyebrow, { color: accent }]}>{campaign.label}</Text>
+        <Text style={hero.headline} numberOfLines={2}>
+          {campaign.headline}
+        </Text>
+        {!!campaign.blurb && (
+          <Text style={hero.blurb} numberOfLines={2}>
+            {campaign.blurb}
+          </Text>
+        )}
+        <View style={hero.bottom}>
+          <View style={hero.avatars}>
+            {campaign.characters.slice(0, 5).map((c, i) => (
+              <View key={c.id} style={[hero.avatar, { marginLeft: i === 0 ? 0 : -10 }]}>
+                <HeroImage
+                  id={c.id}
+                  name={c.name}
+                  imageUrl={c.image_url}
+                  portraitUrl={c.portrait_url}
+                  grid
+                  contentFit="cover"
+                  contentPosition="top"
+                  style={StyleSheet.absoluteFill as object}
+                  recyclingKey={c.id}
+                />
+              </View>
+            ))}
+          </View>
+          <View style={[hero.cta, { backgroundColor: accent }]}>
+            <Text style={hero.ctaText}>Explore ›</Text>
+          </View>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+function PersonalStrip({
+  characters,
+  onHeroPress,
+  disabled,
+}: {
+  characters: TrendingTitleCharacter[];
+  onHeroPress: HeroPress;
+  disabled?: boolean;
+}) {
+  return (
+    <View style={ps.wrap}>
+      <View style={bandStyles.shelfHeader}>
+        <View style={[bandStyles.accentBar, { backgroundColor: COLORS.skin }]} />
+        <View>
+          <Text style={[bandStyles.shelfLabel, { color: COLORS.skin }]}>For You</Text>
+          <Text style={bandStyles.shelfTitle}>In Your Universe</Text>
+        </View>
+      </View>
+      <FlatList
+        horizontal
+        data={characters}
+        keyExtractor={(c) => c.id}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={ps.strip}
+        removeClippedSubviews
+        initialNumToRender={5}
+        renderItem={({ item }) => (
+          <Pressable style={ps.card} onPress={() => onHeroPress(item)} disabled={disabled}>
+            <HeroImage
+              id={item.id}
+              name={item.name}
+              imageUrl={item.image_url}
+              portraitUrl={item.portrait_url}
+              grid
+              contentFit="cover"
+              contentPosition="top"
+              style={StyleSheet.absoluteFill as object}
+              recyclingKey={item.id}
+            />
+            <LinearGradient
+              colors={['transparent', 'rgba(29,45,51,0.9)']}
+              locations={[0.45, 1]}
+              style={StyleSheet.absoluteFill}
+            />
+            <Text style={ps.name} numberOfLines={1}>
+              {item.name}
+            </Text>
+          </Pressable>
+        )}
+      />
+    </View>
+  );
+}
+
+export function RightNowBand({
+  campaign,
+  onScreen,
+  comingSoon,
+  streaming,
+  personalized,
+  onHeroPress,
+  onTitlePress,
+  disabled = false,
+}: RightNowBandProps) {
+  const hasAny =
+    !!campaign ||
+    onScreen.length > 0 ||
+    comingSoon.length > 0 ||
+    streaming.length > 0 ||
+    personalized.length > 0;
+  if (!hasAny) return null;
+
+  return (
+    <View style={bandStyles.band}>
+      <View style={bandStyles.header}>
+        <PulseDot />
+        <Text style={bandStyles.kicker}>Right Now</Text>
+        <View style={{ flex: 1 }} />
+        <Text style={bandStyles.fresh}>Updated today</Text>
+      </View>
+
+      {campaign && campaign.characters.length > 0 && (
+        <CampaignHero campaign={campaign} onHeroPress={onHeroPress} disabled={disabled} />
+      )}
+
+      <TrendingShelf
+        label="In Theaters & Recent"
+        title="On the Big Screen"
+        accent={COLORS.orange}
+        tone="dark"
+        titles={onScreen}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+        disabled={disabled}
+      />
+      <TrendingShelf
+        label="Releasing Soon"
+        title="Coming Soon"
+        accent={COLORS.gold}
+        tone="dark"
+        titles={comingSoon}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+        disabled={disabled}
+      />
+      <TrendingShelf
+        label="Now Streaming"
+        title="Streaming Now"
+        accent={COLORS.blue}
+        tone="dark"
+        titles={streaming}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+        disabled={disabled}
+      />
+
+      {personalized.length > 0 && (
+        <PersonalStrip characters={personalized} onHeroPress={onHeroPress} disabled={disabled} />
+      )}
+    </View>
+  );
+}
+
+const bandStyles = StyleSheet.create({
+  band: {
+    backgroundColor: COLORS.deepNavy,
+    paddingTop: 20,
+    paddingBottom: 18,
+    marginBottom: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 14,
+  },
+  pulse: { width: 8, height: 8, borderRadius: 4, backgroundColor: COLORS.orange },
+  kicker: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    letterSpacing: 2.5,
+    textTransform: 'uppercase',
+    color: COLORS.beige,
+  },
+  fresh: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: 'rgba(245,235,220,0.45)',
+  },
+  shelfHeader: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+    paddingHorizontal: 15,
+    marginBottom: 12,
+  },
+  accentBar: { width: 4, borderRadius: 2 },
+  shelfLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  shelfTitle: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.beige, lineHeight: 28 },
+});
+
+const hero = StyleSheet.create({
+  wrap: {
+    height: Math.round(SCREEN_WIDTH * 0.62),
+    marginHorizontal: 15,
+    marginBottom: 18,
+    borderRadius: 18,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+  },
+  content: { flex: 1, justifyContent: 'flex-end', padding: 16 },
+  eyebrow: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginBottom: 6,
+  },
+  headline: { fontFamily: 'Flame-Regular', fontSize: 28, color: COLORS.beige, lineHeight: 30 },
+  blurb: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    lineHeight: 18,
+    color: 'rgba(245,235,220,0.72)',
+    marginTop: 6,
+  },
+  bottom: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 14,
+  },
+  avatars: { flexDirection: 'row' },
+  avatar: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: COLORS.deepNavy,
+    backgroundColor: COLORS.navy,
+  },
+  cta: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 20 },
+  ctaText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: '#fff',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+});
+
+const POSTER_H = Math.round(Math.round(SCREEN_WIDTH * 0.28) * 1.5);
+const ps = StyleSheet.create({
+  wrap: { marginTop: 4 },
+  strip: { gap: 8, paddingHorizontal: 15, paddingBottom: 4 },
+  card: {
+    width: Math.round(POSTER_H * 0.62),
+    height: POSTER_H,
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    justifyContent: 'flex-end',
+  },
+  name: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    color: COLORS.beige,
+    lineHeight: 12,
+    paddingHorizontal: 6,
+    paddingBottom: 6,
+  },
+});

--- a/src/components/home/TrendingShelf.tsx
+++ b/src/components/home/TrendingShelf.tsx
@@ -7,7 +7,7 @@ import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { HeroImage } from '../HeroImage';
 import { COLORS } from '../../constants/colors';
-import { trendingTitleMeta, type TrendingTitle } from '../../lib/db/trending';
+import { trendingBadge, type BadgeTone, type TrendingTitle } from '../../lib/db/trending';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const POSTER_W = Math.round(SCREEN_WIDTH * 0.28);
@@ -15,10 +15,18 @@ const POSTER_H = Math.round(POSTER_W * 1.5); // 2:3 poster
 const CHAR_W = Math.round(POSTER_H * 0.62);
 const CHAR_H = POSTER_H;
 
+export const BADGE_COLOR: Record<BadgeTone, string> = {
+  theaters: COLORS.orange,
+  streaming: COLORS.blue,
+  coming: COLORS.gold,
+};
+
 export interface TrendingShelfProps {
   label: string;
   title: string;
   accent?: string;
+  /** 'dark' renders the header text light, for use inside the Right Now band. */
+  tone?: 'light' | 'dark';
   titles: TrendingTitle[];
   onHeroPress: (item: {
     id: string;
@@ -74,7 +82,7 @@ function TitleBlock({
   onTitlePress: TrendingShelfProps['onTitlePress'];
   disabled?: boolean;
 }) {
-  const meta = trendingTitleMeta(t);
+  const badge = trendingBadge(t);
   const posterUri = t.poster_url ?? t.backdrop_url ?? undefined;
   return (
     <View style={s.block}>
@@ -89,15 +97,17 @@ function TitleBlock({
           locations={[0.4, 1]}
           style={StyleSheet.absoluteFill}
         />
+        {badge && (
+          <View style={[s.badge, { backgroundColor: BADGE_COLOR[badge.tone] }]}>
+            <Text style={s.badgeText} numberOfLines={1}>
+              {badge.label}
+            </Text>
+          </View>
+        )}
         <View style={s.posterText}>
           <Text style={s.posterTitle} numberOfLines={2}>
             {t.title}
           </Text>
-          {!!meta && (
-            <Text style={s.posterMeta} numberOfLines={1}>
-              {meta}
-            </Text>
-          )}
         </View>
       </Pressable>
 
@@ -123,6 +133,7 @@ export function TrendingShelf({
   label,
   title,
   accent = COLORS.orange,
+  tone = 'light',
   titles,
   onHeroPress,
   onTitlePress,
@@ -135,7 +146,7 @@ export function TrendingShelf({
         <View style={[s.accentBar, { backgroundColor: accent }]} />
         <View style={s.headerText}>
           <Text style={[s.label, { color: accent }]}>{label}</Text>
-          <Text style={s.title}>{title}</Text>
+          <Text style={[s.title, tone === 'dark' && s.titleDark]}>{title}</Text>
         </View>
       </View>
       {titles.map((t) => (
@@ -170,6 +181,24 @@ const s = StyleSheet.create({
     textTransform: 'uppercase',
   },
   title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+  titleDark: { color: COLORS.beige },
+
+  badge: {
+    position: 'absolute',
+    top: 7,
+    left: 7,
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 6,
+    maxWidth: POSTER_W - 14,
+  },
+  badgeText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 8,
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+    color: '#fff',
+  },
 
   block: { flexDirection: 'row', paddingLeft: 15, marginBottom: 16, gap: 10 },
   poster: {

--- a/src/components/web/home/RightNowBand.tsx
+++ b/src/components/web/home/RightNowBand.tsx
@@ -1,0 +1,479 @@
+// src/components/web/home/RightNowBand.tsx — the "what's happening now" editorial
+// zone for web. Desktop: a campaign hero beside a ranked "What's Hot" sidebar,
+// then the badged trending shelves. Mobile-web: a clean vertical stack.
+import React from 'react';
+import { View, Text, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
+import { Image } from 'expo-image';
+import { HeroImage } from '../../HeroImage';
+import { COLORS } from '../../../constants/colors';
+import { TrendingShelf } from './TrendingShelf';
+import {
+  trendingBadge,
+  type BadgeTone,
+  type Campaign,
+  type TrendingTitle,
+  type TrendingTitleCharacter,
+} from '../../../lib/db/trending';
+
+const BADGE_COLOR: Record<BadgeTone, string> = {
+  theaters: COLORS.orange,
+  streaming: COLORS.blue,
+  coming: COLORS.gold,
+};
+
+interface RightNowBandProps {
+  campaign?: Campaign | null;
+  onScreen: TrendingTitle[];
+  comingSoon: TrendingTitle[];
+  streaming: TrendingTitle[];
+  personalized: TrendingTitleCharacter[];
+  onHeroPress: (id: string) => void;
+  onTitlePress: (id: string) => void;
+}
+
+function CampaignHero({
+  campaign,
+  onHeroPress,
+  tall,
+}: {
+  campaign: Campaign;
+  onHeroPress: (id: string) => void;
+  tall: boolean;
+}) {
+  const accent = campaign.accent ?? COLORS.orange;
+  const top = campaign.characters[0];
+  const bgUri = top?.image_url ?? top?.portrait_url ?? undefined;
+  return (
+    <Pressable
+      onPress={() => top && onHeroPress(top.id)}
+      style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+        [ch.wrap, { minHeight: tall ? 320 : 220 }, hovered && (ch.wrapHover as object)] as object
+      }
+    >
+      {bgUri ? (
+        <Image
+          source={{ uri: bgUri }}
+          contentFit="cover"
+          contentPosition="top"
+          style={{ position: 'absolute', inset: 0 } as object}
+        />
+      ) : (
+        <View
+          style={[{ position: 'absolute', inset: 0, backgroundColor: COLORS.navy }] as object}
+        />
+      )}
+      <View style={ch.overlay as object} />
+      <View style={ch.content}>
+        <Text style={[ch.eyebrow, { color: accent }] as object}>{campaign.label}</Text>
+        <Text style={ch.headline as object} numberOfLines={2}>
+          {campaign.headline}
+        </Text>
+        {!!campaign.blurb && (
+          <Text style={ch.blurb as object} numberOfLines={2}>
+            {campaign.blurb}
+          </Text>
+        )}
+        <View style={ch.bottom}>
+          <View style={ch.avatars}>
+            {campaign.characters.slice(0, 6).map((c, i) => (
+              <View key={c.id} style={[ch.avatar, { marginLeft: i === 0 ? 0 : -12 }] as object}>
+                <HeroImage
+                  id={c.id}
+                  name={c.name}
+                  imageUrl={c.image_url}
+                  portraitUrl={c.portrait_url}
+                  grid
+                  contentFit="cover"
+                  contentPosition="top"
+                  style={{ position: 'absolute', inset: 0 } as object}
+                  recyclingKey={c.id}
+                />
+              </View>
+            ))}
+          </View>
+          <View style={[ch.cta, { backgroundColor: accent }] as object}>
+            <Text style={ch.ctaText as object}>Explore ›</Text>
+          </View>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+function WhatsHot({
+  titles,
+  onTitlePress,
+}: {
+  titles: TrendingTitle[];
+  onTitlePress: (id: string) => void;
+}) {
+  if (titles.length === 0) return null;
+  return (
+    <View style={wh.wrap}>
+      <Text style={wh.heading as object}>What’s Hot</Text>
+      {titles.slice(0, 6).map((t, i) => {
+        const badge = trendingBadge(t);
+        const posterUri = t.poster_url ?? t.backdrop_url ?? undefined;
+        return (
+          <Pressable
+            key={t.id}
+            onPress={() => onTitlePress(t.id)}
+            style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+              [wh.row, hovered && (wh.rowHover as object)] as object
+            }
+          >
+            <Text style={wh.rank as object}>{i + 1}</Text>
+            <View style={wh.thumb as object}>
+              {posterUri ? (
+                <Image
+                  source={{ uri: posterUri }}
+                  contentFit="cover"
+                  style={{ position: 'absolute', inset: 0 } as object}
+                />
+              ) : null}
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={wh.title as object} numberOfLines={1}>
+                {t.title}
+              </Text>
+              {badge && (
+                <Text
+                  style={[wh.badge, { color: BADGE_COLOR[badge.tone] }] as object}
+                  numberOfLines={1}
+                >
+                  {badge.label}
+                </Text>
+              )}
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function PersonalRow({
+  characters,
+  onHeroPress,
+}: {
+  characters: TrendingTitleCharacter[];
+  onHeroPress: (id: string) => void;
+}) {
+  const { width } = useWindowDimensions();
+  const pagePad = width < 640 ? 16 : 32;
+  return (
+    <View style={{ marginTop: 8 }}>
+      <View style={[pr.header, { paddingLeft: pagePad }]}>
+        <View style={[pr.accentBar, { backgroundColor: COLORS.skin }]} />
+        <View>
+          <Text style={pr.label as object}>For You</Text>
+          <Text style={pr.title as object}>In Your Universe</Text>
+        </View>
+      </View>
+      <View style={[pr.strip, { paddingLeft: pagePad, paddingRight: pagePad }] as object}>
+        {characters.map((c) => (
+          <Pressable
+            key={c.id}
+            onPress={() => onHeroPress(c.id)}
+            style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+              [pr.card, hovered && (pr.cardHover as object)] as object
+            }
+          >
+            <HeroImage
+              id={c.id}
+              name={c.name}
+              imageUrl={c.image_url}
+              portraitUrl={c.portrait_url}
+              grid
+              contentFit="cover"
+              contentPosition="top"
+              style={{ position: 'absolute', inset: 0 } as object}
+              recyclingKey={c.id}
+            />
+            <View style={pr.cardOverlay as object} />
+            <Text style={pr.cardName as object} numberOfLines={1}>
+              {c.name}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+export function RightNowBand({
+  campaign,
+  onScreen,
+  comingSoon,
+  streaming,
+  personalized,
+  onHeroPress,
+  onTitlePress,
+}: RightNowBandProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 900;
+  const pagePad = width < 640 ? 16 : 32;
+  const hasAny =
+    !!campaign ||
+    onScreen.length > 0 ||
+    comingSoon.length > 0 ||
+    streaming.length > 0 ||
+    personalized.length > 0;
+  if (!hasAny) return null;
+
+  // "What's Hot" ranks the live slate by popularity — on_screen leads, then streaming.
+  const hotTitles = [...onScreen, ...streaming];
+
+  return (
+    <View style={band.band}>
+      <View style={[band.header, { paddingHorizontal: pagePad }]}>
+        <View style={band.pulse as object} />
+        <Text style={band.kicker as object}>Right Now</Text>
+        <View style={{ flex: 1 }} />
+        <Text style={band.fresh as object}>Updated today</Text>
+      </View>
+
+      {isDesktop && campaign && campaign.characters.length > 0 ? (
+        <View style={[band.topRow, { paddingHorizontal: pagePad }]}>
+          <View style={{ flex: 1 }}>
+            <CampaignHero campaign={campaign} onHeroPress={onHeroPress} tall />
+          </View>
+          <WhatsHot titles={hotTitles} onTitlePress={onTitlePress} />
+        </View>
+      ) : (
+        campaign &&
+        campaign.characters.length > 0 && (
+          <View style={{ paddingHorizontal: pagePad }}>
+            <CampaignHero campaign={campaign} onHeroPress={onHeroPress} tall={false} />
+          </View>
+        )
+      )}
+
+      <TrendingShelf
+        label="In Theaters & Recent"
+        title="On the Big Screen"
+        accent={COLORS.orange}
+        tone="dark"
+        titles={onScreen}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+      />
+      <TrendingShelf
+        label="Releasing Soon"
+        title="Coming Soon"
+        accent={COLORS.gold}
+        tone="dark"
+        titles={comingSoon}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+      />
+      <TrendingShelf
+        label="Now Streaming"
+        title="Streaming Now"
+        accent={COLORS.blue}
+        tone="dark"
+        titles={streaming}
+        onHeroPress={onHeroPress}
+        onTitlePress={onTitlePress}
+      />
+
+      {personalized.length > 0 && (
+        <PersonalRow characters={personalized} onHeroPress={onHeroPress} />
+      )}
+    </View>
+  );
+}
+
+const band = StyleSheet.create({
+  band: { backgroundColor: COLORS.deepNavy, paddingTop: 28, paddingBottom: 28 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 9, marginBottom: 18 },
+  pulse: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+    backgroundColor: COLORS.orange,
+    boxShadow: `0 0 0 4px ${COLORS.orange}33`,
+  } as object,
+  kicker: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 13,
+    letterSpacing: 3,
+    textTransform: 'uppercase',
+    color: COLORS.beige,
+  } as object,
+  fresh: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    color: 'rgba(245,235,220,0.45)',
+  } as object,
+  topRow: { flexDirection: 'row', gap: 20, marginBottom: 24, alignItems: 'stretch' },
+});
+
+const ch = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    borderRadius: 18,
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    justifyContent: 'flex-end',
+    cursor: 'pointer',
+    transition: 'transform 200ms ease, box-shadow 200ms ease',
+  } as object,
+  wrapHover: {
+    transform: [{ translateY: -3 }],
+    boxShadow: '0 22px 50px rgba(0,0,0,0.4)',
+  } as object,
+  overlay: {
+    position: 'absolute',
+    inset: 0,
+    backgroundImage:
+      'linear-gradient(to top, rgba(11,24,32,0.96) 0%, rgba(11,24,32,0.45) 55%, rgba(11,24,32,0.2) 100%)',
+  } as object,
+  content: { padding: 24, gap: 2 },
+  eyebrow: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    letterSpacing: 2.5,
+    textTransform: 'uppercase',
+    marginBottom: 6,
+  } as object,
+  headline: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 40,
+    color: COLORS.beige,
+    lineHeight: 42,
+  } as object,
+  blurb: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 15,
+    lineHeight: 21,
+    color: 'rgba(245,235,220,0.75)',
+    marginTop: 8,
+    maxWidth: 520,
+  } as object,
+  bottom: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 18,
+  },
+  avatars: { flexDirection: 'row' },
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: COLORS.deepNavy,
+    backgroundColor: COLORS.navy,
+  } as object,
+  cta: { paddingHorizontal: 20, paddingVertical: 10, borderRadius: 24 } as object,
+  ctaText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: '#fff',
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+  } as object,
+});
+
+const wh = StyleSheet.create({
+  wrap: {
+    width: 320,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    padding: 16,
+    gap: 4,
+  } as object,
+  heading: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 20,
+    color: COLORS.beige,
+    marginBottom: 8,
+  } as object,
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 7,
+    borderRadius: 10,
+    cursor: 'pointer',
+    transition: 'background-color 150ms ease',
+  } as object,
+  rowHover: { backgroundColor: 'rgba(255,255,255,0.05)' } as object,
+  rank: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 26,
+    color: 'rgba(245,235,220,0.35)',
+    width: 26,
+    textAlign: 'center',
+  } as object,
+  thumb: {
+    width: 38,
+    height: 54,
+    borderRadius: 6,
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+  } as object,
+  title: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.beige } as object,
+  badge: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    marginTop: 2,
+  } as object,
+});
+
+const pr = StyleSheet.create({
+  header: { flexDirection: 'row', alignItems: 'stretch', gap: 14, marginTop: 8, marginBottom: 14 },
+  accentBar: { width: 4, borderRadius: 2, minHeight: 36 },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: COLORS.skin,
+  } as object,
+  title: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 26,
+    color: COLORS.beige,
+    lineHeight: 30,
+  } as object,
+  strip: {
+    flexDirection: 'row',
+    gap: 12,
+    overflowX: 'auto',
+    paddingBottom: 8,
+    scrollbarWidth: 'none',
+  } as object,
+  card: {
+    width: 120,
+    height: 170,
+    borderRadius: 10,
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    flexShrink: 0,
+    cursor: 'pointer',
+    justifyContent: 'flex-end',
+    transition: 'transform 200ms ease',
+  } as object,
+  cardHover: { transform: [{ translateY: -4 }] } as object,
+  cardOverlay: {
+    position: 'absolute',
+    inset: 0,
+    backgroundImage: 'linear-gradient(to top, rgba(29,45,51,0.92) 0%, transparent 60%)',
+  } as object,
+  cardName: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    color: COLORS.beige,
+    paddingHorizontal: 8,
+    paddingBottom: 8,
+  } as object,
+});

--- a/src/components/web/home/TrendingShelf.tsx
+++ b/src/components/web/home/TrendingShelf.tsx
@@ -5,12 +5,18 @@ import { View, Text, StyleSheet, Pressable, useWindowDimensions } from 'react-na
 import { Image } from 'expo-image';
 import { HeroImage } from '../../HeroImage';
 import { COLORS } from '../../../constants/colors';
-import { trendingTitleMeta, type TrendingTitle } from '../../../lib/db/trending';
+import { trendingBadge, type BadgeTone, type TrendingTitle } from '../../../lib/db/trending';
 
 const POSTER_W = 150;
 const POSTER_H = 225;
 const CHAR_W = 132;
 const CHAR_H = 190;
+
+const BADGE_COLOR: Record<BadgeTone, string> = {
+  theaters: COLORS.orange,
+  streaming: COLORS.blue,
+  coming: COLORS.gold,
+};
 
 function CharacterCard({
   character,
@@ -54,7 +60,7 @@ function TitleBlock({
   onHeroPress: (id: string) => void;
   onTitlePress: (id: string) => void;
 }) {
-  const meta = trendingTitleMeta(t);
+  const badge = trendingBadge(t);
   const posterUri = t.poster_url ?? t.backdrop_url ?? undefined;
   return (
     <View style={blk.row}>
@@ -74,15 +80,17 @@ function TitleBlock({
           <View style={[blk.posterFallback, { position: 'absolute', inset: 0 }] as object} />
         )}
         <View style={blk.posterOverlay as object} />
+        {badge && (
+          <View style={[blk.badge, { backgroundColor: BADGE_COLOR[badge.tone] }] as object}>
+            <Text style={blk.badgeText as object} numberOfLines={1}>
+              {badge.label}
+            </Text>
+          </View>
+        )}
         <View style={blk.posterText}>
           <Text style={blk.posterTitle as object} numberOfLines={2}>
             {t.title}
           </Text>
-          {!!meta && (
-            <Text style={blk.posterMeta as object} numberOfLines={1}>
-              {meta}
-            </Text>
-          )}
         </View>
       </Pressable>
 
@@ -99,6 +107,7 @@ export function TrendingShelf({
   label,
   title,
   accent = COLORS.orange,
+  tone = 'light',
   titles,
   onHeroPress,
   onTitlePress,
@@ -106,6 +115,7 @@ export function TrendingShelf({
   label: string;
   title: string;
   accent?: string;
+  tone?: 'light' | 'dark';
   titles: TrendingTitle[];
   onHeroPress: (id: string) => void;
   onTitlePress: (id: string) => void;
@@ -119,7 +129,7 @@ export function TrendingShelf({
         <View style={[sec.accentBar, { backgroundColor: accent }]} />
         <View style={sec.headerText}>
           <Text style={[sec.label, { color: accent }] as object}>{label}</Text>
-          <Text style={sec.title as object}>{title}</Text>
+          <Text style={[sec.title, tone === 'dark' && sec.titleDark] as object}>{title}</Text>
         </View>
       </View>
       <View style={{ paddingLeft: pagePad, paddingRight: pagePad }}>
@@ -154,6 +164,7 @@ const sec = StyleSheet.create({
     color: COLORS.navy,
     lineHeight: 34,
   } as object,
+  titleDark: { color: COLORS.beige } as object,
 });
 
 const blk = StyleSheet.create({
@@ -196,6 +207,22 @@ const blk = StyleSheet.create({
     letterSpacing: 0.8,
     textTransform: 'uppercase',
     marginTop: 4,
+  } as object,
+  badge: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    maxWidth: POSTER_W - 20,
+  } as object,
+  badgeText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: '#fff',
   } as object,
   strip: {
     flex: 1,

--- a/src/lib/db/trending.ts
+++ b/src/lib/db/trending.ts
@@ -206,3 +206,33 @@ export function trendingTitleMeta(t: TrendingTitle): string | null {
   }
   return null;
 }
+
+// ── Contextual badges (Phase 5) ──────────────────────────────────────────────
+// The card's "why": in theaters, new on a streamer, or coming soon. Tone keys a
+// colour in the UI so a card reads its status at a glance.
+export type BadgeTone = 'theaters' | 'streaming' | 'coming';
+export interface TrendingBadge {
+  tone: BadgeTone;
+  label: string;
+}
+
+export function trendingBadge(
+  t: Pick<TrendingTitle, 'provider' | 'release_date'>,
+): TrendingBadge | null {
+  if (t.release_date) {
+    const d = new Date(t.release_date);
+    if (!Number.isNaN(d.getTime()) && d.getTime() > Date.now()) {
+      return {
+        tone: 'coming',
+        label: `Coming ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`,
+      };
+    }
+  }
+  if (t.provider) {
+    const short =
+      t.provider.length <= 16 ? t.provider : t.provider.split(' ').slice(0, 2).join(' ');
+    return { tone: 'streaming', label: short };
+  }
+  if (t.release_date) return { tone: 'theaters', label: 'In Theaters' };
+  return null;
+}


### PR DESCRIPTION
## The problem

We'd added spotlight injection, campaigns, three trending shelves, and personalization — but every one rendered as the **same** thing: a header + a horizontal strip of cards. Stack 15 of those and the freshest, smartest, most personal content reads exactly like "Brightest Minds." No hierarchy, no sense of "now," and cards threw away their context (`In Theaters` / provider / release date).

## The fix — a living "Right Now" zone

**`RightNowBand`** (native + web): one continuous **dark editorial chapter** under the billboard that gives the dynamic data its own identity:
- **Live pulse + "Updated today"** freshness cue.
- A **cinematic campaign hero** — backdrop, eyebrow, headline, blurb, overlapping character avatars, and a CTA — instead of a flat card row.
- The **badged trending shelves**.
- A bespoke **"In Your Universe"** personalized strip.

**Contextual badges** on every trending poster — `IN THEATERS` (orange), a streaming provider (blue), or `COMING JUN 23` (gold) — so each card reads its "why" at a glance. (`trendingBadge()` in `src/lib/db/trending.ts`; `TrendingShelf` gains `tone` + badge on both platforms.)

**Desktop-distinct:** the web band lays the campaign hero **beside a ranked "What's Hot" sidebar** (popularity-ordered, 1–6 with poster thumbs), then full-width shelves — a designed page, not stretched rails. Mobile-web and native stack cleanly.

**"Browse the Universe" chapter break** separates the evergreen library from the dynamic zone, so Explore reads as chapters instead of row soup.

## Scope
UI only — **no schema changes**. Reuses the Phase 1–4 data layer end to end.

## Testing
- `yarn test:ci` — **318 passed**.
- `yarn typecheck` — changed files clean.

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_