### PR TITLE
Phase 5.2: image-backed Browse tiles

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -36,7 +36,10 @@ import {
   getSpotlightHeroes,
   getIconicHeroes,
   getTrendingSpotlightHeroes,
+  getBrowseCovers,
   type Hero,
+  type BrowseCover,
+  type CategorySlug,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
 import {
@@ -48,7 +51,7 @@ import {
   type TrendingTitleCharacter,
 } from '../../src/lib/db/trending';
 import { RightNowBand } from '../../src/components/home/RightNowBand';
-import { CategoryPodGrid } from '../../src/components/home/CategoryPodGrid';
+import { CategoryPodGrid, BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -100,6 +103,7 @@ export default function HomeScreen() {
 
   // One marquee rail (Most Iconic); everything else lives in the Browse grid.
   const [iconic, setIconic] = useState<Hero[]>([]);
+  const [browseCovers, setBrowseCovers] = useState<Record<string, BrowseCover>>({});
   const [onScreen, setOnScreen] = useState<TrendingTitle[]>([]);
   const [comingSoon, setComingSoon] = useState<TrendingTitle[]>([]);
   const [streaming, setStreaming] = useState<TrendingTitle[]>([]);
@@ -149,6 +153,9 @@ export default function HomeScreen() {
 
     getIconicHeroes(20)
       .then(setIconic)
+      .catch(() => {});
+    getBrowseCovers(BROWSE_PODS.map((p) => p.slug as CategorySlug))
+      .then(setBrowseCovers)
       .catch(() => {});
     getTrendingTitles('on_screen', 6)
       .then(setOnScreen)
@@ -301,7 +308,7 @@ export default function HomeScreen() {
             </View>
           );
         case 'browsegrid':
-          return <CategoryPodGrid onPress={handleCategoryPress} />;
+          return <CategoryPodGrid covers={browseCovers} onPress={handleCategoryPress} />;
         case 'favourites':
           return (
             <HomeHeroRow
@@ -332,7 +339,16 @@ export default function HomeScreen() {
         }
       }
     },
-    [insets.top, scrollY, handlePress, handleCategoryPress, handleTitlePress, navigating, router],
+    [
+      insets.top,
+      scrollY,
+      handlePress,
+      handleCategoryPress,
+      handleTitlePress,
+      navigating,
+      router,
+      browseCovers,
+    ],
   );
 
   // Translate every rendered cell uniformly to counteract the overscroll bounce,

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -20,7 +20,10 @@ import {
   getFranchiseIcons,
   getHeroesByMediaTag,
   getTrendingSpotlightHeroes,
+  getBrowseCovers,
   type Hero,
+  type BrowseCover,
+  type CategorySlug,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
 import {
@@ -33,6 +36,7 @@ import {
 } from '../../src/lib/db/trending';
 import { RightNowBand } from '../../src/components/web/home/RightNowBand';
 import { CategoryPodGrid } from '../../src/components/web/home/CategoryPodGrid';
+import { BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -1192,6 +1196,7 @@ export default function WebHomeScreen() {
     streaming: TrendingTitle[];
     campaigns: Campaign[];
     trendingForUser: TrendingTitleCharacter[];
+    browseCovers: Record<string, BrowseCover>;
     strongestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     smartestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
     fastestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
@@ -1287,6 +1292,9 @@ export default function WebHomeScreen() {
       .catch(() => {});
     getTrendingTitles('streaming', 6)
       .then(set('streaming'))
+      .catch(() => {});
+    getBrowseCovers(BROWSE_PODS.map((p) => p.slug as CategorySlug))
+      .then(set('browseCovers'))
       .catch(() => {});
     getFirstAppearanceCovers(14)
       .then(set('covers'))
@@ -1428,6 +1436,7 @@ export default function WebHomeScreen() {
               onViewAll={() => router.push('/category/most-iconic')}
             />
             <CategoryPodGrid
+              covers={homeData.browseCovers}
               onPress={(slug) =>
                 router.push(`/category/${slug}` as Parameters<typeof router.push>[0])
               }

--- a/src/components/home/CategoryPodGrid.tsx
+++ b/src/components/home/CategoryPodGrid.tsx
@@ -1,8 +1,17 @@
-// src/components/home/CategoryPodGrid.tsx — the calm "Browse" block. Replaces a
-// dozen look-alike catalog carousels with one scannable grid of tiles, each a
-// doorway into the category page that already exists. One restrained accent.
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+// src/components/home/CategoryPodGrid.tsx — the "Browse" block. Image-backed
+// category tiles in a real two-up grid (each wears a representative character's
+// art), so browse reads as premium as the rest of the page — not a text menu.
+import { View, Text, StyleSheet, Pressable, Dimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { HeroImage } from '../HeroImage';
 import { COLORS } from '../../constants/colors';
+import type { BrowseCover } from '../../lib/db/heroes';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const H_PAD = 16;
+const GAP = 12;
+const TILE_W = Math.floor((SCREEN_WIDTH - H_PAD * 2 - GAP) / 2);
+const TILE_H = Math.round(TILE_W * 0.82);
 
 export interface CategoryPod {
   slug: string;
@@ -24,18 +33,41 @@ export const BROWSE_PODS: CategoryPod[] = [
   { slug: 'most-intelligent', label: 'Smartest' },
 ];
 
-export function CategoryPodGrid({ onPress }: { onPress: (slug: string) => void }) {
+export function CategoryPodGrid({
+  covers,
+  onPress,
+}: {
+  covers?: Record<string, BrowseCover>;
+  onPress: (slug: string) => void;
+}) {
   return (
     <View style={s.grid}>
-      {BROWSE_PODS.map((p) => (
-        <Pressable key={p.slug} style={s.pod} onPress={() => onPress(p.slug)}>
-          <View style={s.accent} />
-          <Text style={s.label} numberOfLines={1}>
-            {p.label}
-          </Text>
-          <Text style={s.chevron}>›</Text>
-        </Pressable>
-      ))}
+      {BROWSE_PODS.map((p) => {
+        const c = covers?.[p.slug];
+        return (
+          <Pressable key={p.slug} style={s.tile} onPress={() => onPress(p.slug)}>
+            <HeroImage
+              id={p.slug}
+              name={c?.name ?? p.label}
+              imageUrl={c?.image_url ?? c?.image_md_url}
+              portraitUrl={c?.portrait_url}
+              grid
+              contentFit="cover"
+              contentPosition="top"
+              style={StyleSheet.absoluteFill as object}
+              recyclingKey={p.slug}
+            />
+            <LinearGradient
+              colors={['transparent', 'rgba(11,24,32,0.55)', 'rgba(11,24,32,0.94)']}
+              locations={[0.25, 0.6, 1]}
+              style={StyleSheet.absoluteFill}
+            />
+            <Text style={s.label} numberOfLines={2}>
+              {p.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
@@ -44,40 +76,28 @@ const s = StyleSheet.create({
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 10,
-    paddingHorizontal: 16,
+    gap: GAP,
+    paddingHorizontal: H_PAD,
     paddingTop: 4,
   },
-  pod: {
-    flexGrow: 1,
-    flexBasis: '46%',
-    minHeight: 58,
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#fffdf8',
-    borderRadius: 14,
+  tile: {
+    width: TILE_W,
+    height: TILE_H,
+    borderRadius: 16,
     borderCurve: 'continuous',
-    borderWidth: 1,
-    borderColor: 'rgba(41,60,67,0.08)',
-    paddingHorizontal: 14,
-    gap: 10,
-  },
-  accent: {
-    width: 4,
-    height: 26,
-    borderRadius: 2,
-    backgroundColor: COLORS.orange,
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    justifyContent: 'flex-end',
   },
   label: {
-    flex: 1,
-    fontFamily: 'Flame-Regular',
-    fontSize: 16,
-    color: COLORS.navy,
-  },
-  chevron: {
-    fontFamily: 'Flame-Regular',
-    fontSize: 22,
-    color: 'rgba(41,60,67,0.35)',
-    marginTop: -2,
+    fontFamily: 'Flame-Bold',
+    fontSize: 19,
+    color: COLORS.beige,
+    lineHeight: 21,
+    paddingHorizontal: 12,
+    paddingBottom: 11,
+    textShadowColor: 'rgba(0,0,0,0.7)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 8,
   },
 });

--- a/src/components/web/home/CategoryPodGrid.tsx
+++ b/src/components/web/home/CategoryPodGrid.tsx
@@ -1,30 +1,57 @@
-// src/components/web/home/CategoryPodGrid.tsx — the calm "Browse" block for web.
-// One responsive grid of category doorways replaces a dozen look-alike carousels.
+// src/components/web/home/CategoryPodGrid.tsx — image-backed "Browse" tiles for
+// web. One responsive grid of category doorways, each wearing a representative
+// character's art, replaces a dozen look-alike carousels.
 import React from 'react';
 import { View, Text, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { HeroImage } from '../../HeroImage';
 import { COLORS } from '../../../constants/colors';
 import { BROWSE_PODS } from '../../home/CategoryPodGrid';
+import type { BrowseCover } from '../../../lib/db/heroes';
 
-export function CategoryPodGrid({ onPress }: { onPress: (slug: string) => void }) {
+export function CategoryPodGrid({
+  covers,
+  onPress,
+}: {
+  covers?: Record<string, BrowseCover>;
+  onPress: (slug: string) => void;
+}) {
   const { width } = useWindowDimensions();
   const pagePad = width < 640 ? 16 : 32;
   return (
     <View style={[g.grid, { marginHorizontal: pagePad }] as object}>
-      {BROWSE_PODS.map((p) => (
-        <Pressable
-          key={p.slug}
-          onPress={() => onPress(p.slug)}
-          style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
-            [g.pod, hovered && (g.podHover as object)] as object
-          }
-        >
-          <View style={g.accent as object} />
-          <Text style={g.label as object} numberOfLines={1}>
-            {p.label}
-          </Text>
-          <Text style={g.chevron as object}>›</Text>
-        </Pressable>
-      ))}
+      {BROWSE_PODS.map((p) => {
+        const c = covers?.[p.slug];
+        return (
+          <Pressable
+            key={p.slug}
+            onPress={() => onPress(p.slug)}
+            style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+              [g.tile, hovered && (g.tileHover as object)] as object
+            }
+          >
+            <HeroImage
+              id={p.slug}
+              name={c?.name ?? p.label}
+              imageUrl={c?.image_url ?? c?.image_md_url}
+              portraitUrl={c?.portrait_url}
+              grid
+              contentFit="cover"
+              contentPosition="top"
+              style={{ position: 'absolute', inset: 0 } as object}
+              recyclingKey={p.slug}
+            />
+            <LinearGradient
+              colors={['transparent', 'rgba(11,24,32,0.5)', 'rgba(11,24,32,0.95)']}
+              locations={[0.25, 0.6, 1]}
+              style={{ position: 'absolute', inset: 0 } as object}
+            />
+            <Text style={g.label as object} numberOfLines={2}>
+              {p.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
@@ -32,27 +59,29 @@ export function CategoryPodGrid({ onPress }: { onPress: (slug: string) => void }
 const g = StyleSheet.create({
   grid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-    gap: 12,
+    gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+    gap: 14,
   } as object,
-  pod: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    minHeight: 64,
-    paddingHorizontal: 18,
-    backgroundColor: '#fffdf8',
-    borderRadius: 14,
-    borderWidth: 1,
-    borderColor: 'rgba(41,60,67,0.08)',
+  tile: {
+    height: 168,
+    borderRadius: 16,
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    justifyContent: 'flex-end',
     cursor: 'pointer',
-    transition: 'transform 160ms ease, box-shadow 160ms ease',
+    transition: 'transform 180ms ease, box-shadow 180ms ease',
   } as object,
-  podHover: {
-    transform: [{ translateY: -2 }],
-    boxShadow: '0 10px 28px rgba(58,42,20,0.1)',
+  tileHover: {
+    transform: [{ translateY: -4 }],
+    boxShadow: '0 20px 46px rgba(0,0,0,0.34)',
   } as object,
-  accent: { width: 4, height: 28, borderRadius: 2, backgroundColor: COLORS.orange } as object,
-  label: { flex: 1, fontFamily: 'Flame-Regular', fontSize: 19, color: COLORS.navy } as object,
-  chevron: { fontFamily: 'Flame-Regular', fontSize: 24, color: 'rgba(41,60,67,0.35)' } as object,
+  label: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 24,
+    color: COLORS.beige,
+    lineHeight: 26,
+    paddingHorizontal: 16,
+    paddingBottom: 14,
+    textShadow: '0 1px 10px rgba(0,0,0,0.7)',
+  } as object,
 });

--- a/src/lib/db/heroes.ts
+++ b/src/lib/db/heroes.ts
@@ -1,7 +1,7 @@
 import { supabase } from '../supabase';
 import type { Tables } from '../../types/database.generated';
 import type { CharacterData, MovieAppearance, StatsSource } from '../../types';
-import type { CategoryFilters, FacetCounts } from './categoryFilters';
+import { DEFAULT_FILTERS, type CategoryFilters, type FacetCounts } from './categoryFilters';
 import { rowToMember, type FamilyRow } from '../family/rowToMember';
 import type { FamilyMember } from '../family/types';
 
@@ -820,6 +820,52 @@ export async function getCategoryPage(
   const { data, error, count } = await q.range(from, to);
   if (error) throw new Error(error.message);
   return { heroes: (data ?? []) as Hero[], total: count ?? 0 };
+}
+
+export interface BrowseCover {
+  name: string;
+  image_url: string | null;
+  image_md_url: string | null;
+  portrait_url: string | null;
+}
+
+/**
+ * One representative (most-popular) hero per browse category, for the image-backed
+ * category tiles on the home screen. Fires a light single-row query per slug in
+ * parallel; missing/empty categories simply don't get a cover (the tile falls
+ * back to a solid colour).
+ */
+export async function getBrowseCovers(slugs: CategorySlug[]): Promise<Record<string, BrowseCover>> {
+  const entries = await Promise.all(
+    slugs.map(async (slug) => {
+      try {
+        const { heroes } = await getCategoryPage(slug, {
+          ...DEFAULT_FILTERS,
+          page: 0,
+          pageSize: 1,
+          withCount: false,
+          sort: 'popular',
+        });
+        const h = heroes[0];
+        return [
+          slug,
+          h
+            ? {
+                name: h.name,
+                image_url: h.image_url,
+                image_md_url: h.image_md_url,
+                portrait_url: h.portrait_url,
+              }
+            : null,
+        ] as const;
+      } catch {
+        return [slug, null] as const;
+      }
+    }),
+  );
+  const out: Record<string, BrowseCover> = {};
+  for (const [slug, cover] of entries) if (cover) out[slug] = cover;
+  return out;
 }
 
 export async function getCategoryFacetCounts(


### PR DESCRIPTION
## What the screenshots showed

The "Browse" grid was rendering as **one tall column of identical text pills** (a `flexBasis: '46%'` that didn't hold two-up on mobile) — still soup, and bland sitting right under that gorgeous Batman/Superman hero art.

## Fix

- **Image-backed category tiles** in a real two-up grid — each category wears a representative character's art (cover + gradient + label), so Browse matches the quality of the Most Iconic cards instead of looking like a settings menu.
- **Actually two columns now** — explicit tile width math instead of the flaky `flexBasis`.
- **`getBrowseCovers()`** supplies the art: one top hero per category (parallel single-row queries); a category with no cover falls back to a clean monogram.

Native + web. UI only — **no schema changes**.

## Testing
- `yarn test:ci` — **318 passed**.
- `yarn typecheck` — changed files clean.

https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhtYvUFdQ649ULZh5vWD47)_