### PR TITLE
Harden Supabase access model: RPC grants, search_path, verdicts cache, storage

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -225,6 +225,10 @@ export async function fetchHeroGallery(
 }
 
 export interface VerdictInput {
+  // Hero ids let the edge function read/write the shared verdict cache. Optional
+  // so callers that only have names still get a (non-cached) verdict.
+  heroAId?: string;
+  heroBId?: string;
   heroA: string;
   heroB: string;
   winsA: number;

--- a/src/lib/db/verdicts.ts
+++ b/src/lib/db/verdicts.ts
@@ -18,13 +18,5 @@ export async function getCachedVerdict(heroAId: string, heroBId: string): Promis
   return data?.verdict ?? null;
 }
 
-export async function saveVerdict(
-  heroAId: string,
-  heroBId: string,
-  verdict: string,
-): Promise<void> {
-  const [a, b] = normalizeKey(heroAId, heroBId);
-  await supabase
-    .from('verdicts')
-    .upsert({ hero_a_id: a, hero_b_id: b, verdict }, { onConflict: 'hero_a_id,hero_b_id' });
-}
+// Writes happen server-side: the generate-verdict edge function persists the
+// cache with the service_role key. The verdicts table is read-only to clients.

--- a/src/lib/matchup.ts
+++ b/src/lib/matchup.ts
@@ -1,5 +1,5 @@
 import { getIconicHeroes, type Hero } from './db/heroes';
-import { getCachedVerdict, saveVerdict } from './db/verdicts';
+import { getCachedVerdict } from './db/verdicts';
 import { compareStats } from './compare';
 import { generateVerdict } from './api';
 
@@ -70,6 +70,8 @@ export async function getTodaysMatchup(): Promise<TodaysMatchup | null> {
   let verdict = await getCachedVerdict(a.id, b.id);
   if (!verdict) {
     verdict = await generateVerdict({
+      heroAId: a.id,
+      heroBId: b.id,
       heroA: a.name,
       heroB: b.name,
       winsA: cmp.winsA,
@@ -77,7 +79,6 @@ export async function getTodaysMatchup(): Promise<TodaysMatchup | null> {
       statsA: statsNumber(a),
       statsB: statsNumber(b),
     });
-    saveVerdict(a.id, b.id, verdict).catch(() => {});
   }
 
   return {

--- a/src/lib/query/heroQueries.ts
+++ b/src/lib/query/heroQueries.ts
@@ -20,7 +20,7 @@ import {
 } from '../db/heroes';
 import { DEFAULT_FILTERS, type CategoryFilters } from '../db/categoryFilters';
 import { generateVerdict, type VerdictInput } from '../api';
-import { getCachedVerdict, saveVerdict } from '../db/verdicts';
+import { getCachedVerdict } from '../db/verdicts';
 import { queryKeys } from './keys';
 import { findCachedHero } from './heroCache';
 
@@ -181,9 +181,9 @@ export function useVerdict(heroId: string, opponentId: string, input: VerdictInp
     queryFn: async () => {
       const cached = await getCachedVerdict(heroId, opponentId);
       if (cached) return cached;
-      const verdict = await generateVerdict(input!);
-      await saveVerdict(heroId, opponentId, verdict);
-      return verdict;
+      // The edge function persists the cache server-side (service_role); pass the
+      // ids so it can key the write to this matchup pair.
+      return generateVerdict({ ...input!, heroAId: heroId, heroBId: opponentId });
     },
     staleTime: Infinity,
     gcTime: Infinity,

--- a/supabase/functions/generate-verdict/index.ts
+++ b/supabase/functions/generate-verdict/index.ts
@@ -1,10 +1,21 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const GEMINI_KEY = Deno.env.get('GOOGLE_AI_STUDIO_API_KEY') ?? '';
 const GEMINI_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent';
 
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
 interface VerdictRequest {
+  // Hero ids are optional for backwards compatibility with older app builds;
+  // when both are present the verdict is read/written from the shared cache.
+  heroAId?: string;
+  heroBId?: string;
   heroA: string;
   heroB: string;
   winsA: number;
@@ -13,20 +24,44 @@ interface VerdictRequest {
   statsB: Record<string, number>;
 }
 
+// Store/look up with the lexicographically smaller id first so A vs B and B vs A
+// share a single row. Mirrors normalizeKey in src/lib/db/verdicts.ts.
+function normalizeKey(a: string, b: string): [string, string] {
+  return a <= b ? [a, b] : [b, a];
+}
+
 serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      },
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json', ...CORS },
     });
-  }
 
   try {
     const body: VerdictRequest = await req.json();
-    const { heroA, heroB, winsA, winsB, statsA, statsB } = body;
+    const { heroAId, heroBId, heroA, heroB, winsA, winsB, statsA, statsB } = body;
+
+    const sb = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    const canCache = Boolean(heroAId) && Boolean(heroBId);
+    let keyA = '';
+    let keyB = '';
+    if (canCache) {
+      [keyA, keyB] = normalizeKey(heroAId as string, heroBId as string);
+      // Read-through: another client may have already generated this pair.
+      const { data: cached } = await sb
+        .from('verdicts')
+        .select('verdict')
+        .eq('hero_a_id', keyA)
+        .eq('hero_b_id', keyB)
+        .maybeSingle();
+      if (cached?.verdict) return json({ verdict: cached.verdict });
+    }
 
     const winner = winsA >= winsB ? heroA : heroB;
     const loser = winsA >= winsB ? heroB : heroA;
@@ -61,14 +96,22 @@ serve(async (req: Request) => {
 
     if (!verdict) throw new Error('Empty Gemini response');
 
+    // Persist to the shared cache (service_role bypasses RLS). Only successful
+    // generations are cached — never the client-side fallback string.
+    if (canCache) {
+      await sb
+        .from('verdicts')
+        .upsert({ hero_a_id: keyA, hero_b_id: keyB, verdict }, { onConflict: 'hero_a_id,hero_b_id' });
+    }
+
     return new Response(JSON.stringify({ verdict }), {
-      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      headers: { 'Content-Type': 'application/json', ...CORS },
     });
   } catch (err) {
     console.error('[generate-verdict]', err);
     return new Response(JSON.stringify({ verdict: null }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      headers: { 'Content-Type': 'application/json', ...CORS },
     });
   }
 });

--- a/supabase/migrations/20260616150000_harden_security_definer_rpcs_and_verdicts.sql
+++ b/supabase/migrations/20260616150000_harden_security_definer_rpcs_and_verdicts.sql
@@ -1,0 +1,141 @@
+-- Harden SECURITY DEFINER RPCs and the verdicts cache policies (defense in depth).
+--
+-- Context: every SECURITY DEFINER function in `public` carried Postgres' default
+-- PUBLIC execute grant, so `anon` (a logged-out visitor) could invoke all of
+-- them. The admin_* RPCs self-protect with an is_admin guard, but:
+--   * resolve_hero_qid / mark_hero_unresolved had NO guard yet are reachable by
+--     any authenticated user and mutate heroes.* directly; and
+--   * several functions never pinned search_path — the classic SECURITY DEFINER
+--     privilege-escalation vector.
+--
+-- This migration does not change any function's behaviour beyond adding the two
+-- missing admin guards. Resulting access policy:
+--   * admin_* RPCs (self-guarded)          -> authenticated, service_role
+--   * resolve_hero_qid / mark_unresolved   -> authenticated, service_role (+ guard added)
+--   * pipeline mutators (service-only)     -> service_role only
+--   * all of the above                     -> REVOKE from PUBLIC + anon; search_path = public
+--
+-- Callers verified before tightening:
+--   * Admin RPCs + the two wikidata mutators are invoked from the admin
+--     catalog-health console (src/lib/db/catalogHealth.ts, campaigns.ts,
+--     cvIngest.ts) as the authenticated admin account.
+--   * cache_hero_comicvine_data / register_film_match / register_media_match /
+--     snapshot_catalog_health are only ever called by edge functions and cron,
+--     all of which authenticate with SUPABASE_SERVICE_ROLE_KEY.
+--   * rls_auto_enable is an event-trigger function and is intentionally untouched.
+
+-- ── 1. Pin search_path on the SECURITY DEFINER functions that lacked it ───────
+alter function public.admin_cron_status()                 set search_path = public;
+alter function public.admin_reenrich_hero(text)           set search_path = public;
+alter function public.admin_retry_failed()                set search_path = public;
+alter function public.admin_run_drain(integer)            set search_path = public;
+alter function public.admin_run_wikidata_enrich(integer)  set search_path = public;
+alter function public.admin_run_wikidata_resolve(integer) set search_path = public;
+alter function public.admin_set_drain_cron(boolean)       set search_path = public;
+alter function public.admin_snapshot_now()                set search_path = public;
+alter function public.admin_stop_run(bigint)              set search_path = public;
+alter function public.admin_toggle_cron(text, boolean)    set search_path = public;
+alter function public.snapshot_catalog_health()           set search_path = public;
+
+-- ── 2. Add the missing admin guard to the two client-facing wikidata mutators ─
+-- Bodies are unchanged from the live definitions; only the is_admin guard is
+-- prepended so they match every other admin RPC.
+create or replace function public.resolve_hero_qid(p_hero_id text, p_qid text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  update public.heroes
+     set wikidata_qid = p_qid,
+         wikidata_status = 'resolved',
+         wikidata_candidates = null
+   where id = p_hero_id;
+end;
+$function$;
+
+create or replace function public.mark_hero_unresolved(p_hero_id text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  update public.heroes
+     set wikidata_status = 'unresolved',
+         wikidata_candidates = null
+   where id = p_hero_id;
+end;
+$function$;
+
+-- ── 3a. Admin + admin-gated RPCs: authenticated admins (the guard enforces ────
+--        is_admin at runtime) and service_role. Revoke the default PUBLIC + anon.
+do $$
+declare f text;
+begin
+  foreach f in array array[
+    'public.admin_add_comicvine_heroes(jsonb)',
+    'public.admin_cron_status()',
+    'public.admin_delete_campaign(uuid)',
+    'public.admin_delete_hero(text)',
+    'public.admin_reenrich_hero(text)',
+    'public.admin_reschedule_cron(text, text, integer)',
+    'public.admin_retry_failed()',
+    'public.admin_run_drain(integer)',
+    'public.admin_run_wikidata_enrich(integer)',
+    'public.admin_run_wikidata_resolve(integer)',
+    'public.admin_set_drain_cron(boolean)',
+    'public.admin_snapshot_now()',
+    'public.admin_stop_run(bigint)',
+    'public.admin_toggle_cron(text, boolean)',
+    'public.admin_upsert_campaign(text, text, timestamptz, uuid, text, text, text, text, text[], integer, timestamptz)',
+    'public.resolve_hero_qid(text, text)',
+    'public.mark_hero_unresolved(text)'
+  ]
+  loop
+    execute format('revoke all on function %s from public, anon;', f);
+    execute format('grant execute on function %s to authenticated, service_role;', f);
+  end loop;
+end $$;
+
+-- ── 3b. Pipeline mutators: only ever invoked by edge functions / cron as ──────
+--        service_role. Revoke PUBLIC, anon AND authenticated.
+do $$
+declare f text;
+begin
+  foreach f in array array[
+    'public.cache_hero_comicvine_data(text, text, text[])',
+    'public.register_film_match(text, text, text, text)',
+    'public.register_media_match(text, text, text, text, text)',
+    'public.snapshot_catalog_health()'
+  ]
+  loop
+    execute format('revoke all on function %s from public, anon, authenticated;', f);
+    execute format('grant execute on function %s to service_role;', f);
+  end loop;
+end $$;
+
+-- ── 4. verdicts cache: scope the always-true policies to authenticated ────────
+-- The app is auth-gated, so anonymous writes are never legitimate. Shared-cache
+-- semantics are preserved (any signed-in user may read and seed a row); there is
+-- intentionally still no UPDATE policy, so rows stay insert-once.
+drop policy if exists verdicts_select on public.verdicts;
+drop policy if exists verdicts_insert on public.verdicts;
+
+create policy verdicts_select on public.verdicts
+  for select to authenticated using (true);
+
+create policy verdicts_insert on public.verdicts
+  for insert to authenticated with check (true);
+
+-- ── 5. rls_auto_enable: event-trigger helper (ensure_rls, ddl_command_end) ────
+-- It is never meant to be invoked over the REST RPC surface; event triggers fire
+-- regardless of EXECUTE grants, so revoking the default PUBLIC grant is safe.
+revoke all on function public.rls_auto_enable() from public, anon, authenticated;

--- a/supabase/migrations/20260616160000_mature_hardening_search_path_storage_verdicts.sql
+++ b/supabase/migrations/20260616160000_mature_hardening_search_path_storage_verdicts.sql
@@ -1,0 +1,51 @@
+-- Round 2 hardening: pin search_path on the remaining (SECURITY INVOKER) RPCs,
+-- take the maintenance rebuild off the public RPC surface, make the verdicts
+-- cache client-read-only (the generate-verdict edge function becomes the sole
+-- writer, via service_role), and stop the public storage buckets from being
+-- listable.
+
+-- ── 1. Pin search_path on the app's SECURITY INVOKER read/maintenance RPCs ────
+-- These run as the caller (lower risk than DEFINER), but pinning clears the
+-- advisor's function_search_path_mutable warnings and is best practice. Every
+-- object they touch — including the pg_trgm operators used by search — lives in
+-- public, so `= public` is sufficient.
+alter function public.catalog_distributions()                                            set search_path = public;
+alter function public.catalog_health()                                                   set search_path = public;
+alter function public.category_facet_counts(text, text, text, text, boolean, text)       set search_path = public;
+alter function public.get_active_campaigns(integer, integer)                             set search_path = public;
+alter function public.get_era_timeline(integer)                                          set search_path = public;
+alter function public.get_family_opponents(text, integer)                                set search_path = public;
+alter function public.get_most_feared(integer)                                           set search_path = public;
+alter function public.get_related_heroes(text, text, integer, boolean)                   set search_path = public;
+alter function public.get_relationship(text, text)                                       set search_path = public;
+alter function public.get_top_rivalries(integer)                                         set search_path = public;
+alter function public.get_trending_for_user(uuid, integer)                               set search_path = public;
+alter function public.get_trending_heroes(text, integer)                                 set search_path = public;
+alter function public.get_trending_titles(text, integer, integer)                        set search_path = public;
+alter function public.heroes_aliases_text(text[])                                        set search_path = public;
+alter function public.rebuild_hero_relationships()                                       set search_path = public;
+alter function public.search_heroes(text, text, text, integer, integer)                  set search_path = public;
+
+-- ── 2. rebuild_hero_relationships: maintenance only, never a client RPC ───────
+-- It TRUNCATEs + repopulates hero_relationships. As SECURITY INVOKER a client
+-- call already fails on the missing TRUNCATE privilege, but it has no business
+-- on the REST surface — restrict it to service_role (cron / edge functions).
+revoke all on function public.rebuild_hero_relationships() from public, anon, authenticated;
+grant execute on function public.rebuild_hero_relationships() to service_role;
+
+-- ── 3. verdicts: make the shared AI cache client-read-only ───────────────────
+-- Previously any signed-in user could INSERT arbitrary verdict text for any
+-- hero pair into a cache every other user reads (cache poisoning). The
+-- generate-verdict edge function now writes the cache with the service_role key
+-- (which bypasses RLS), so clients only ever read. Keep the authenticated SELECT
+-- policy from the previous migration; drop the client INSERT path.
+drop policy if exists verdicts_insert on public.verdicts;
+
+-- ── 4. Storage: stop public buckets from being listable ──────────────────────
+-- Both buckets are public (objects are served via /object/public/… which does
+-- not consult these policies) and currently empty. The broad SELECT policies
+-- only enable the authenticated `list`/`select` API, letting any client
+-- enumerate every file. The app never lists (it uses getPublicUrl / direct
+-- URLs; the maintenance scripts use service_role), so remove them.
+drop policy if exists "Public read hero portraits" on storage.objects;
+drop policy if exists "Public read user media" on storage.objects;


### PR DESCRIPTION
## Summary

Two-round hardening of the Supabase access model. Both migrations and the edge-function change are **already applied to the live project**; this PR brings the repo (source of truth) in sync and ships the client changes in the next app build.

### Migration 1 — `20260616150000_harden_security_definer_rpcs_and_verdicts.sql`
- Revoke the default `PUBLIC`/`anon` execute grant from every `SECURITY DEFINER` function; pin `search_path = public` on the 11 that lacked it.
- Add the missing `is_admin` guard to `resolve_hero_qid` and `mark_hero_unresolved` (reachable from the admin console but previously unguarded).
- Lock pipeline mutators (`register_*`, `cache_hero_comicvine_data`, `snapshot_catalog_health`) to `service_role`.
- Scope the `verdicts` policies to `authenticated` (remove anonymous writes).
- Take the `rls_auto_enable` event-trigger helper off the RPC surface.

### Migration 2 — `20260616160000_mature_hardening_search_path_storage_verdicts.sql`
- Pin `search_path = public` on the 16 `SECURITY INVOKER` read/maintenance RPCs (clears all `function_search_path_mutable` advisories).
- Restrict `rebuild_hero_relationships` to `service_role`.
- Make `verdicts` client-read-only (drop `verdicts_insert`); the edge function becomes the sole writer.
- Drop the broad SELECT policies that let clients list the (empty) public storage buckets.

### Edge function — `generate-verdict`
- Now reads/writes the shared verdict cache with the `service_role` key (closing the cache-poisoning hole where any signed-in user could write arbitrary verdict text).
- `verify_jwt` enabled so the paid Gemini endpoint is no longer anonymously callable.

### Client
- `VerdictInput` gains optional `heroAId`/`heroBId`; `matchup.ts` and `useVerdict` pass them so the edge function can key the cache write.
- `saveVerdict` removed — clients only read the cache now.

## Net effect
Cleared advisories: all `function_search_path_mutable` (17), `verdicts` always-true (1), public-bucket listing (2), and the anon-executable `rls_auto_enable` (1). Remaining warnings are by-design (admin RPCs guarded by runtime `is_admin`), deliberately left (`pg_trgm`/`pg_net` in public — moving them would break search/cron), or dashboard-only (leaked-password protection).

## Testing
- `yarn test:ci` — 318/318 pass.
- No `database.generated.ts` change (grants/RLS/search_path don't surface in generated types).
- Each migration dry-run validated in a `BEGIN … ROLLBACK` transaction before applying.

## Transition note
The live backend is already updated. The client changes ship with the next app build; until then, existing installs still get verdicts but won't populate the shared cache (graceful, no user-visible breakage).

https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt)_