### PR TITLE
Remove legacy hero-portraits storage bucket leftovers

### DIFF
--- a/supabase/migrations/20260616170000_drop_orphaned_hero_portraits_storage_policy.sql
+++ b/supabase/migrations/20260616170000_drop_orphaned_hero_portraits_storage_policy.sql
@@ -1,0 +1,6 @@
+-- The legacy hero-portraits Supabase Storage bucket was removed via the Storage
+-- API (portraits are served from Cloudinary; the bucket was empty with no rows
+-- referencing it). Supabase blocks deleting storage.buckets rows via SQL, so the
+-- bucket removal itself isn't expressible as a migration. This drops the
+-- now-orphaned write policy that referenced the bucket — its last trace in the schema.
+drop policy if exists "Authenticated write hero portraits" on storage.objects;


### PR DESCRIPTION
Follow-up cleanup. The empty legacy `hero-portraits` Supabase Storage bucket — superseded by Cloudinary, 0 objects, and verified that **no** `heroes` row references Supabase Storage for any image — was deleted via the Storage API (HTTP 200 "Successfully deleted"). The service-role key was read inline from the vault inside Postgres via `pg_net`, so it never left the database.

Supabase blocks deleting `storage.buckets` rows via SQL, so the bucket removal itself can't be a migration. This migration drops the now-orphaned `Authenticated write hero portraits` policy on `storage.objects` — the bucket's last trace in the schema.

https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt)_