### PR TITLE
Address performance advisors: FK indexes, RLS initplan, hero_people PK

### DIFF
--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -356,6 +356,7 @@ export type Database = {
       hero_people: {
         Row: {
           hero_id: string
+          id: number
           person_name: string
           role: string
           source: string
@@ -363,6 +364,7 @@ export type Database = {
         }
         Insert: {
           hero_id: string
+          id?: never
           person_name: string
           role: string
           source?: string
@@ -370,6 +372,7 @@ export type Database = {
         }
         Update: {
           hero_id?: string
+          id?: never
           person_name?: string
           role?: string
           source?: string

--- a/supabase/migrations/20260616180000_perf_fk_indexes_rls_initplan_hero_people_pk.sql
+++ b/supabase/migrations/20260616180000_perf_fk_indexes_rls_initplan_hero_people_pk.sql
@@ -1,0 +1,65 @@
+-- Performance advisor pass: cover the unindexed foreign keys, stop RLS policies
+-- from re-evaluating auth.uid() per row, and give hero_people a primary key.
+-- (The two unused_index notices are intentionally left: the "unused" signal is
+-- unreliable on low-traffic stats and heroes_aliases_trgm_idx backs alias search.)
+
+-- ── 1. Covering indexes for foreign keys ─────────────────────────────────────
+create index if not exists featured_campaigns_title_id_idx     on public.featured_campaigns (title_id);
+create index if not exists hero_media_appearances_title_id_idx on public.hero_media_appearances (title_id);
+create index if not exists hero_people_title_id_idx            on public.hero_people (title_id);
+create index if not exists user_favourites_hero_id_idx         on public.user_favourites (hero_id);
+
+-- ── 2. hero_people primary key ───────────────────────────────────────────────
+-- title_id is nullable (and currently always null), so the natural-key UNIQUE
+-- index (hero_id, person_name, role, coalesce(title_id,'')) can't serve as a PK.
+-- Add a surrogate identity key; the dedup UNIQUE index stays as the upsert target.
+alter table public.hero_people add column if not exists id bigint generated always as identity;
+alter table public.hero_people add constraint hero_people_pkey primary key (id);
+
+-- ── 3. Wrap auth.uid() so RLS evaluates it once per query, not once per row ───
+-- Behaviour is identical; only the initplan changes. Roles/commands preserved.
+
+-- user_favourites (self-scoped, authenticated)
+drop policy if exists favourites_select on public.user_favourites;
+create policy favourites_select on public.user_favourites
+  for select to authenticated using ((select auth.uid()) = user_id);
+drop policy if exists favourites_insert on public.user_favourites;
+create policy favourites_insert on public.user_favourites
+  for insert to authenticated with check ((select auth.uid()) = user_id);
+drop policy if exists favourites_delete on public.user_favourites;
+create policy favourites_delete on public.user_favourites
+  for delete to authenticated using ((select auth.uid()) = user_id);
+
+-- user_profiles (self-scoped, authenticated)
+drop policy if exists profiles_select on public.user_profiles;
+create policy profiles_select on public.user_profiles
+  for select to authenticated using ((select auth.uid()) = id);
+drop policy if exists profiles_insert on public.user_profiles;
+create policy profiles_insert on public.user_profiles
+  for insert to authenticated with check ((select auth.uid()) = id);
+
+-- user_view_history (self-scoped, ALL)
+drop policy if exists "Users can manage their own view history" on public.user_view_history;
+create policy "Users can manage their own view history" on public.user_view_history
+  for all to public using ((select auth.uid()) = user_id);
+
+-- admin-read ops tables (is_admin gate)
+drop policy if exists enrichment_runs_admin_read on public.enrichment_runs;
+create policy enrichment_runs_admin_read on public.enrichment_runs
+  for select to public
+  using (exists (select 1 from user_profiles p where p.id = (select auth.uid()) and p.is_admin));
+
+drop policy if exists api_usage_admin_read on public.api_usage;
+create policy api_usage_admin_read on public.api_usage
+  for select to public
+  using (exists (select 1 from user_profiles p where p.id = (select auth.uid()) and p.is_admin));
+
+drop policy if exists snapshots_admin_read on public.catalog_health_snapshots;
+create policy snapshots_admin_read on public.catalog_health_snapshots
+  for select to public
+  using (exists (select 1 from user_profiles p where p.id = (select auth.uid()) and p.is_admin));
+
+drop policy if exists enrichment_run_heroes_admin_read on public.enrichment_run_heroes;
+create policy enrichment_run_heroes_admin_read on public.enrichment_run_heroes
+  for select to public
+  using (exists (select 1 from user_profiles p where p.id = (select auth.uid()) and p.is_admin));


### PR DESCRIPTION
Performance-advisor pass (migration applied live; this syncs the repo).

### Changes — `20260616180000_perf_fk_indexes_rls_initplan_hero_people_pk.sql`
- **4 covering indexes** for the unindexed foreign keys: `featured_campaigns.title_id`, `hero_media_appearances.title_id`, `hero_people.title_id`, `user_favourites.hero_id` (clears `unindexed_foreign_keys`).
- **10 RLS policies** rewritten to wrap `auth.uid()` as `(select auth.uid())` so it evaluates once per query instead of per row (clears `auth_rls_initplan`). Roles, commands, and predicates are otherwise identical — no behavior change.
- **`hero_people` primary key** — added a surrogate `id bigint generated always as identity` PK. Its natural key includes the nullable `title_id`, so the existing dedup UNIQUE index can't be a PK; that index stays as the upsert target. `database.generated.ts` regenerated (only `hero_people` gains `id`).

### Deliberately left
The two `unused_index` notices (`heroes_aliases_trgm_idx`, `user_view_history_user_recent`) — the "unused" signal is unreliable on low-traffic stats and the alias trigram index plausibly backs search; dropping risks a silent regression.

### Net effect
All 15 actionable performance items cleared (4 FK + 10 initplan + 1 no-PK). The advisor now lists only `unused_index` INFOs — including the 4 brand-new FK indexes, which read as "unused" simply because they haven't served a query yet.

### Testing
`yarn test:ci` — 318/318 pass. Migration dry-run validated in a `BEGIN … ROLLBACK` transaction before applying.

https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Xk4rbmV46AwcwQFdoLYt)_