### PR TITLE
Explore: native↔web parity, editorial features & community matchup vote

### DIFF
--- a/__tests__/lib/home/matchupVote.test.ts
+++ b/__tests__/lib/home/matchupVote.test.ts
@@ -1,0 +1,55 @@
+// __tests__/lib/home/matchupVote.test.ts
+import {
+  dayStamp,
+  matchupVoteKey,
+  statSplit,
+  statLead,
+} from '../../../src/lib/home/matchupVote';
+
+describe('dayStamp', () => {
+  it('formats the local calendar day as YYYY-MM-DD with zero-padding', () => {
+    expect(dayStamp(new Date(2026, 0, 5))).toBe('2026-01-05');
+    expect(dayStamp(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+});
+
+describe('matchupVoteKey', () => {
+  it('namespaces by day and pair so a reschedule never reads a stale pick', () => {
+    const d = new Date(2026, 5, 17);
+    expect(matchupVoteKey('a1', 'b2', d)).toBe('matchup-vote:2026-06-17:a1-b2');
+  });
+
+  it('changes when the day changes', () => {
+    const a = matchupVoteKey('x', 'y', new Date(2026, 5, 17));
+    const b = matchupVoteKey('x', 'y', new Date(2026, 5, 18));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('statSplit', () => {
+  it('returns whole percentages that sum to 100', () => {
+    const { pctA, pctB } = statSplit(4, 2);
+    expect(pctA + pctB).toBe(100);
+    expect(pctA).toBe(67);
+    expect(pctB).toBe(33);
+  });
+
+  it('reads a 0–0 (no stats either side) as evenly matched', () => {
+    expect(statSplit(0, 0)).toEqual({ pctA: 50, pctB: 50 });
+  });
+
+  it('handles a clean sweep', () => {
+    expect(statSplit(6, 0)).toEqual({ pctA: 100, pctB: 0 });
+  });
+});
+
+describe('statLead', () => {
+  it('names the stat leader with the score', () => {
+    expect(statLead(4, 2, 'Thor', 'Hulk')).toBe('Thor leads 4–2 on stats');
+    expect(statLead(1, 5, 'Thor', 'Hulk')).toBe('Hulk leads 5–1 on stats');
+  });
+
+  it('calls an even tape evenly matched', () => {
+    expect(statLead(3, 3, 'Thor', 'Hulk')).toBe('Evenly matched on the tape');
+  });
+});

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,4 +1,7 @@
-// app/(tabs)/explore.tsx — Home screen: spotlight + curated/personal carousels
+// app/(tabs)/explore.tsx — Home screen: spotlight + curated/personal carousels +
+// the daily battle and editorial "Beyond the Page" features (rivalries, most
+// feared, era timeline, first-appearance covers). Brought to parity with the web
+// explore so native shows the full catalogue's depth, not a thin slice.
 import {
   useEffect,
   useState,
@@ -37,9 +40,25 @@ import {
   getIconicHeroes,
   getTrendingSpotlightHeroes,
   getBrowseCovers,
+  getVillains,
+  getAntiHeroes,
+  getXMen,
+  getNewlyAddedCV,
+  getFranchiseIcons,
+  getHeroesByPublisher,
+  getHeroesByMediaTag,
+  getHeroesByStatRanking,
+  getTopRivalries,
+  getMostFeared,
+  getEraTimeline,
+  getFirstAppearanceCovers,
   type Hero,
   type BrowseCover,
   type CategorySlug,
+  type Rivalry,
+  type FearedVillain,
+  type EraBucket,
+  type FirstAppearanceCover,
 } from '../../src/lib/db/heroes';
 import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
 import {
@@ -50,7 +69,13 @@ import {
   type Campaign,
   type TrendingTitleCharacter,
 } from '../../src/lib/db/trending';
+import { getTodaysMatchup, type TodaysMatchup as Matchup } from '../../src/lib/matchup';
 import { RightNowBand } from '../../src/components/home/RightNowBand';
+import { TodaysMatchup } from '../../src/components/home/TodaysMatchup';
+import { GreatestRivalries } from '../../src/components/home/GreatestRivalries';
+import { HallOfInfamy } from '../../src/components/home/HallOfInfamy';
+import { EraTimeline } from '../../src/components/home/EraTimeline';
+import { CoverGallery } from '../../src/components/home/CoverGallery';
 import { CategoryPodGrid, BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
@@ -62,10 +87,21 @@ function toRowHero(h: Hero | FavouriteHero): RowHero {
   return { id: h.id, name: h.name, image_url: h.image_url, portrait_url: h.portrait_url };
 }
 
+// A curated carousel row, declared as data so the catalogue order lives in one
+// place. `key` selects its editorial style (tone/accent/ranked) via rowStyle.
+interface CuratedRow {
+  key: string;
+  label: string;
+  title: string;
+  heroes: Hero[];
+  route?: Href;
+}
+
 // Each visible section of the feed is one FlatList row, so only the rows near
 // the viewport stay mounted (the old ScrollView mounted all ~12 at once).
 type FeedRow =
   | { type: 'spotlight'; heroes: Hero[] }
+  | { type: 'matchup'; matchup: Matchup }
   | { type: 'recent'; heroes: RowHero[] }
   | { type: 'browsegrid' }
   | { type: 'favourites'; heroes: RowHero[] }
@@ -77,15 +113,12 @@ type FeedRow =
       streaming: TrendingTitle[];
       personalized: TrendingTitleCharacter[];
     }
-  | { type: 'browsehead' }
-  | {
-      type: 'curated';
-      key: string;
-      label: string;
-      title: string;
-      heroes: Hero[];
-      route?: Href;
-    };
+  | { type: 'chapter'; kicker: string; title: string }
+  | { type: 'rivalries'; rivalries: Rivalry[] }
+  | { type: 'infamy'; villains: FearedVillain[] }
+  | { type: 'era'; eras: EraBucket[] }
+  | { type: 'covers'; covers: FirstAppearanceCover[] }
+  | { type: 'curated'; key: string; label: string; title: string; heroes: Hero[]; route?: Href };
 
 // Typed Animated.FlatList so renderItem/keyExtractor/CellRenderer infer FeedRow.
 const FeedList = Animated.FlatList as unknown as ComponentType<
@@ -101,7 +134,6 @@ export default function HomeScreen() {
   const [spotlight, setSpotlight] = useState<Hero[]>([]);
   const [initialLoaded, setInitialLoaded] = useState(false);
 
-  // One marquee rail (Most Iconic); everything else lives in the Browse grid.
   const [iconic, setIconic] = useState<Hero[]>([]);
   const [browseCovers, setBrowseCovers] = useState<Record<string, BrowseCover>>({});
   const [onScreen, setOnScreen] = useState<TrendingTitle[]>([]);
@@ -109,6 +141,27 @@ export default function HomeScreen() {
   const [streaming, setStreaming] = useState<TrendingTitle[]>([]);
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [trendingForUser, setTrendingForUser] = useState<TrendingTitleCharacter[]>([]);
+  const [matchup, setMatchup] = useState<Matchup | null>(null);
+
+  // Curated catalogue rows (the dormant depth, now surfaced on native).
+  const [villains, setVillains] = useState<Hero[]>([]);
+  const [horror, setHorror] = useState<Hero[]>([]);
+  const [antiHeroes, setAntiHeroes] = useState<Hero[]>([]);
+  const [marvel, setMarvel] = useState<Hero[]>([]);
+  const [dc, setDc] = useState<Hero[]>([]);
+  const [strongest, setStrongest] = useState<Hero[]>([]);
+  const [mostIntelligent, setMostIntelligent] = useState<Hero[]>([]);
+  const [xmen, setXmen] = useState<Hero[]>([]);
+  const [anime, setAnime] = useState<Hero[]>([]);
+  const [videoGames, setVideoGames] = useState<Hero[]>([]);
+  const [franchise, setFranchise] = useState<Hero[]>([]);
+  const [newlyAdded, setNewlyAdded] = useState<Hero[]>([]);
+
+  // Editorial "Beyond the Page" features.
+  const [rivalries, setRivalries] = useState<Rivalry[]>([]);
+  const [mostFeared, setMostFeared] = useState<FearedVillain[]>([]);
+  const [eras, setEras] = useState<EraBucket[]>([]);
+  const [covers, setCovers] = useState<FirstAppearanceCover[]>([]);
 
   const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
@@ -150,6 +203,9 @@ export default function HomeScreen() {
     getActiveCampaigns()
       .then(setCampaigns)
       .catch(() => {});
+    getTodaysMatchup()
+      .then(setMatchup)
+      .catch(() => {});
 
     getIconicHeroes(20)
       .then(setIconic)
@@ -165,6 +221,58 @@ export default function HomeScreen() {
       .catch(() => {});
     getTrendingTitles('streaming', 6)
       .then(setStreaming)
+      .catch(() => {});
+
+    // Curated catalogue rows.
+    getVillains(25)
+      .then(setVillains)
+      .catch(() => {});
+    getHeroesByMediaTag('horror-icon', 20)
+      .then(setHorror)
+      .catch(() => {});
+    getAntiHeroes(20)
+      .then(setAntiHeroes)
+      .catch(() => {});
+    getHeroesByPublisher('marvel', 25)
+      .then(setMarvel)
+      .catch(() => {});
+    getHeroesByPublisher('dc', 25)
+      .then(setDc)
+      .catch(() => {});
+    getHeroesByStatRanking('strength', 20)
+      .then(setStrongest)
+      .catch(() => {});
+    getHeroesByStatRanking('intelligence', 20)
+      .then(setMostIntelligent)
+      .catch(() => {});
+    getXMen(25)
+      .then(setXmen)
+      .catch(() => {});
+    getHeroesByMediaTag('anime', 25)
+      .then(setAnime)
+      .catch(() => {});
+    getHeroesByMediaTag('video-game', 25)
+      .then(setVideoGames)
+      .catch(() => {});
+    getFranchiseIcons(25)
+      .then(setFranchise)
+      .catch(() => {});
+    getNewlyAddedCV(25)
+      .then(setNewlyAdded)
+      .catch(() => {});
+
+    // Editorial features.
+    getTopRivalries(12)
+      .then(setRivalries)
+      .catch(() => {});
+    getMostFeared(12)
+      .then(setMostFeared)
+      .catch(() => {});
+    getEraTimeline(7)
+      .then(setEras)
+      .catch(() => {});
+    getFirstAppearanceCovers(14)
+      .then(setCovers)
       .catch(() => {});
   }, []);
 
@@ -194,6 +302,16 @@ export default function HomeScreen() {
     [router, navigating],
   );
 
+  const handleHeroId = useCallback((id: string) => handlePress({ id }), [handlePress]);
+
+  const handleOpenPath = useCallback(
+    (path: string) => {
+      Haptics.selectionAsync();
+      router.push(path as Href);
+    },
+    [router],
+  );
+
   const handleCategoryPress = useCallback(
     (slug: string) => {
       Haptics.selectionAsync();
@@ -210,12 +328,14 @@ export default function HomeScreen() {
     [router],
   );
 
-  // The feed as a flat list of rows. A deliberate, short sequence: billboard →
-  // the dynamic "Right Now" zone → your personal rows → one marquee rail → the
-  // Browse grid. No row soup.
+  // The feed as a flat list of rows. A deliberate, chaptered sequence: billboard →
+  // today's battle → the dynamic "Right Now" zone → your personal rows → the
+  // Library (browse) → curated catalogue rows → "Beyond the Page" editorial
+  // features. Chapter headers keep the rhythm so it reads as a magazine, not soup.
   const rows = useMemo<FeedRow[]>(() => {
     const out: FeedRow[] = [];
     if (spotlightPool.length > 0) out.push({ type: 'spotlight', heroes: spotlightPool });
+    if (matchup) out.push({ type: 'matchup', matchup });
     if (
       campaigns[0] ||
       onScreen.length > 0 ||
@@ -235,7 +355,8 @@ export default function HomeScreen() {
     if (recentlyViewed.length > 0)
       out.push({ type: 'recent', heroes: recentlyViewed.map(toRowHero) });
     if (favourites.length > 0) out.push({ type: 'favourites', heroes: favourites.map(toRowHero) });
-    out.push({ type: 'browsehead' });
+
+    out.push({ type: 'chapter', kicker: 'The Library', title: 'Browse the Universe' });
     if (iconic.length > 0)
       out.push({
         type: 'curated',
@@ -246,9 +367,43 @@ export default function HomeScreen() {
         route: '/category/most-iconic',
       });
     out.push({ type: 'browsegrid' });
+
+    // Curated catalogue rows, declared in catalogue order. Style comes from the
+    // row's `key` (see rowStyle): the dark-toned villain/horror/anti rows render
+    // on navy bands; strongest/minds get leaderboard numerals.
+    const curated: CuratedRow[] = [
+      { key: 'villains', label: 'The Dark Side', title: 'Villains', heroes: villains, route: '/category/villain' },
+      { key: 'horror', label: 'Movie Nightmares', title: 'Horror Icons', heroes: horror, route: '/category/horror' },
+      { key: 'anti', label: 'Grey Morality', title: 'Anti-Heroes', heroes: antiHeroes, route: '/category/anti-heroes' },
+      { key: 'marvel', label: 'Publisher', title: 'Marvel Universe', heroes: marvel, route: '/category/marvel' },
+      { key: 'dc', label: 'Publisher', title: 'DC Universe', heroes: dc, route: '/category/dc' },
+      { key: 'strongest', label: 'Raw Power', title: 'Strongest', heroes: strongest, route: '/category/strongest' },
+      { key: 'minds', label: 'Great Minds', title: 'Most Intelligent', heroes: mostIntelligent, route: '/category/most-intelligent' },
+      { key: 'xmen', label: 'Mutantkind', title: 'X-Men', heroes: xmen, route: '/category/xmen' },
+      { key: 'anime', label: 'Beyond the Comics', title: 'Anime Legends', heroes: anime, route: '/category/anime' },
+      { key: 'games', label: 'Press Start', title: 'Video Game Heroes', heroes: videoGames, route: '/category/video-games' },
+      { key: 'franchise', label: 'Franchise Icons', title: 'Beyond the Comics', heroes: franchise, route: '/category/franchise-icons' },
+      { key: 'new', label: 'Fresh to the Vault', title: 'Newly Added', heroes: newlyAdded },
+    ];
+    for (const r of curated) {
+      if (r.heroes.length > 0)
+        out.push({ type: 'curated', key: r.key, label: r.label, title: r.title, heroes: r.heroes, route: r.route });
+    }
+
+    // "Beyond the Page" — the editorial chapter.
+    const hasEditorial =
+      rivalries.length > 0 || mostFeared.length > 0 || eras.length > 0 || covers.length > 0;
+    if (hasEditorial)
+      out.push({ type: 'chapter', kicker: 'Go Deeper', title: 'Beyond the Page' });
+    if (rivalries.length > 0) out.push({ type: 'rivalries', rivalries });
+    if (mostFeared.length > 0) out.push({ type: 'infamy', villains: mostFeared });
+    if (eras.length > 0) out.push({ type: 'era', eras });
+    if (covers.length > 0) out.push({ type: 'covers', covers });
+
     return out;
   }, [
     spotlightPool,
+    matchup,
     recentlyViewed,
     favourites,
     iconic,
@@ -257,10 +412,31 @@ export default function HomeScreen() {
     streaming,
     campaigns,
     trendingForUser,
+    villains,
+    horror,
+    antiHeroes,
+    marvel,
+    dc,
+    strongest,
+    mostIntelligent,
+    xmen,
+    anime,
+    videoGames,
+    franchise,
+    newlyAdded,
+    rivalries,
+    mostFeared,
+    eras,
+    covers,
   ]);
 
   const keyExtractor = useCallback(
-    (row: FeedRow) => (row.type === 'curated' ? `curated-${row.key}` : row.type),
+    (row: FeedRow) =>
+      row.type === 'curated'
+        ? `curated-${row.key}`
+        : row.type === 'chapter'
+          ? `chapter-${row.title}`
+          : row.type,
     [],
   );
 
@@ -276,6 +452,8 @@ export default function HomeScreen() {
               onHeroPress={handlePress}
             />
           );
+        case 'matchup':
+          return <TodaysMatchup matchup={item.matchup} onOpen={handleOpenPath} />;
         case 'recent':
           return (
             <HomeHeroRow
@@ -300,11 +478,11 @@ export default function HomeScreen() {
               disabled={navigating}
             />
           );
-        case 'browsehead':
+        case 'chapter':
           return (
             <View style={styles.browseHead}>
-              <Text style={styles.browseKicker}>The Library</Text>
-              <Text style={styles.browseTitle}>Browse the Universe</Text>
+              <Text style={styles.browseKicker}>{item.kicker}</Text>
+              <Text style={styles.browseTitle}>{item.title}</Text>
             </View>
           );
         case 'browsegrid':
@@ -320,6 +498,14 @@ export default function HomeScreen() {
               disabled={navigating}
             />
           );
+        case 'rivalries':
+          return <GreatestRivalries rivalries={item.rivalries} onOpen={handleOpenPath} />;
+        case 'infamy':
+          return <HallOfInfamy villains={item.villains} onPress={handleHeroId} />;
+        case 'era':
+          return <EraTimeline eras={item.eras} onPress={handleHeroId} />;
+        case 'covers':
+          return <CoverGallery covers={item.covers} onPress={handleHeroId} />;
         case 'curated': {
           const rs = rowStyle(item.key);
           return (
@@ -343,6 +529,8 @@ export default function HomeScreen() {
       insets.top,
       scrollY,
       handlePress,
+      handleHeroId,
+      handleOpenPath,
       handleCategoryPress,
       handleTitlePress,
       navigating,
@@ -400,7 +588,7 @@ const styles = StyleSheet.create({
   // Beige content sheet. The spotlight (first row) is opaque navy and covers the
   // beige behind it; the rows below sit on this beige, as the old sheet did.
   content: { flexGrow: 1, backgroundColor: COLORS.beige, paddingBottom: 120 },
-  // "Browse the Universe" chapter break between the dynamic zone and the library.
+  // Chapter break ("Browse the Universe", "Beyond the Page").
   browseHead: { paddingHorizontal: 16, paddingTop: 22, paddingBottom: 4 },
   browseKicker: {
     fontFamily: 'Nunito_700Bold',

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -52,6 +52,7 @@ import {
   getMostFeared,
   getEraTimeline,
   getFirstAppearanceCovers,
+  getHeroCount,
   type Hero,
   type BrowseCover,
   type CategorySlug,
@@ -77,6 +78,8 @@ import { HallOfInfamy } from '../../src/components/home/HallOfInfamy';
 import { EraTimeline } from '../../src/components/home/EraTimeline';
 import { CoverGallery } from '../../src/components/home/CoverGallery';
 import { CategoryPodGrid, BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
+import { PublisherGrid } from '../../src/components/home/PublisherGrid';
+import { PulseTicker } from '../../src/components/home/PulseTicker';
 import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
 import { useAuth } from '../../src/hooks/useAuth';
 import type { FavouriteHero } from '../../src/types';
@@ -101,7 +104,9 @@ interface CuratedRow {
 // the viewport stay mounted (the old ScrollView mounted all ~12 at once).
 type FeedRow =
   | { type: 'spotlight'; heroes: Hero[] }
+  | { type: 'publishers' }
   | { type: 'matchup'; matchup: Matchup }
+  | { type: 'ticker'; heroCount: number; newlyAddedCount: number }
   | { type: 'recent'; heroes: RowHero[] }
   | { type: 'browsegrid' }
   | { type: 'favourites'; heroes: RowHero[] }
@@ -142,6 +147,7 @@ export default function HomeScreen() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [trendingForUser, setTrendingForUser] = useState<TrendingTitleCharacter[]>([]);
   const [matchup, setMatchup] = useState<Matchup | null>(null);
+  const [heroCount, setHeroCount] = useState(0);
 
   // Curated catalogue rows (the dormant depth, now surfaced on native).
   const [villains, setVillains] = useState<Hero[]>([]);
@@ -205,6 +211,9 @@ export default function HomeScreen() {
       .catch(() => {});
     getTodaysMatchup()
       .then(setMatchup)
+      .catch(() => {});
+    getHeroCount()
+      .then(setHeroCount)
       .catch(() => {});
 
     getIconicHeroes(20)
@@ -335,7 +344,10 @@ export default function HomeScreen() {
   const rows = useMemo<FeedRow[]>(() => {
     const out: FeedRow[] = [];
     if (spotlightPool.length > 0) out.push({ type: 'spotlight', heroes: spotlightPool });
+    out.push({ type: 'publishers' });
     if (matchup) out.push({ type: 'matchup', matchup });
+    if (heroCount > 0)
+      out.push({ type: 'ticker', heroCount, newlyAddedCount: newlyAdded.length });
     if (
       campaigns[0] ||
       onScreen.length > 0 ||
@@ -404,6 +416,7 @@ export default function HomeScreen() {
   }, [
     spotlightPool,
     matchup,
+    heroCount,
     recentlyViewed,
     favourites,
     iconic,
@@ -452,8 +465,14 @@ export default function HomeScreen() {
               onHeroPress={handlePress}
             />
           );
+        case 'publishers':
+          return <PublisherGrid onPress={handleCategoryPress} />;
         case 'matchup':
           return <TodaysMatchup matchup={item.matchup} onOpen={handleOpenPath} />;
+        case 'ticker':
+          return (
+            <PulseTicker heroCount={item.heroCount} newlyAddedCount={item.newlyAddedCount} />
+          );
         case 'recent':
           return (
             <HomeHeroRow

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -1,7 +1,7 @@
 // app/(tabs)/explore.web.tsx — Home screen for web (spotlight + horizontal scroll rows).
 // Search lives on the dedicated /search route; this screen is home-only.
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { View, Text, ScrollView, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { COLORS } from '../../src/constants/colors';
@@ -1449,6 +1449,72 @@ export default function WebHomeScreen() {
               onPress={(slug) =>
                 router.push(`/category/${slug}` as Parameters<typeof router.push>[0])
               }
+            />
+
+            {/* ── More of the Library — publishers, teams, media & power ────── */}
+            <HomeRow
+              label="Publisher"
+              title="Marvel Universe"
+              heroes={homeData.marvel ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/marvel')}
+            />
+            <HomeRow
+              label="Publisher"
+              title="DC Universe"
+              heroes={homeData.dc ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/dc')}
+            />
+            <HomeRow
+              label="Mutantkind"
+              title="X-Men"
+              heroes={homeData.xmen ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/xmen')}
+            />
+            <HomeRow
+              label="Raw Power"
+              title="Strongest"
+              heroes={homeData.strongest ?? []}
+              statKey="strength"
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/strongest')}
+            />
+            <HomeRow
+              label="Great Minds"
+              title="Most Intelligent"
+              heroes={homeData.mostIntelligent ?? []}
+              statKey="intelligence"
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/most-intelligent')}
+            />
+            <HomeRow
+              label="Beyond the Comics"
+              title="Anime Legends"
+              heroes={homeData.anime ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/anime')}
+            />
+            <HomeRow
+              label="Press Start"
+              title="Video Game Heroes"
+              heroes={homeData.videoGames ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/video-games')}
+            />
+            <HomeRow
+              label="Franchise Icons"
+              title="Beyond the Comics"
+              heroes={homeData.franchiseIcons ?? []}
+              onPress={handlePress}
+              onViewAll={() => router.push('/category/franchise-icons')}
+            />
+            <HomeRow
+              label="Fresh to the Vault"
+              title="Newly Added"
+              heroes={homeData.newlyAdded ?? []}
+              onPress={handlePress}
             />
 
             {/* ── The Dark Side — one deliberate dark zone ──────────────────── */}

--- a/src/components/home/CoverGallery.tsx
+++ b/src/components/home/CoverGallery.tsx
@@ -1,0 +1,109 @@
+// src/components/home/CoverGallery.tsx — native "Origins" gallery wall.
+// First-appearance comic covers; taps open the character.
+import { View, Text, ScrollView, StyleSheet, Dimensions } from 'react-native';
+import { Image } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
+import { PressScale } from '../ui/PressScale';
+import { COLORS } from '../../constants/colors';
+import type { FirstAppearanceCover } from '../../lib/db/heroes';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_W = Math.round(SCREEN_WIDTH * 0.4);
+const CARD_H = Math.round(CARD_W * 1.5); // ~2:3 comic cover
+
+function CoverCard({ cover, onPress }: { cover: FirstAppearanceCover; onPress: () => void }) {
+  return (
+    <PressScale onPress={onPress} scale={0.95} style={g.card}>
+      <Image
+        source={{ uri: cover.first_issue_image_url ?? undefined }}
+        contentFit="cover"
+        contentPosition="top"
+        style={StyleSheet.absoluteFill}
+        cachePolicy="memory-disk"
+        recyclingKey={cover.id}
+        transition={200}
+      />
+      <LinearGradient
+        colors={['rgba(15,20,24,0.95)', 'rgba(15,20,24,0.1)', 'transparent']}
+        locations={[0, 0.45, 0.75]}
+        start={{ x: 0, y: 1 }}
+        end={{ x: 0, y: 0 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <View style={g.caption}>
+        <Text style={g.name} numberOfLines={1}>
+          {cover.name}
+        </Text>
+        {!!cover.first_appearance && (
+          <Text style={g.issue} numberOfLines={1}>
+            {cover.first_appearance}
+          </Text>
+        )}
+      </View>
+    </PressScale>
+  );
+}
+
+export function CoverGallery({
+  covers,
+  onPress,
+}: {
+  covers: FirstAppearanceCover[];
+  onPress: (id: string) => void;
+}) {
+  if (covers.length === 0) return null;
+  return (
+    <View style={g.section}>
+      <View style={g.header}>
+        <View style={g.accentBar} />
+        <View style={g.headerText}>
+          <Text style={g.label}>Origins</Text>
+          <Text style={g.title}>First Appearances</Text>
+        </View>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={g.row}>
+        {covers.map((c) => (
+          <CoverCard key={c.id} cover={c} onPress={() => onPress(c.id)} />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const g = StyleSheet.create({
+  section: { paddingTop: 14, paddingBottom: 16 },
+  header: {
+    paddingHorizontal: 15,
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+  },
+  accentBar: { width: 4, borderRadius: 2, backgroundColor: COLORS.orange },
+  headerText: { gap: 2, justifyContent: 'center' },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: COLORS.orange,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+  row: { gap: 12, paddingHorizontal: 15, paddingBottom: 4 },
+  card: {
+    width: CARD_W,
+    height: CARD_H,
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+  },
+  caption: { position: 'absolute', bottom: 10, left: 12, right: 12 },
+  name: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.beige, lineHeight: 18 },
+  issue: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    color: 'rgba(245,235,220,0.6)',
+    marginTop: 2,
+  },
+});

--- a/src/components/home/EraTimeline.tsx
+++ b/src/components/home/EraTimeline.tsx
@@ -1,0 +1,147 @@
+// src/components/home/EraTimeline.tsx — native "Comics History" timeline.
+// Heroes bucketed by comic age, hung off an orange spine (Golden → Modern).
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { HeroImage } from '../HeroImage';
+import { PressScale } from '../ui/PressScale';
+import { COLORS } from '../../constants/colors';
+import type { EraBucket, EraHero } from '../../lib/db/heroes';
+
+const ERA_YEARS: Record<string, string> = {
+  'Golden Age': '1938 – 1955',
+  'Silver Age': '1956 – 1969',
+  'Bronze Age': '1970 – 1984',
+  'Modern Age': '1985 – Today',
+};
+
+function EraCard({ hero, onPress }: { hero: EraHero; onPress: () => void }) {
+  return (
+    <PressScale onPress={onPress} scale={0.94} style={t.card}>
+      <View style={t.cardImgWrap}>
+        <HeroImage
+          id={hero.id}
+          name={hero.name}
+          imageUrl={hero.image_url}
+          portraitUrl={hero.portrait_url}
+          contentFit="cover"
+          contentPosition="top"
+          style={StyleSheet.absoluteFill}
+          recyclingKey={hero.id}
+        />
+      </View>
+      <Text style={t.cardName} numberOfLines={1}>
+        {hero.name}
+      </Text>
+      <Text style={t.cardYear}>{hero.year}</Text>
+    </PressScale>
+  );
+}
+
+export function EraTimeline({
+  eras,
+  onPress,
+}: {
+  eras: EraBucket[];
+  onPress: (id: string) => void;
+}) {
+  if (eras.length === 0) return null;
+  return (
+    <View style={t.section}>
+      <View style={t.header}>
+        <View style={t.accentBar} />
+        <View style={t.headerText}>
+          <Text style={t.label}>Comics History</Text>
+          <Text style={t.title}>Through the Ages</Text>
+        </View>
+      </View>
+
+      <View style={t.timeline}>
+        <View style={t.spine} pointerEvents="none" />
+        {eras.map((bucket) => (
+          <View key={bucket.era} style={t.eraBlock}>
+            <View style={t.eraDot} />
+            <View style={t.eraHead}>
+              <Text style={t.eraName}>{bucket.era}</Text>
+              <Text style={t.eraYears}>{ERA_YEARS[bucket.era] ?? ''}</Text>
+            </View>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={t.heroScroll}
+              contentContainerStyle={t.heroStrip}
+            >
+              {bucket.heroes.map((h) => (
+                <EraCard key={h.id} hero={h} onPress={() => onPress(h.id)} />
+              ))}
+            </ScrollView>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const t = StyleSheet.create({
+  section: { paddingTop: 14, paddingBottom: 16 },
+  header: {
+    paddingHorizontal: 15,
+    marginBottom: 16,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+  },
+  accentBar: { width: 4, borderRadius: 2, backgroundColor: COLORS.orange },
+  headerText: { gap: 2, justifyContent: 'center' },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: COLORS.orange,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+
+  timeline: { position: 'relative', paddingLeft: 41 },
+  spine: {
+    position: 'absolute',
+    left: 20,
+    top: 8,
+    bottom: 24,
+    width: 2,
+    backgroundColor: 'rgba(231,115,51,0.25)',
+  },
+  eraBlock: { position: 'relative', marginBottom: 26 },
+  eraDot: {
+    position: 'absolute',
+    left: -26,
+    top: 3,
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: COLORS.orange,
+    borderWidth: 3,
+    borderColor: COLORS.beige,
+  },
+  eraHead: { flexDirection: 'row', alignItems: 'baseline', gap: 10, marginBottom: 12 },
+  eraName: { fontFamily: 'Flame-Regular', fontSize: 18, color: COLORS.navy },
+  eraYears: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    color: 'rgba(41,60,67,0.5)',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  heroScroll: { marginLeft: -41 },
+  heroStrip: { gap: 12, paddingLeft: 41, paddingRight: 15 },
+  card: { width: 88 },
+  cardImgWrap: {
+    width: 88,
+    height: 118,
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+    marginBottom: 6,
+  },
+  cardName: { fontFamily: 'Flame-Regular', fontSize: 13, color: COLORS.navy, lineHeight: 15 },
+  cardYear: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: 'rgba(41,60,67,0.5)', marginTop: 1 },
+});

--- a/src/components/home/GreatestRivalries.tsx
+++ b/src/components/home/GreatestRivalries.tsx
@@ -1,0 +1,164 @@
+// src/components/home/GreatestRivalries.tsx — native "Settle the Debate" carousel.
+// Each card is a split-portrait matchup that taps straight into the compare arena.
+import { View, Text, ScrollView, StyleSheet, Dimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { HeroImage } from '../HeroImage';
+import { VsBadge } from '../compare/VsBadge';
+import { PressScale } from '../ui/PressScale';
+import { COLORS } from '../../constants/colors';
+import type { Rivalry } from '../../lib/db/heroes';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_W = Math.min(296, Math.round(SCREEN_WIDTH * 0.78));
+const CARD_H = Math.round(CARD_W * 0.57);
+
+function RivalryCard({ r, onPress }: { r: Rivalry; onPress: () => void }) {
+  return (
+    <PressScale onPress={onPress} scale={0.96} style={c.card}>
+      <HeroImage
+        id={r.a.id}
+        name={r.a.name}
+        imageUrl={r.a.image_url}
+        portraitUrl={r.a.portrait_url}
+        style={c.faceA}
+        contentFit="cover"
+        contentPosition="top"
+      />
+      <HeroImage
+        id={r.b.id}
+        name={r.b.name}
+        imageUrl={r.b.image_url}
+        portraitUrl={r.b.portrait_url}
+        style={c.faceB}
+        contentFit="cover"
+        contentPosition="top"
+      />
+      {/* Soft dark seam so the two portraits read as one matchup. */}
+      <LinearGradient
+        colors={['transparent', 'rgba(11,24,32,0.55)', 'transparent']}
+        locations={[0, 0.5, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 0 }}
+        style={c.seam}
+      />
+      <LinearGradient
+        colors={['transparent', 'rgba(11,24,32,0.95)']}
+        locations={[0.5, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <View style={c.vsWrap}>
+        <VsBadge size={40} variant="solid" />
+      </View>
+      {r.crossUniverse ? (
+        <View style={c.dreamTag}>
+          <Text style={c.dreamText}>Dream Match</Text>
+        </View>
+      ) : null}
+      <View style={c.names}>
+        <Text style={c.name} numberOfLines={1}>
+          {r.a.name}
+        </Text>
+        <Text style={[c.name, c.nameRight]} numberOfLines={1}>
+          {r.b.name}
+        </Text>
+      </View>
+    </PressScale>
+  );
+}
+
+/** Explore carousel of iconic rivalries — each card taps into the matchup arena. */
+export function GreatestRivalries({
+  rivalries,
+  onOpen,
+}: {
+  rivalries: Rivalry[];
+  onOpen: (path: string) => void;
+}) {
+  if (rivalries.length === 0) return null;
+  return (
+    <View style={c.section}>
+      <View style={c.header}>
+        <View style={c.accentBar} />
+        <View style={c.headerText}>
+          <Text style={c.label}>Settle the Debate</Text>
+          <Text style={c.title}>Greatest Rivalries</Text>
+        </View>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={c.row}>
+        {rivalries.map((r) => (
+          <RivalryCard
+            key={`${r.a.id}-${r.b.id}`}
+            r={r}
+            onPress={() => onOpen(`/compare/${r.a.id}/${r.b.id}`)}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const c = StyleSheet.create({
+  section: { paddingTop: 14, paddingBottom: 16 },
+  header: {
+    paddingHorizontal: 15,
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+  },
+  accentBar: { width: 4, borderRadius: 2, backgroundColor: COLORS.orange },
+  headerText: { gap: 2, justifyContent: 'center' },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: COLORS.orange,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+  row: { gap: 12, paddingHorizontal: 15, paddingBottom: 4 },
+  card: {
+    width: CARD_W,
+    height: CARD_H,
+    borderRadius: 14,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+  },
+  faceA: { position: 'absolute', top: 0, left: 0, width: '50%', height: '100%' },
+  faceB: { position: 'absolute', top: 0, right: 0, width: '50%', height: '100%' },
+  seam: { position: 'absolute', top: 0, bottom: 0, left: '50%', width: 60, marginLeft: -30 },
+  vsWrap: { position: 'absolute', top: '50%', left: '50%', marginLeft: -20, marginTop: -20 },
+  dreamTag: {
+    position: 'absolute',
+    top: 9,
+    alignSelf: 'center',
+    backgroundColor: 'rgba(206,155,51,0.92)',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+  },
+  dreamText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: '#1b1206',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  names: {
+    position: 'absolute',
+    bottom: 10,
+    left: 12,
+    right: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  name: {
+    flex: 1,
+    fontFamily: 'Flame-Regular',
+    fontSize: 14,
+    color: COLORS.beige,
+  },
+  nameRight: { textAlign: 'right' },
+});

--- a/src/components/home/HallOfInfamy.tsx
+++ b/src/components/home/HallOfInfamy.tsx
@@ -1,0 +1,125 @@
+// src/components/home/HallOfInfamy.tsx — native "Public Enemies" carousel.
+// Villains ranked by enemy in-degree (how many heroes line up against them).
+import { View, Text, ScrollView, StyleSheet, Dimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { HeroImage } from '../HeroImage';
+import { PressScale } from '../ui/PressScale';
+import { COLORS } from '../../constants/colors';
+import type { FearedVillain } from '../../lib/db/heroes';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_W = Math.round(SCREEN_WIDTH * 0.42);
+const CARD_H = Math.round(CARD_W * 1.33);
+
+function FearedCard({
+  villain,
+  rank,
+  onPress,
+}: {
+  villain: FearedVillain;
+  rank: number;
+  onPress: () => void;
+}) {
+  return (
+    <PressScale onPress={onPress} scale={0.95} style={c.card}>
+      <HeroImage
+        id={villain.id}
+        name={villain.name}
+        imageUrl={villain.image_url}
+        portraitUrl={villain.portrait_url}
+        contentFit="cover"
+        contentPosition="top"
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={['rgba(11,24,32,0.96)', 'rgba(11,24,32,0.05)', 'transparent']}
+        locations={[0, 0.52, 1]}
+        start={{ x: 0, y: 1 }}
+        end={{ x: 0, y: 0 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <Text style={c.rank}>{rank}</Text>
+      <View style={c.bottom}>
+        <Text style={c.name} numberOfLines={1}>
+          {villain.name}
+        </Text>
+        <Text style={c.feared}>Feared by {villain.fearedBy} heroes</Text>
+      </View>
+    </PressScale>
+  );
+}
+
+/** Explore carousel — the villains the most heroes count as an enemy. */
+export function HallOfInfamy({
+  villains,
+  onPress,
+}: {
+  villains: FearedVillain[];
+  onPress: (id: string) => void;
+}) {
+  if (villains.length === 0) return null;
+  return (
+    <View style={c.section}>
+      <View style={c.header}>
+        <View style={c.accentBar} />
+        <View style={c.headerText}>
+          <Text style={c.label}>Public Enemies</Text>
+          <Text style={c.title}>Most Feared</Text>
+        </View>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={c.row}>
+        {villains.map((v, i) => (
+          <FearedCard key={v.id} villain={v} rank={i + 1} onPress={() => onPress(v.id)} />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const c = StyleSheet.create({
+  section: { paddingTop: 14, paddingBottom: 16 },
+  header: {
+    paddingHorizontal: 15,
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+  },
+  accentBar: { width: 4, borderRadius: 2, backgroundColor: COLORS.orange },
+  headerText: { gap: 2, justifyContent: 'center' },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: COLORS.orange,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+  row: { gap: 12, paddingHorizontal: 15, paddingBottom: 4 },
+  card: {
+    width: CARD_W,
+    height: CARD_H,
+    borderRadius: 12,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.navy,
+  },
+  rank: {
+    position: 'absolute',
+    top: 2,
+    left: 10,
+    fontFamily: 'Flame-Regular',
+    fontSize: 44,
+    color: 'rgba(245,235,220,0.92)',
+  },
+  bottom: { position: 'absolute', bottom: 11, left: 12, right: 12 },
+  name: { fontFamily: 'Flame-Regular', fontSize: 16, color: COLORS.beige },
+  feared: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    color: '#E8543B',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+    marginTop: 2,
+  },
+});

--- a/src/components/home/PulseTicker.tsx
+++ b/src/components/home/PulseTicker.tsx
@@ -1,0 +1,73 @@
+// src/components/home/PulseTicker.tsx — native auto-scrolling marquee strip.
+// Two identical copies sit in a row; the track translates left by exactly one
+// copy's width on a linear loop, so the seam is invisible. Mirrors the web
+// PulseTicker's content (the web one uses a raw-DOM CSS keyframe; native drives
+// it with Reanimated instead).
+import { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  Easing,
+  cancelAnimation,
+} from 'react-native-reanimated';
+import { COLORS } from '../../constants/colors';
+
+interface PulseTickerProps {
+  heroCount: number;
+  newlyAddedCount: number;
+}
+
+const SPEED = 45; // px per second — steady, readable drift
+
+export function PulseTicker({ heroCount, newlyAddedCount }: PulseTickerProps) {
+  const text = `${heroCount.toLocaleString()} Heroes & Villains  ·  Marvel, DC & Beyond  ·  Powers, Origins & First Appearances  ·  500+ Teams & Affiliations  ·  ${newlyAddedCount} Recently Added  ·  `;
+  const [copyW, setCopyW] = useState(0);
+  const tx = useSharedValue(0);
+
+  const onCopyLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w > 0 && Math.abs(w - copyW) > 1) setCopyW(w);
+  };
+
+  useEffect(() => {
+    if (copyW <= 0) return;
+    tx.value = 0;
+    tx.value = withRepeat(
+      withTiming(-copyW, { duration: (copyW / SPEED) * 1000, easing: Easing.linear }),
+      -1,
+      false,
+    );
+    return () => cancelAnimation(tx);
+  }, [copyW, tx]);
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: tx.value }] }));
+
+  return (
+    <View style={s.wrap} pointerEvents="none">
+      <Animated.View style={[s.track, style]}>
+        <Text style={s.text} numberOfLines={1} onLayout={onCopyLayout}>
+          {text}
+        </Text>
+        <Text style={s.text} numberOfLines={1}>
+          {text}
+        </Text>
+      </Animated.View>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: { backgroundColor: COLORS.orange, paddingVertical: 10, overflow: 'hidden' },
+  track: { flexDirection: 'row', flexShrink: 0 },
+  text: {
+    flexShrink: 0,
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: 'rgba(255,255,255,0.88)',
+  },
+});

--- a/src/components/home/TodaysMatchup.tsx
+++ b/src/components/home/TodaysMatchup.tsx
@@ -1,0 +1,327 @@
+// src/components/home/TodaysMatchup.tsx — native "Today's Battle" card.
+// A daily, deterministic matchup (see src/lib/matchup.ts) with a "Who would win?"
+// vote: tap a fighter to cast a pick, which persists for the day and reveals the
+// stat scorecard ("tale of the tape") + the AI verdict. The card taps through to
+// the full compare arena.
+import { useEffect, useState, useCallback } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Haptics from 'expo-haptics';
+import { HeroImage } from '../HeroImage';
+import { COLORS } from '../../constants/colors';
+import {
+  matchupVoteKey,
+  statSplit,
+  statLead,
+  type MatchupSide,
+} from '../../lib/home/matchupVote';
+import type { TodaysMatchup as Matchup } from '../../lib/matchup';
+
+const PORTRAIT = 96;
+
+function Fighter({
+  hero,
+  side,
+  picked,
+  dimmed,
+  onVote,
+}: {
+  hero: Matchup['heroA'];
+  side: MatchupSide;
+  picked: boolean;
+  dimmed: boolean;
+  onVote: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onVote}
+      style={[
+        m.portrait,
+        side === 'b' && m.portraitB,
+        picked && m.portraitPicked,
+        dimmed && m.portraitDimmed,
+      ]}
+    >
+      <HeroImage
+        id={hero.id}
+        name={hero.name}
+        imageUrl={hero.image_url}
+        portraitUrl={hero.portrait_url}
+        contentFit="cover"
+        contentPosition="top"
+        style={StyleSheet.absoluteFill}
+        recyclingKey={hero.id}
+      />
+      {picked && (
+        <View style={m.pickedTag}>
+          <Text style={m.pickedTagText}>Your pick</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+export function TodaysMatchup({
+  matchup,
+  onOpen,
+}: {
+  matchup: Matchup;
+  onOpen: (path: string) => void;
+}) {
+  const { heroA, heroB, winsA, winsB } = matchup;
+  const [vote, setVote] = useState<MatchupSide | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const key = matchupVoteKey(heroA.id, heroB.id);
+
+  // Restore any pick made earlier today so the reveal persists across launches.
+  useEffect(() => {
+    let active = true;
+    AsyncStorage.getItem(key)
+      .then((v) => {
+        if (!active) return;
+        if (v === 'a' || v === 'b') setVote(v);
+        setLoaded(true);
+      })
+      .catch(() => active && setLoaded(true));
+    return () => {
+      active = false;
+    };
+  }, [key]);
+
+  const castVote = useCallback(
+    (side: MatchupSide) => {
+      if (vote) return; // one vote per day's matchup
+      setVote(side);
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      AsyncStorage.setItem(key, side).catch(() => {});
+    },
+    [vote, key],
+  );
+
+  const { pctA, pctB } = statSplit(winsA, winsB);
+  const revealed = vote !== null;
+
+  return (
+    <View style={m.section}>
+      <View style={m.header}>
+        <View style={m.accentBar} />
+        <View style={m.headerText}>
+          <Text style={m.label}>Daily</Text>
+          <Text style={m.title}>{"Today's Battle"}</Text>
+        </View>
+      </View>
+
+      <View style={m.card}>
+        <View style={m.fighters}>
+          <Fighter
+            hero={heroA}
+            side="a"
+            picked={vote === 'a'}
+            dimmed={revealed && vote !== 'a'}
+            onVote={() => castVote('a')}
+          />
+          <View style={m.vsBadge}>
+            <Text style={m.vsText}>VS</Text>
+          </View>
+          <Fighter
+            hero={heroB}
+            side="b"
+            picked={vote === 'b'}
+            dimmed={revealed && vote !== 'b'}
+            onVote={() => castVote('b')}
+          />
+        </View>
+
+        <Text style={m.matchTitle} numberOfLines={1}>
+          {heroA.name} vs {heroB.name}
+        </Text>
+
+        {!loaded ? null : !revealed ? (
+          <>
+            <Text style={m.prompt}>Who would win? Tap your pick.</Text>
+            <View style={m.voteRow}>
+              <Pressable style={m.voteBtn} onPress={() => castVote('a')}>
+                <Text style={m.voteBtnText} numberOfLines={1}>
+                  {heroA.name}
+                </Text>
+              </Pressable>
+              <Pressable style={m.voteBtn} onPress={() => castVote('b')}>
+                <Text style={m.voteBtnText} numberOfLines={1}>
+                  {heroB.name}
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        ) : (
+          <>
+            {/* Tale of the tape — the stat scorecard split. */}
+            <View style={m.barTrack}>
+              <View style={[m.barFillA, { flex: Math.max(pctA, 1) }]} />
+              <View style={[m.barFillB, { flex: Math.max(pctB, 1) }]} />
+            </View>
+            <View style={m.barLabels}>
+              <Text style={[m.barPct, { color: COLORS.orange }]}>{pctA}%</Text>
+              <Text style={m.lead}>{statLead(winsA, winsB, heroA.name, heroB.name)}</Text>
+              <Text style={[m.barPct, { color: COLORS.blue }]}>{pctB}%</Text>
+            </View>
+            <Text style={m.verdict} numberOfLines={3}>
+              “{matchup.verdict}”
+            </Text>
+            <Pressable
+              onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)}
+              style={m.linkRow}
+            >
+              <Text style={m.link}>See full breakdown →</Text>
+            </Pressable>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const m = StyleSheet.create({
+  section: { paddingTop: 14, paddingBottom: 16 },
+  header: {
+    paddingHorizontal: 15,
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 11,
+  },
+  accentBar: { width: 4, borderRadius: 2, backgroundColor: COLORS.orange },
+  headerText: { gap: 2, justifyContent: 'center' },
+  label: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    color: COLORS.orange,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 24, color: COLORS.navy, lineHeight: 28 },
+
+  card: {
+    marginHorizontal: 15,
+    backgroundColor: COLORS.navy,
+    borderRadius: 18,
+    borderCurve: 'continuous',
+    paddingVertical: 20,
+    paddingHorizontal: 18,
+    alignItems: 'center',
+  },
+  fighters: { flexDirection: 'row', alignItems: 'center', marginBottom: 14 },
+  portrait: {
+    width: PORTRAIT,
+    height: PORTRAIT,
+    borderRadius: 16,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+    backgroundColor: COLORS.deepNavy,
+    borderWidth: 2,
+    borderColor: 'rgba(11,24,32,0.9)',
+  },
+  portraitB: { marginLeft: -14 },
+  portraitPicked: { borderColor: COLORS.orange },
+  portraitDimmed: { opacity: 0.5 },
+  pickedTag: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: COLORS.orange,
+    paddingVertical: 2,
+    alignItems: 'center',
+  },
+  pickedTagText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 8,
+    color: '#fff',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  vsBadge: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    marginHorizontal: -12,
+    zIndex: 2,
+    backgroundColor: COLORS.orange,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: COLORS.deepNavy,
+  },
+  vsText: { fontFamily: 'Flame-Regular', fontSize: 13, color: '#fff' },
+
+  matchTitle: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 20,
+    color: COLORS.beige,
+    lineHeight: 24,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  prompt: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: 'rgba(245,235,220,0.7)',
+    marginBottom: 12,
+  },
+  voteRow: { flexDirection: 'row', gap: 10, alignSelf: 'stretch' },
+  voteBtn: {
+    flex: 1,
+    backgroundColor: 'rgba(245,235,220,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(245,235,220,0.18)',
+    borderRadius: 24,
+    paddingVertical: 11,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+  voteBtnText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 13,
+    color: COLORS.beige,
+  },
+
+  barTrack: {
+    flexDirection: 'row',
+    alignSelf: 'stretch',
+    height: 10,
+    borderRadius: 5,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(245,235,220,0.1)',
+    marginBottom: 8,
+  },
+  barFillA: { backgroundColor: COLORS.orange },
+  barFillB: { backgroundColor: COLORS.blue },
+  barLabels: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    alignSelf: 'stretch',
+    gap: 8,
+    marginBottom: 12,
+  },
+  barPct: { fontFamily: 'Flame-Regular', fontSize: 15 },
+  lead: {
+    flex: 1,
+    textAlign: 'center',
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: 'rgba(245,235,220,0.5)',
+  },
+  verdict: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    fontStyle: 'italic',
+    color: 'rgba(245,235,220,0.72)',
+    lineHeight: 19,
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  linkRow: { alignSelf: 'center' },
+  link: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.orange, letterSpacing: 0.3 },
+});

--- a/src/components/home/TodaysMatchup.tsx
+++ b/src/components/home/TodaysMatchup.tsx
@@ -1,20 +1,17 @@
 // src/components/home/TodaysMatchup.tsx — native "Today's Battle" card.
 // A daily, deterministic matchup (see src/lib/matchup.ts) with a "Who would win?"
-// vote: tap a fighter to cast a pick, which persists for the day and reveals the
-// stat scorecard ("tale of the tape") + the AI verdict. The card taps through to
-// the full compare arena.
+// vote. Tapping a fighter casts a community vote (matchup_votes via the
+// cast_matchup_vote RPC) and reveals the crowd split + AI verdict. The local
+// AsyncStorage pick is kept as an offline fallback so the reveal still persists
+// when the network call fails. The card taps through to the full compare arena.
 import { useEffect, useState, useCallback } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Haptics from 'expo-haptics';
 import { HeroImage } from '../HeroImage';
 import { COLORS } from '../../constants/colors';
-import {
-  matchupVoteKey,
-  statSplit,
-  statLead,
-  type MatchupSide,
-} from '../../lib/home/matchupVote';
+import { matchupVoteKey, statSplit, statLead, type MatchupSide } from '../../lib/home/matchupVote';
+import { getMatchupTally, castMatchupVote, type MatchupTally } from '../../lib/db/matchupVotes';
 import type { TodaysMatchup as Matchup } from '../../lib/matchup';
 
 const PORTRAIT = 96;
@@ -49,7 +46,7 @@ function Fighter({
         portraitUrl={hero.portrait_url}
         contentFit="cover"
         contentPosition="top"
-        style={StyleSheet.absoluteFill}
+        style={[StyleSheet.absoluteFill, side === 'b' && m.faceInward]}
         recyclingKey={hero.id}
       />
       {picked && (
@@ -69,37 +66,60 @@ export function TodaysMatchup({
   onOpen: (path: string) => void;
 }) {
   const { heroA, heroB, winsA, winsB } = matchup;
-  const [vote, setVote] = useState<MatchupSide | null>(null);
+  const [pickedId, setPickedId] = useState<string | null>(null);
+  const [tally, setTally] = useState<MatchupTally | null>(null);
   const [loaded, setLoaded] = useState(false);
   const key = matchupVoteKey(heroA.id, heroB.id);
 
-  // Restore any pick made earlier today so the reveal persists across launches.
+  // Restore the crowd tally (and the caller's prior pick) from the server, with
+  // the local pick as an offline fallback so the reveal persists either way.
   useEffect(() => {
     let active = true;
-    AsyncStorage.getItem(key)
-      .then((v) => {
+    getMatchupTally(heroA.id, heroB.id)
+      .then(async (t) => {
         if (!active) return;
-        if (v === 'a' || v === 'b') setVote(v);
-        setLoaded(true);
+        if (t) {
+          setTally(t);
+          if (t.myPick) setPickedId(t.myPick);
+        }
+        if (!t || !t.myPick) {
+          const local = await AsyncStorage.getItem(key).catch(() => null);
+          if (active && (local === 'a' || local === 'b')) {
+            setPickedId(local === 'a' ? heroA.id : heroB.id);
+          }
+        }
+        if (active) setLoaded(true);
       })
       .catch(() => active && setLoaded(true));
     return () => {
       active = false;
     };
-  }, [key]);
+  }, [key, heroA.id, heroB.id]);
 
   const castVote = useCallback(
     (side: MatchupSide) => {
-      if (vote) return; // one vote per day's matchup
-      setVote(side);
+      if (pickedId) return; // one vote per day's matchup
+      const picked = side === 'a' ? heroA.id : heroB.id;
+      setPickedId(picked); // optimistic
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       AsyncStorage.setItem(key, side).catch(() => {});
+      castMatchupVote(heroA.id, heroB.id, picked)
+        .then((t) => t && setTally(t))
+        .catch(() => {});
     },
-    [vote, key],
+    [pickedId, key, heroA.id, heroB.id],
   );
 
-  const { pctA, pctB } = statSplit(winsA, winsB);
-  const revealed = vote !== null;
+  const revealed = pickedId !== null;
+  // The bar shows the crowd split once anyone has voted; before that it falls
+  // back to the stat scorecard so the reveal is never an empty 50/50.
+  const usingVotes = !!tally && tally.total > 0;
+  const { pctA, pctB } = usingVotes
+    ? statSplit(tally!.votesA, tally!.votesB)
+    : statSplit(winsA, winsB);
+  const caption = usingVotes
+    ? `${tally!.total} ${tally!.total === 1 ? 'fan' : 'fans'} voted`
+    : statLead(winsA, winsB, heroA.name, heroB.name);
 
   return (
     <View style={m.section}>
@@ -116,8 +136,8 @@ export function TodaysMatchup({
           <Fighter
             hero={heroA}
             side="a"
-            picked={vote === 'a'}
-            dimmed={revealed && vote !== 'a'}
+            picked={pickedId === heroA.id}
+            dimmed={revealed && pickedId !== heroA.id}
             onVote={() => castVote('a')}
           />
           <View style={m.vsBadge}>
@@ -126,8 +146,8 @@ export function TodaysMatchup({
           <Fighter
             hero={heroB}
             side="b"
-            picked={vote === 'b'}
-            dimmed={revealed && vote !== 'b'}
+            picked={pickedId === heroB.id}
+            dimmed={revealed && pickedId !== heroB.id}
             onVote={() => castVote('b')}
           />
         </View>
@@ -154,23 +174,19 @@ export function TodaysMatchup({
           </>
         ) : (
           <>
-            {/* Tale of the tape — the stat scorecard split. */}
             <View style={m.barTrack}>
               <View style={[m.barFillA, { flex: Math.max(pctA, 1) }]} />
               <View style={[m.barFillB, { flex: Math.max(pctB, 1) }]} />
             </View>
             <View style={m.barLabels}>
               <Text style={[m.barPct, { color: COLORS.orange }]}>{pctA}%</Text>
-              <Text style={m.lead}>{statLead(winsA, winsB, heroA.name, heroB.name)}</Text>
+              <Text style={m.lead}>{caption}</Text>
               <Text style={[m.barPct, { color: COLORS.blue }]}>{pctB}%</Text>
             </View>
             <Text style={m.verdict} numberOfLines={3}>
               “{matchup.verdict}”
             </Text>
-            <Pressable
-              onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)}
-              style={m.linkRow}
-            >
+            <Pressable onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)} style={m.linkRow}>
               <Text style={m.link}>See full breakdown →</Text>
             </Pressable>
           </>
@@ -221,6 +237,8 @@ const m = StyleSheet.create({
     borderColor: 'rgba(11,24,32,0.9)',
   },
   portraitB: { marginLeft: -14 },
+  // Mirror the right fighter so they face inward, toward the left fighter.
+  faceInward: { transform: [{ scaleX: -1 }] },
   portraitPicked: { borderColor: COLORS.orange },
   portraitDimmed: { opacity: 0.5 },
   pickedTag: {

--- a/src/components/web/home/TodaysMatchup.tsx
+++ b/src/components/web/home/TodaysMatchup.tsx
@@ -1,7 +1,15 @@
+import { useEffect, useState, useCallback } from 'react';
 import { View, Text, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { COLORS } from '../../../constants/colors';
 import { HeroImage } from '../../HeroImage';
 import { useSkeletonAnim, SkeletonBlock } from '../Skeleton';
+import {
+  matchupVoteKey,
+  statSplit,
+  statLead,
+  type MatchupSide,
+} from '../../../lib/home/matchupVote';
 import type { TodaysMatchup as Matchup } from '../../../lib/matchup';
 
 interface TodaysMatchupProps {
@@ -13,18 +21,27 @@ function Fighter({
   hero,
   side,
   size = PORTRAIT,
+  picked,
+  dimmed,
+  onVote,
 }: {
   hero: Matchup['heroA'];
   side: 'a' | 'b';
   size?: number;
+  picked: boolean;
+  dimmed: boolean;
+  onVote: () => void;
 }) {
   return (
-    <View
+    <Pressable
+      onPress={onVote}
       style={
         [
           m.portrait,
           { width: size, height: size },
           side === 'b' && (m.portraitB as object),
+          picked && (m.portraitPicked as object),
+          dimmed && (m.portraitDimmed as object),
         ] as object
       }
     >
@@ -38,78 +55,196 @@ function Fighter({
         style={StyleSheet.absoluteFill}
         recyclingKey={hero.id}
       />
-    </View>
+      {picked && (
+        <View style={m.pickedTag as object}>
+          <Text style={m.pickedTagText as object}>Your pick</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+// The post-vote reveal: stat scorecard split bar + lead line + AI verdict + link.
+function Result({
+  matchup,
+  onOpen,
+  centered,
+}: {
+  matchup: Matchup;
+  onOpen: (path: string) => void;
+  centered?: boolean;
+}) {
+  const { heroA, heroB, winsA, winsB } = matchup;
+  const { pctA, pctB } = statSplit(winsA, winsB);
+  return (
+    <>
+      <View style={m.barTrack as object}>
+        <View style={[m.barFillA, { flex: Math.max(pctA, 1) }] as object} />
+        <View style={[m.barFillB, { flex: Math.max(pctB, 1) }] as object} />
+      </View>
+      <View style={m.barLabels as object}>
+        <Text style={[m.barPct, { color: COLORS.orange }] as object}>{pctA}%</Text>
+        <Text style={m.lead as object}>{statLead(winsA, winsB, heroA.name, heroB.name)}</Text>
+        <Text style={[m.barPct, { color: COLORS.blue }] as object}>{pctB}%</Text>
+      </View>
+      <Text style={[m.verdict, centered && (m.textCenter as object)] as object} numberOfLines={3}>
+        “{matchup.verdict}”
+      </Text>
+      <Pressable onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)} style={m.linkRow as object}>
+        <Text style={m.link}>See full breakdown →</Text>
+      </Pressable>
+    </>
+  );
+}
+
+function VotePrompt({
+  heroA,
+  heroB,
+  onVote,
+  centered,
+}: {
+  heroA: Matchup['heroA'];
+  heroB: Matchup['heroB'];
+  onVote: (side: MatchupSide) => void;
+  centered?: boolean;
+}) {
+  return (
+    <>
+      <Text style={[m.prompt, centered && (m.textCenter as object)] as object}>
+        Who would win? Cast your vote.
+      </Text>
+      <View style={m.voteRow as object}>
+        <Pressable
+          onPress={() => onVote('a')}
+          style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+            [m.voteBtn, hovered && (m.voteBtnHover as object)] as object
+          }
+        >
+          <Text style={m.voteBtnText} numberOfLines={1}>
+            {heroA.name}
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={() => onVote('b')}
+          style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
+            [m.voteBtn, hovered && (m.voteBtnHover as object)] as object
+          }
+        >
+          <Text style={m.voteBtnText} numberOfLines={1}>
+            {heroB.name}
+          </Text>
+        </Pressable>
+      </View>
+    </>
   );
 }
 
 export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
-  const { heroA, heroB, winsA, winsB } = matchup;
-  const lead =
-    winsA === winsB ? 'Evenly matched' : `${winsA > winsB ? heroA.name : heroB.name} leads`;
+  const { heroA, heroB } = matchup;
 
-  // ── Mobile: a centred "fight poster" — face-off portraits on top, then the
-  // verdict. Same content + tokens as the desktop card, reflowed vertically. ──
+  const [vote, setVote] = useState<MatchupSide | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const key = matchupVoteKey(heroA.id, heroB.id);
+
+  useEffect(() => {
+    let active = true;
+    AsyncStorage.getItem(key)
+      .then((v) => {
+        if (!active) return;
+        if (v === 'a' || v === 'b') setVote(v);
+        setLoaded(true);
+      })
+      .catch(() => active && setLoaded(true));
+    return () => {
+      active = false;
+    };
+  }, [key]);
+
+  const castVote = useCallback(
+    (side: MatchupSide) => {
+      if (vote) return;
+      setVote(side);
+      AsyncStorage.setItem(key, side).catch(() => {});
+    },
+    [vote, key],
+  );
+
+  const revealed = vote !== null;
+
+  // ── Mobile: a centred "fight poster" — face-off portraits, then vote / reveal ──
   if (!isDesktop) {
     return (
-      <Pressable
-        onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)}
-        style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
-          [m.card, m.cardMobile, hovered && (m.cardHover as object)] as object
-        }
-      >
-        <Text style={[m.eyebrow, m.textCenter] as object}>⚔ Today's Battle</Text>
-        <View style={m.fightersMobile}>
-          <Fighter hero={heroA} side="a" size={92} />
+      <View style={[m.card, m.cardMobile] as object}>
+        <Text style={[m.eyebrow, m.textCenter] as object}>⚔ Today&apos;s Battle</Text>
+        <View style={m.fightersMobile as object}>
+          <Fighter
+            hero={heroA}
+            side="a"
+            size={92}
+            picked={vote === 'a'}
+            dimmed={revealed && vote !== 'a'}
+            onVote={() => castVote('a')}
+          />
           <View style={m.vsBadge as object}>
             <Text style={m.vsText}>VS</Text>
           </View>
-          <Fighter hero={heroB} side="b" size={92} />
+          <Fighter
+            hero={heroB}
+            side="b"
+            size={92}
+            picked={vote === 'b'}
+            dimmed={revealed && vote !== 'b'}
+            onVote={() => castVote('b')}
+          />
         </View>
         <Text style={[m.title, m.textCenter] as object} numberOfLines={1}>
           {heroA.name} vs {heroB.name}
         </Text>
-        <Text style={[m.verdict, m.textCenter] as object} numberOfLines={3}>
-          “{matchup.verdict}”
-        </Text>
-        <View style={m.footerMobile}>
-          <Text style={m.lead}>{lead}</Text>
-          <Text style={m.link}>See full breakdown →</Text>
-        </View>
-      </Pressable>
+        {!loaded ? null : revealed ? (
+          <Result matchup={matchup} onOpen={onOpen} centered />
+        ) : (
+          <VotePrompt heroA={heroA} heroB={heroB} onVote={castVote} centered />
+        )}
+      </View>
     );
   }
 
   return (
-    <Pressable
-      onPress={() => onOpen(`/compare/${heroA.id}/${heroB.id}`)}
-      style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
-        [m.card, m.cardDesktop, hovered && (m.cardHover as object)] as object
-      }
-    >
+    <View style={[m.card, m.cardDesktop] as object}>
       <View style={m.fighters}>
-        <Fighter hero={heroA} side="a" />
+        <Fighter
+          hero={heroA}
+          side="a"
+          picked={vote === 'a'}
+          dimmed={revealed && vote !== 'a'}
+          onVote={() => castVote('a')}
+        />
         <View style={m.vsBadge as object}>
           <Text style={m.vsText}>VS</Text>
         </View>
-        <Fighter hero={heroB} side="b" />
+        <Fighter
+          hero={heroB}
+          side="b"
+          picked={vote === 'b'}
+          dimmed={revealed && vote !== 'b'}
+          onVote={() => castVote('b')}
+        />
       </View>
 
       <View style={m.info}>
-        <Text style={m.eyebrow as object}>⚔ Today's Battle</Text>
+        <Text style={m.eyebrow as object}>⚔ Today&apos;s Battle</Text>
         <Text style={m.title} numberOfLines={1}>
           {heroA.name} vs {heroB.name}
         </Text>
-        <Text style={m.verdict} numberOfLines={2}>
-          “{matchup.verdict}”
-        </Text>
-        <View style={m.footer}>
-          <Text style={m.lead}>{lead}</Text>
-          <Text style={m.link}>See full breakdown →</Text>
-        </View>
+        {!loaded ? null : revealed ? (
+          <Result matchup={matchup} onOpen={onOpen} />
+        ) : (
+          <VotePrompt heroA={heroA} heroB={heroB} onVote={castVote} />
+        )}
       </View>
-    </Pressable>
+    </View>
   );
 }
 
@@ -127,14 +262,14 @@ export function TodaysMatchupSkeleton() {
     return (
       <View style={[m.card, m.cardMobile] as object}>
         <SkeletonBlock opacity={opacity} dark width={110} height={9} />
-        <View style={m.fightersMobile}>
+        <View style={m.fightersMobile as object}>
           <SkeletonBlock opacity={opacity} dark width={92} height={92} borderRadius={14} />
           <View style={[m.vsBadge, { backgroundColor: 'rgba(245,235,220,0.15)' }] as object} />
           <SkeletonBlock opacity={opacity} dark width={92} height={92} borderRadius={14} />
         </View>
         <SkeletonBlock opacity={opacity} dark width={200} height={20} />
         <SkeletonBlock opacity={opacity} dark width={260} height={14} />
-        <View style={m.footerMobile}>
+        <View style={m.footerMobile as object}>
           <SkeletonBlock opacity={opacity} dark width={90} height={10} />
           <SkeletonBlock opacity={opacity} dark width={120} height={10} />
         </View>
@@ -145,13 +280,7 @@ export function TodaysMatchupSkeleton() {
   return (
     <View style={[m.card, m.cardDesktop] as object}>
       <View style={m.fighters}>
-        <SkeletonBlock
-          opacity={opacity}
-          dark
-          width={PORTRAIT}
-          height={PORTRAIT}
-          borderRadius={14}
-        />
+        <SkeletonBlock opacity={opacity} dark width={PORTRAIT} height={PORTRAIT} borderRadius={14} />
         <View
           style={
             [
@@ -160,24 +289,12 @@ export function TodaysMatchupSkeleton() {
             ] as object
           }
         />
-        <SkeletonBlock
-          opacity={opacity}
-          dark
-          width={PORTRAIT}
-          height={PORTRAIT}
-          borderRadius={14}
-        />
+        <SkeletonBlock opacity={opacity} dark width={PORTRAIT} height={PORTRAIT} borderRadius={14} />
       </View>
       <View style={m.info}>
         <SkeletonBlock opacity={opacity} dark width={110} height={9} style={{ marginBottom: 8 }} />
         <SkeletonBlock opacity={opacity} dark width={220} height={20} style={{ marginBottom: 8 }} />
-        <SkeletonBlock
-          opacity={opacity}
-          dark
-          width="80%"
-          height={14}
-          style={{ marginBottom: 12 }}
-        />
+        <SkeletonBlock opacity={opacity} dark width="80%" height={14} style={{ marginBottom: 12 }} />
         <View style={m.footer}>
           <SkeletonBlock opacity={opacity} dark width={90} height={10} />
           <SkeletonBlock opacity={opacity} dark width={120} height={10} />
@@ -200,8 +317,6 @@ const m = StyleSheet.create({
     borderRadius: 16,
     padding: 18,
     marginTop: 12,
-    cursor: 'pointer',
-    transition: 'background-color 150ms ease, transform 150ms ease',
   } as object,
   cardDesktop: { marginHorizontal: 32 } as object,
   cardMobile: {
@@ -211,7 +326,6 @@ const m = StyleSheet.create({
     paddingVertical: 22,
     marginHorizontal: 16,
   } as object,
-  cardHover: { backgroundColor: 'rgba(255,255,255,0.08)' } as object,
 
   fighters: { flexDirection: 'row', alignItems: 'center', flexShrink: 0 },
   fightersMobile: {
@@ -237,8 +351,28 @@ const m = StyleSheet.create({
     backgroundColor: COLORS.navy,
     borderWidth: 2,
     borderColor: 'rgba(11,24,32,0.9)',
+    cursor: 'pointer',
+    transition: 'opacity 150ms ease, border-color 150ms ease',
   } as object,
   portraitB: { marginLeft: -16 } as object,
+  portraitPicked: { borderColor: COLORS.orange } as object,
+  portraitDimmed: { opacity: 0.5 } as object,
+  pickedTag: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: COLORS.orange,
+    paddingVertical: 2,
+    alignItems: 'center',
+  } as object,
+  pickedTagText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 8,
+    color: '#fff',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  } as object,
   vsBadge: {
     width: 34,
     height: 34,
@@ -251,11 +385,7 @@ const m = StyleSheet.create({
     borderWidth: 2,
     borderColor: '#0b1820',
   } as object,
-  vsText: {
-    fontFamily: 'Flame-Regular',
-    fontSize: 12,
-    color: '#fff',
-  },
+  vsText: { fontFamily: 'Flame-Regular', fontSize: 12, color: '#fff' },
 
   info: { flex: 1, minWidth: 0 },
   eyebrow: {
@@ -271,8 +401,50 @@ const m = StyleSheet.create({
     fontSize: 22,
     color: COLORS.beige,
     lineHeight: 25,
-    marginBottom: 6,
+    marginBottom: 8,
   },
+  prompt: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: 'rgba(245,235,220,0.7)',
+    marginBottom: 10,
+  } as object,
+  voteRow: { flexDirection: 'row', gap: 10, alignSelf: 'stretch' } as object,
+  voteBtn: {
+    flex: 1,
+    backgroundColor: 'rgba(245,235,220,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(245,235,220,0.18)',
+    borderRadius: 24,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    cursor: 'pointer',
+    transition: 'background-color 150ms ease',
+  } as object,
+  voteBtnHover: { backgroundColor: 'rgba(245,235,220,0.14)' } as object,
+  voteBtnText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.beige },
+
+  barTrack: {
+    flexDirection: 'row',
+    alignSelf: 'stretch',
+    height: 10,
+    borderRadius: 5,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(245,235,220,0.1)',
+    marginBottom: 8,
+  } as object,
+  barFillA: { backgroundColor: COLORS.orange } as object,
+  barFillB: { backgroundColor: COLORS.blue } as object,
+  barLabels: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    alignSelf: 'stretch',
+    gap: 8,
+    marginBottom: 10,
+  } as object,
+  barPct: { fontFamily: 'Flame-Regular', fontSize: 15 } as object,
   verdict: {
     fontFamily: 'Nunito_400Regular',
     fontSize: 13,
@@ -283,12 +455,15 @@ const m = StyleSheet.create({
   },
   footer: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 12 },
   lead: {
+    flex: 1,
+    textAlign: 'center',
     fontFamily: 'Nunito_700Bold',
     fontSize: 10,
     letterSpacing: 0.5,
     textTransform: 'uppercase',
     color: 'rgba(245,235,220,0.45)',
   } as object,
+  linkRow: { alignSelf: 'flex-start', cursor: 'pointer' } as object,
   link: {
     fontFamily: 'Nunito_700Bold',
     fontSize: 11,

--- a/src/components/web/home/TodaysMatchup.tsx
+++ b/src/components/web/home/TodaysMatchup.tsx
@@ -4,12 +4,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { COLORS } from '../../../constants/colors';
 import { HeroImage } from '../../HeroImage';
 import { useSkeletonAnim, SkeletonBlock } from '../Skeleton';
+import { matchupVoteKey, statSplit, statLead, type MatchupSide } from '../../../lib/home/matchupVote';
 import {
-  matchupVoteKey,
-  statSplit,
-  statLead,
-  type MatchupSide,
-} from '../../../lib/home/matchupVote';
+  getMatchupTally,
+  castMatchupVote,
+  type MatchupTally,
+} from '../../../lib/db/matchupVotes';
 import type { TodaysMatchup as Matchup } from '../../../lib/matchup';
 
 interface TodaysMatchupProps {
@@ -52,7 +52,7 @@ function Fighter({
         portraitUrl={hero.portrait_url}
         contentFit="cover"
         contentPosition="top"
-        style={StyleSheet.absoluteFill}
+        style={[StyleSheet.absoluteFill, side === 'b' && (m.faceInward as object)]}
         recyclingKey={hero.id}
       />
       {picked && (
@@ -64,18 +64,27 @@ function Fighter({
   );
 }
 
-// The post-vote reveal: stat scorecard split bar + lead line + AI verdict + link.
+// The post-vote reveal: crowd split bar (falls back to the stat scorecard until
+// anyone has voted) + caption + AI verdict + link to the full breakdown.
 function Result({
   matchup,
+  tally,
   onOpen,
   centered,
 }: {
   matchup: Matchup;
+  tally: MatchupTally | null;
   onOpen: (path: string) => void;
   centered?: boolean;
 }) {
   const { heroA, heroB, winsA, winsB } = matchup;
-  const { pctA, pctB } = statSplit(winsA, winsB);
+  const usingVotes = !!tally && tally.total > 0;
+  const { pctA, pctB } = usingVotes
+    ? statSplit(tally!.votesA, tally!.votesB)
+    : statSplit(winsA, winsB);
+  const caption = usingVotes
+    ? `${tally!.total} ${tally!.total === 1 ? 'fan' : 'fans'} voted`
+    : statLead(winsA, winsB, heroA.name, heroB.name);
   return (
     <>
       <View style={m.barTrack as object}>
@@ -84,7 +93,7 @@ function Result({
       </View>
       <View style={m.barLabels as object}>
         <Text style={[m.barPct, { color: COLORS.orange }] as object}>{pctA}%</Text>
-        <Text style={m.lead as object}>{statLead(winsA, winsB, heroA.name, heroB.name)}</Text>
+        <Text style={m.lead as object}>{caption}</Text>
         <Text style={[m.barPct, { color: COLORS.blue }] as object}>{pctB}%</Text>
       </View>
       <Text style={[m.verdict, centered && (m.textCenter as object)] as object} numberOfLines={3}>
@@ -144,34 +153,48 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
   const isDesktop = width >= 768;
   const { heroA, heroB } = matchup;
 
-  const [vote, setVote] = useState<MatchupSide | null>(null);
+  const [pickedId, setPickedId] = useState<string | null>(null);
+  const [tally, setTally] = useState<MatchupTally | null>(null);
   const [loaded, setLoaded] = useState(false);
   const key = matchupVoteKey(heroA.id, heroB.id);
 
   useEffect(() => {
     let active = true;
-    AsyncStorage.getItem(key)
-      .then((v) => {
+    getMatchupTally(heroA.id, heroB.id)
+      .then(async (t) => {
         if (!active) return;
-        if (v === 'a' || v === 'b') setVote(v);
-        setLoaded(true);
+        if (t) {
+          setTally(t);
+          if (t.myPick) setPickedId(t.myPick);
+        }
+        if (!t || !t.myPick) {
+          const local = await AsyncStorage.getItem(key).catch(() => null);
+          if (active && (local === 'a' || local === 'b')) {
+            setPickedId(local === 'a' ? heroA.id : heroB.id);
+          }
+        }
+        if (active) setLoaded(true);
       })
       .catch(() => active && setLoaded(true));
     return () => {
       active = false;
     };
-  }, [key]);
+  }, [key, heroA.id, heroB.id]);
 
   const castVote = useCallback(
     (side: MatchupSide) => {
-      if (vote) return;
-      setVote(side);
+      if (pickedId) return;
+      const picked = side === 'a' ? heroA.id : heroB.id;
+      setPickedId(picked);
       AsyncStorage.setItem(key, side).catch(() => {});
+      castMatchupVote(heroA.id, heroB.id, picked)
+        .then((t) => t && setTally(t))
+        .catch(() => {});
     },
-    [vote, key],
+    [pickedId, key, heroA.id, heroB.id],
   );
 
-  const revealed = vote !== null;
+  const revealed = pickedId !== null;
 
   // ── Mobile: a centred "fight poster" — face-off portraits, then vote / reveal ──
   if (!isDesktop) {
@@ -183,8 +206,8 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
             hero={heroA}
             side="a"
             size={92}
-            picked={vote === 'a'}
-            dimmed={revealed && vote !== 'a'}
+            picked={pickedId === heroA.id}
+            dimmed={revealed && pickedId !== heroA.id}
             onVote={() => castVote('a')}
           />
           <View style={m.vsBadge as object}>
@@ -194,8 +217,8 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
             hero={heroB}
             side="b"
             size={92}
-            picked={vote === 'b'}
-            dimmed={revealed && vote !== 'b'}
+            picked={pickedId === heroB.id}
+            dimmed={revealed && pickedId !== heroB.id}
             onVote={() => castVote('b')}
           />
         </View>
@@ -203,7 +226,7 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
           {heroA.name} vs {heroB.name}
         </Text>
         {!loaded ? null : revealed ? (
-          <Result matchup={matchup} onOpen={onOpen} centered />
+          <Result matchup={matchup} tally={tally} onOpen={onOpen} centered />
         ) : (
           <VotePrompt heroA={heroA} heroB={heroB} onVote={castVote} centered />
         )}
@@ -217,8 +240,8 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
         <Fighter
           hero={heroA}
           side="a"
-          picked={vote === 'a'}
-          dimmed={revealed && vote !== 'a'}
+          picked={pickedId === heroA.id}
+          dimmed={revealed && pickedId !== heroA.id}
           onVote={() => castVote('a')}
         />
         <View style={m.vsBadge as object}>
@@ -227,8 +250,8 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
         <Fighter
           hero={heroB}
           side="b"
-          picked={vote === 'b'}
-          dimmed={revealed && vote !== 'b'}
+          picked={pickedId === heroB.id}
+          dimmed={revealed && pickedId !== heroB.id}
           onVote={() => castVote('b')}
         />
       </View>
@@ -239,7 +262,7 @@ export function TodaysMatchup({ matchup, onOpen }: TodaysMatchupProps) {
           {heroA.name} vs {heroB.name}
         </Text>
         {!loaded ? null : revealed ? (
-          <Result matchup={matchup} onOpen={onOpen} />
+          <Result matchup={matchup} tally={tally} onOpen={onOpen} />
         ) : (
           <VotePrompt heroA={heroA} heroB={heroB} onVote={castVote} />
         )}
@@ -355,6 +378,8 @@ const m = StyleSheet.create({
     transition: 'opacity 150ms ease, border-color 150ms ease',
   } as object,
   portraitB: { marginLeft: -16 } as object,
+  // Mirror the right fighter so they face inward, toward the left fighter.
+  faceInward: { transform: [{ scaleX: -1 }] } as object,
   portraitPicked: { borderColor: COLORS.orange } as object,
   portraitDimmed: { opacity: 0.5 } as object,
   pickedTag: {

--- a/src/lib/db/matchupVotes.ts
+++ b/src/lib/db/matchupVotes.ts
@@ -1,0 +1,63 @@
+import { supabase } from '../supabase';
+
+// Community "Who would win?" votes for a matchup pair. The aggregate tally is
+// read/written through SECURITY DEFINER RPCs (get_matchup_tally / cast_matchup_vote)
+// so the matchup_votes table itself stays locked to each user's own row. Pair
+// order is normalized server-side, so callers pass heroes in display order and
+// the tally comes back relative to that order.
+
+export interface MatchupTally {
+  /** Votes for the hero passed as `a`. */
+  votesA: number;
+  /** Votes for the hero passed as `b`. */
+  votesB: number;
+  total: number;
+  /** The caller's own pick (a hero id), or null if they haven't voted. */
+  myPick: string | null;
+}
+
+// The RPCs return a json object; PostgREST hands it back loosely typed.
+interface TallyJson {
+  votes_a?: number;
+  votes_b?: number;
+  total?: number;
+  my_pick?: string | null;
+}
+
+function toTally(data: unknown): MatchupTally {
+  const d = (data ?? {}) as TallyJson;
+  return {
+    votesA: d.votes_a ?? 0,
+    votesB: d.votes_b ?? 0,
+    total: d.total ?? 0,
+    myPick: d.my_pick ?? null,
+  };
+}
+
+/** Read the crowd tally for a pair plus the caller's own pick. Null on error. */
+export async function getMatchupTally(a: string, b: string): Promise<MatchupTally | null> {
+  const { data, error } = await supabase.rpc('get_matchup_tally', { p_a: a, p_b: b });
+  if (error) {
+    console.warn('[getMatchupTally] error:', error.message);
+    return null;
+  }
+  return toTally(data);
+}
+
+/** Cast (or change) the caller's pick; returns the fresh tally. Null on error. */
+export async function castMatchupVote(
+  a: string,
+  b: string,
+  pickedId: string,
+): Promise<MatchupTally | null> {
+  const { data, error } = await supabase.rpc('cast_matchup_vote', {
+    p_a: a,
+    p_b: b,
+    p_picked: pickedId,
+  });
+  if (error) {
+    console.warn('[castMatchupVote] error:', error.message);
+    return null;
+  }
+  return toTally(data);
+}

--- a/src/lib/home/matchupVote.ts
+++ b/src/lib/home/matchupVote.ts
@@ -1,0 +1,38 @@
+// src/lib/home/matchupVote.ts — pure helpers for the daily "Who would win?" vote.
+// The vote is persisted locally (AsyncStorage) so a user's pick is remembered for
+// the day; the reveal shows the stat scorecard ("tale of the tape") + AI verdict.
+// Community-aggregate tallies would be a backend follow-up (a votes table + RPC).
+
+export type MatchupSide = 'a' | 'b';
+
+/** Local calendar day as YYYY-MM-DD — the matchup rotates daily, so does the key. */
+export function dayStamp(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Storage key for a given day's matchup. Includes the pair ids so a reschedule
+ *  (different pair, same day) never reads a stale pick. */
+export function matchupVoteKey(heroAId: string, heroBId: string, d = new Date()): string {
+  return `matchup-vote:${dayStamp(d)}:${heroAId}-${heroBId}`;
+}
+
+/**
+ * The stat scorecard split as whole percentages summing to 100. Derived from how
+ * many of the six powerstat categories each hero wins. A 0–0 (no stats either
+ * side) reads as evenly matched.
+ */
+export function statSplit(winsA: number, winsB: number): { pctA: number; pctB: number } {
+  const total = winsA + winsB;
+  if (total <= 0) return { pctA: 50, pctB: 50 };
+  const pctA = Math.round((winsA / total) * 100);
+  return { pctA, pctB: 100 - pctA };
+}
+
+/** Short verdict-line on who the tale of the tape favours. */
+export function statLead(winsA: number, winsB: number, nameA: string, nameB: string): string {
+  if (winsA === winsB) return 'Evenly matched on the tape';
+  return `${winsA > winsB ? nameA : nameB} leads ${Math.max(winsA, winsB)}–${Math.min(winsA, winsB)} on stats`;
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -756,6 +756,30 @@ export type Database = {
         }
         Relationships: []
       }
+      matchup_votes: {
+        Row: {
+          created_at: string
+          hero_a_id: string
+          hero_b_id: string
+          picked_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          hero_a_id: string
+          hero_b_id: string
+          picked_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          hero_a_id?: string
+          hero_b_id?: string
+          picked_id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       titles: {
         Row: {
           backdrop_url: string | null
@@ -1008,6 +1032,10 @@ export type Database = {
         Args: { p_id: string; p_powers: string[]; p_summary: string }
         Returns: undefined
       }
+      cast_matchup_vote: {
+        Args: { p_a: string; p_b: string; p_picked: string }
+        Returns: Json
+      }
       catalog_distributions: { Args: never; Returns: Json }
       catalog_health: { Args: never; Returns: Json }
       get_source_coverage: { Args: Record<PropertyKey, never>; Returns: Json }
@@ -1073,6 +1101,7 @@ export type Database = {
           publisher: string
         }[]
       }
+      get_matchup_tally: { Args: { p_a: string; p_b: string }; Returns: Json }
       get_most_feared: {
         Args: { p_limit?: number }
         Returns: {

--- a/supabase/migrations/20260617120000_matchup_votes.sql
+++ b/supabase/migrations/20260617120000_matchup_votes.sql
@@ -1,0 +1,106 @@
+-- Community "Who would win?" votes for the daily matchup (and any compare pair).
+--
+-- The explore "Today's Battle" card lets a user pick a winner; until now that
+-- pick lived only in the client (AsyncStorage). This adds the backend so the
+-- reveal can show a real crowd tally.
+--
+-- Design:
+--   * One row per (normalized pair, user). The pair is normalized so that
+--     hero_a_id <= hero_b_id, so A-vs-B and B-vs-A share a single tally — the
+--     same convention the `verdicts` cache uses.
+--   * The chosen hero is stored by id (`picked_id`), not "side A/B", so the
+--     tally is order-independent and survives either display order.
+--   * The table is locked by RLS to each user's own row; aggregate tallies are
+--     read/written only through the two SECURITY DEFINER RPCs below (which pin
+--     search_path and are revoked from PUBLIC + anon, matching the hardening
+--     migration). Explore is auth-gated, so anon never needs access.
+
+create table if not exists public.matchup_votes (
+  hero_a_id  text not null,
+  hero_b_id  text not null,
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  picked_id  text not null,
+  created_at timestamptz not null default now(),
+  primary key (hero_a_id, hero_b_id, user_id),
+  constraint matchup_votes_pair_ordered check (hero_a_id <= hero_b_id),
+  constraint matchup_votes_pick_in_pair check (picked_id in (hero_a_id, hero_b_id))
+);
+
+-- Lets the per-user policy filter (and an eventual "your picks" view) avoid a
+-- full scan; the PK already covers the per-pair aggregate lookups.
+create index if not exists matchup_votes_user_idx on public.matchup_votes (user_id);
+
+alter table public.matchup_votes enable row level security;
+
+drop policy if exists matchup_votes_own_select on public.matchup_votes;
+create policy matchup_votes_own_select on public.matchup_votes
+  for select to authenticated
+  using (user_id = auth.uid());
+
+drop policy if exists matchup_votes_own_write on public.matchup_votes;
+create policy matchup_votes_own_write on public.matchup_votes
+  for all to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- ── Read a pair's tally, relative to the caller's requested order ─────────────
+-- Returns counts for p_a and p_b (the caller's order), the total, and the
+-- caller's own pick (null when they haven't voted). Pair order is normalized
+-- internally. STABLE + SECURITY DEFINER so it sees all rows past RLS.
+create or replace function public.get_matchup_tally(p_a text, p_b text)
+returns json
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with norm as (
+    select least(p_a, p_b) as lo, greatest(p_a, p_b) as hi
+  )
+  select json_build_object(
+    'votes_a', count(*) filter (where v.picked_id = p_a),
+    'votes_b', count(*) filter (where v.picked_id = p_b),
+    'total',   count(v.picked_id),
+    'my_pick', max(v.picked_id) filter (where v.user_id = auth.uid())
+  )
+  from norm n
+  left join public.matchup_votes v
+    on v.hero_a_id = n.lo and v.hero_b_id = n.hi;
+$$;
+
+-- ── Cast (or change) the caller's pick and return the fresh tally ─────────────
+-- Requires auth; validates the pick is one of the two combatants; upserts so a
+-- user has at most one vote per pair (and may switch sides).
+create or replace function public.cast_matchup_vote(p_a text, p_b text, p_picked text)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_lo  text := least(p_a, p_b);
+  v_hi  text := greatest(p_a, p_b);
+begin
+  if v_uid is null then
+    raise exception 'not authenticated';
+  end if;
+  if p_picked is distinct from p_a and p_picked is distinct from p_b then
+    raise exception 'pick must be one of the two heroes';
+  end if;
+
+  insert into public.matchup_votes (hero_a_id, hero_b_id, user_id, picked_id, created_at)
+  values (v_lo, v_hi, v_uid, p_picked, now())
+  on conflict (hero_a_id, hero_b_id, user_id)
+  do update set picked_id = excluded.picked_id, created_at = now();
+
+  return public.get_matchup_tally(p_a, p_b);
+end;
+$$;
+
+-- Lock execution to authenticated users + service_role (mirrors the hardening
+-- migration's policy for client-facing RPCs).
+revoke all on function public.get_matchup_tally(text, text)        from public, anon;
+revoke all on function public.cast_matchup_vote(text, text, text)  from public, anon;
+grant execute on function public.get_matchup_tally(text, text)       to authenticated, service_role;
+grant execute on function public.cast_matchup_vote(text, text, text) to authenticated, service_role;


### PR DESCRIPTION
## Summary

Brings the native explore page to full parity with web, surfaces dormant catalogue depth, and adds a community **"Who would win?"** vote backed by a new table + RPCs.

### Native ↔ web parity
- Native now renders everything web does: publisher pods, pulse ticker, the full set of curated catalogue rows (Marvel, DC, X-Men, Strongest, Most Intelligent, Anime, Video Games, Franchise Icons, Newly Added), the Dark Side cluster, and the editorial modules.
- Web now renders its previously fetched-but-unused rows and gained the vote interaction, so both platforms render the same content set.

### New editorial modules (native ports of the web components)
- **Greatest Rivalries** (`get_top_rivalries`) → split-portrait matchups into the compare arena
- **Hall of Infamy / Most Feared** (`get_most_feared`)
- **Era Timeline** (`get_era_timeline`)
- **Cover Gallery** — first-appearance covers

### Today's Battle + community vote
- Deterministic daily matchup; tapping a fighter casts a vote.
- New backend: `matchup_votes` table (RLS-locked to each user's own row) + `cast_matchup_vote` / `get_matchup_tally` RPCs (`SECURITY DEFINER`, pinned `search_path`, revoked from anon).
- Both cards read the tally on mount, cast server-side, and reveal the real crowd split ("N fans voted") — falling back to the stat scorecard before anyone votes, and to a local AsyncStorage pick on network failure.
- Right fighter's portrait mirrored so both combatants face inward.

## Verification
- `yarn typecheck` clean · `yarn lint` clean on changed files · **326/326 tests pass** (new `matchupVote` pure logic unit-tested)
- Migration applied to the project; `database.generated.ts` regenerated
- Live DB checks: tally returns correct zeroed result, unauthenticated cast is rejected with no row leakage, security advisors show RLS-with-policies and no anon-executable RPCs

## Notes
- The vote writes only for authenticated users (RPC requires `auth.uid()`), which is fine since the tabs are auth-gated.
- Couldn't run the apps in this environment, so card layouts are matched to existing components rather than visually verified on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_