### PR TITLE
Profile "Your Universe" taste profile

### DIFF
--- a/__tests__/lib/db/taste.test.ts
+++ b/__tests__/lib/db/taste.test.ts
@@ -1,0 +1,38 @@
+import { dominantAlignment, shortPublisher, type TasteProfile } from '../../../src/lib/db/taste';
+
+const base: TasteProfile = {
+  basedOn: 0,
+  publishers: [],
+  franchises: [],
+  tags: [],
+  alignment: { good: 0, bad: 0, neutral: 0 },
+};
+
+describe('dominantAlignment', () => {
+  it('returns the label of the highest-weighted alignment', () => {
+    expect(dominantAlignment({ ...base, alignment: { good: 10, bad: 3, neutral: 1 } })).toBe('Heroes');
+    expect(dominantAlignment({ ...base, alignment: { good: 2, bad: 9, neutral: 1 } })).toBe('Villains');
+    expect(dominantAlignment({ ...base, alignment: { good: 1, bad: 2, neutral: 8 } })).toBe('Anti-Heroes');
+  });
+
+  it('returns null when there is no alignment signal', () => {
+    expect(dominantAlignment(base)).toBeNull();
+  });
+
+  it('breaks ties toward Heroes, then Villains', () => {
+    expect(dominantAlignment({ ...base, alignment: { good: 5, bad: 5, neutral: 0 } })).toBe('Heroes');
+    expect(dominantAlignment({ ...base, alignment: { good: 0, bad: 5, neutral: 5 } })).toBe('Villains');
+  });
+});
+
+describe('shortPublisher', () => {
+  it('strips a trailing "Comics"', () => {
+    expect(shortPublisher('DC Comics')).toBe('DC');
+    expect(shortPublisher('Dark Horse Comics')).toBe('Dark Horse');
+  });
+
+  it('leaves other names untouched', () => {
+    expect(shortPublisher('Marvel')).toBe('Marvel');
+    expect(shortPublisher('Image')).toBe('Image');
+  });
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -33,6 +33,12 @@ import {
   type FavouriteHero,
 } from '../../src/lib/db/favourites';
 import { getBattleRecord, type BattleRecord } from '../../src/lib/db/matchupVotes';
+import {
+  getTasteProfile,
+  dominantAlignment,
+  shortPublisher,
+  type TasteProfile,
+} from '../../src/lib/db/taste';
 import { HeroImage } from '../../src/components/HeroImage';
 import { COLORS } from '../../src/constants/colors';
 import { Toast, useToast } from '../../src/components/ui/Toast';
@@ -257,6 +263,7 @@ export default function ProfileScreen() {
   } = useProfile(user?.id);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
   const [battle, setBattle] = useState<BattleRecord | null>(null);
+  const [taste, setTaste] = useState<TasteProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
@@ -269,6 +276,9 @@ export default function ProfileScreen() {
     if (!user) return;
     getBattleRecord()
       .then(setBattle)
+      .catch(() => {});
+    getTasteProfile()
+      .then(setTaste)
       .catch(() => {});
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
@@ -361,6 +371,18 @@ export default function ProfileScreen() {
   const joinedDate = user?.created_at
     ? new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     : null;
+
+  // "Your Universe" — a one-line lean + a handful of franchise/tag chips.
+  const tasteChips = taste
+    ? Array.from(
+        new Set([...taste.franchises.map((f) => f.name), ...taste.tags.map((t) => t.label)]),
+      ).slice(0, 7)
+    : [];
+  const tasteInsight = taste
+    ? [dominantAlignment(taste), taste.publishers[0]?.name && shortPublisher(taste.publishers[0].name)]
+        .filter(Boolean)
+        .join(' · ')
+    : '';
 
   const handleUnfavourite = (hero: FavouriteHero) => {
     if (!user) return;
@@ -564,6 +586,31 @@ export default function ProfileScreen() {
                   <Text style={styles.battleLabel}>Day streak</Text>
                 </View>
               </View>
+            </View>
+            <View style={styles.hairline} />
+          </>
+        )}
+
+        {/* Your Universe — taste profile from favourites + view history. */}
+        {taste && taste.basedOn > 0 && (!!tasteInsight || tasteChips.length > 0) && (
+          <>
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <Text style={styles.sectionTitle}>Your Universe</Text>
+              </View>
+              {!!tasteInsight && <Text style={styles.tasteInsight}>{tasteInsight}</Text>}
+              {tasteChips.length > 0 && (
+                <View style={styles.tasteChipRow}>
+                  {tasteChips.map((c) => (
+                    <View key={c} style={styles.tasteChip}>
+                      <Text style={styles.tasteChipText}>{c}</Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+              <Text style={styles.tasteFootnote}>
+                {`Based on ${taste.basedOn} ${taste.basedOn === 1 ? 'hero' : 'heroes'} you've saved & viewed`}
+              </Text>
             </View>
             <View style={styles.hairline} />
           </>
@@ -1085,6 +1132,28 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
     textTransform: 'uppercase',
     color: 'rgba(245,235,220,0.55)',
+  },
+
+  // Your Universe (taste profile)
+  tasteInsight: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 18,
+    color: COLORS.navy,
+    marginBottom: 12,
+  },
+  tasteChipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  tasteChip: {
+    backgroundColor: '#e8ddd0',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tasteChipText: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.navy },
+  tasteFootnote: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 12,
+    color: COLORS.grey,
+    marginTop: 12,
   },
 
   // Favourites

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -23,6 +23,12 @@ import {
   type FavouriteHero,
 } from '../../src/lib/db/favourites';
 import { getBattleRecord, type BattleRecord } from '../../src/lib/db/matchupVotes';
+import {
+  getTasteProfile,
+  dominantAlignment,
+  shortPublisher,
+  type TasteProfile,
+} from '../../src/lib/db/taste';
 import { WebHeroCard } from '../../src/components/web/WebHeroCard';
 import { useSkeletonAnim, SkeletonBlock } from '../../src/components/web/Skeleton';
 import { COLORS } from '../../src/constants/colors';
@@ -281,6 +287,7 @@ export default function WebProfileScreen() {
   } = useProfile(user?.id);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
   const [battle, setBattle] = useState<BattleRecord | null>(null);
+  const [taste, setTaste] = useState<TasteProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [signingOut, setSigningOut] = useState(false);
   const [deletingAccount, setDeletingAccount] = useState(false);
@@ -292,6 +299,9 @@ export default function WebProfileScreen() {
     if (!user) return;
     getBattleRecord()
       .then(setBattle)
+      .catch(() => {});
+    getTasteProfile()
+      .then(setTaste)
       .catch(() => {});
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
@@ -366,6 +376,22 @@ export default function WebProfileScreen() {
   const joinedDate = user?.created_at
     ? new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     : null;
+
+  // "Your Universe" — a one-line lean + a handful of franchise/tag chips.
+  const tasteChips = taste
+    ? Array.from(
+        new Set([...taste.franchises.map((f) => f.name), ...taste.tags.map((t) => t.label)]),
+      ).slice(0, 8)
+    : [];
+  const tasteInsight = taste
+    ? [dominantAlignment(taste), taste.publishers[0]?.name && shortPublisher(taste.publishers[0].name)]
+        .filter(Boolean)
+        .join(' · ')
+    : '';
+  const showTaste = !!taste && taste.basedOn > 0 && (!!tasteInsight || tasteChips.length > 0);
+  const tasteFootnote = taste
+    ? `Based on ${taste.basedOn} ${taste.basedOn === 1 ? 'hero' : 'heroes'} you've saved & viewed`
+    : '';
 
   const handleUpdateName = async (newName: string) => {
     await updateDisplayName(newName);
@@ -527,6 +553,29 @@ export default function WebProfileScreen() {
                     <Text style={mob.battleLabel}>Day streak</Text>
                   </View>
                 </View>
+              </View>
+              <View style={mob.hairline} />
+            </>
+          )}
+
+          {/* ── Your Universe ── */}
+          {showTaste && (
+            <>
+              <View style={mob.section}>
+                <View style={mob.sectionHeader}>
+                  <Text style={mob.sectionTitle}>Your Universe</Text>
+                </View>
+                {!!tasteInsight && <Text style={mob.tasteInsight}>{tasteInsight}</Text>}
+                {tasteChips.length > 0 && (
+                  <View style={mob.tasteChipRow}>
+                    {tasteChips.map((c) => (
+                      <View key={c} style={mob.tasteChip}>
+                        <Text style={mob.tasteChipText}>{c}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+                <Text style={mob.tasteFootnote}>{tasteFootnote}</Text>
               </View>
               <View style={mob.hairline} />
             </>
@@ -1011,6 +1060,22 @@ export default function WebProfileScreen() {
                 </View>
               </View>
             )}
+            {showTaste && (
+              <View style={desk.battleBlock}>
+                <Text style={desk.sectionTitle}>Your Universe</Text>
+                {!!tasteInsight && <Text style={desk.tasteInsight}>{tasteInsight}</Text>}
+                {tasteChips.length > 0 && (
+                  <View style={desk.tasteChipRow}>
+                    {tasteChips.map((c) => (
+                      <View key={c} style={desk.tasteChip}>
+                        <Text style={desk.tasteChipText}>{c}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+                <Text style={desk.tasteFootnote}>{tasteFootnote}</Text>
+              </View>
+            )}
             <View style={desk.sectionHeader}>
               <Text style={desk.sectionTitle}>My Favourites</Text>
               {!loading && favourites.length > 0 && (
@@ -1282,6 +1347,18 @@ const mob = StyleSheet.create({
     textTransform: 'uppercase',
     color: 'rgba(245,235,220,0.55)',
   } as object,
+
+  // Your Universe
+  tasteInsight: { fontFamily: 'Flame-Regular', fontSize: 18, color: COLORS.navy, marginBottom: 12 },
+  tasteChipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  tasteChip: {
+    backgroundColor: '#e8ddd0',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tasteChipText: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.navy },
+  tasteFootnote: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey, marginTop: 12 },
 
   // Favourites
   section: { paddingHorizontal: 16, marginBottom: 24 },
@@ -1699,6 +1776,17 @@ const desk = StyleSheet.create({
     textTransform: 'uppercase',
     color: 'rgba(245,235,220,0.55)',
   } as object,
+  // Your Universe
+  tasteInsight: { fontFamily: 'Flame-Regular', fontSize: 20, color: COLORS.navy, marginBottom: 4 },
+  tasteChipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  tasteChip: {
+    backgroundColor: '#e8ddd0',
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+  },
+  tasteChipText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
+  tasteFootnote: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey },
   sectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/lib/db/taste.ts
+++ b/src/lib/db/taste.ts
@@ -1,0 +1,68 @@
+import { supabase } from '../supabase';
+
+// "Your Universe" — the signed-in user's taste profile, derived from their
+// favourites (weighted 3x) + view history (1x) via the get_my_taste_profile RPC.
+// Read-only; the RPC does the aggregation so the client just renders it.
+
+export interface TasteFacet {
+  name: string;
+  weight: number;
+}
+
+export interface TasteTag {
+  slug: string;
+  label: string;
+  weight: number;
+}
+
+export interface TasteProfile {
+  /** Distinct heroes the profile is based on (favourited or viewed). */
+  basedOn: number;
+  publishers: TasteFacet[];
+  franchises: TasteFacet[];
+  tags: TasteTag[];
+  alignment: { good: number; bad: number; neutral: number };
+}
+
+interface TasteJson {
+  based_on?: number;
+  publishers?: TasteFacet[];
+  franchises?: TasteFacet[];
+  tags?: TasteTag[];
+  alignment?: { good?: number; bad?: number; neutral?: number };
+}
+
+export async function getTasteProfile(): Promise<TasteProfile | null> {
+  const { data, error } = await supabase.rpc('get_my_taste_profile');
+  if (error) {
+    console.warn('[getTasteProfile] error:', error.message);
+    return null;
+  }
+  const d = (data ?? {}) as TasteJson;
+  return {
+    basedOn: d.based_on ?? 0,
+    publishers: d.publishers ?? [],
+    franchises: d.franchises ?? [],
+    tags: d.tags ?? [],
+    alignment: {
+      good: d.alignment?.good ?? 0,
+      bad: d.alignment?.bad ?? 0,
+      neutral: d.alignment?.neutral ?? 0,
+    },
+  };
+}
+
+/** The user's dominant alignment as a display label, or null if they have none. */
+export function dominantAlignment(t: TasteProfile): string | null {
+  const { good, bad, neutral } = t.alignment;
+  const max = Math.max(good, bad, neutral);
+  if (max <= 0) return null;
+  if (good === max) return 'Heroes';
+  if (bad === max) return 'Villains';
+  return 'Anti-Heroes';
+}
+
+/** Tidy a raw publisher string for display ("DC Comics" → "DC"). */
+export function shortPublisher(name: string): string {
+  return name.replace(/\s+comics$/i, '').trim();
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1116,6 +1116,7 @@ export type Database = {
         }[]
       }
       get_my_battle_record: { Args: never; Returns: Json }
+      get_my_taste_profile: { Args: never; Returns: Json }
       get_pending_build_ids: { Args: { p_limit?: number }; Returns: string[] }
       get_related_heroes: {
         Args: {

--- a/supabase/migrations/20260617140000_taste_profile_rpc.sql
+++ b/supabase/migrations/20260617140000_taste_profile_rpc.sql
@@ -1,0 +1,63 @@
+-- "Your Universe" taste profile for the signed-in user. Aggregates the heroes
+-- they've engaged with (favourites weighted 3x, viewed 1x) into top publishers,
+-- franchises, tags, and an alignment lean. Read-only, SECURITY DEFINER (joins
+-- heroes/hero_tags past the per-user RLS on the engagement tables).
+create or replace function public.get_my_taste_profile()
+returns json
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with engaged as (
+    select hero_id, max(w) as weight
+    from (
+      select hero_id, 3 as w from public.user_favourites
+        where user_id = auth.uid() and hero_id is not null
+      union all
+      select hero_id, 1 as w from public.user_view_history
+        where user_id = auth.uid()
+    ) u
+    group by hero_id
+  ),
+  h as (
+    select e.weight, x.publisher, x.franchise, x.alignment
+    from engaged e
+    join public.heroes x on x.id = e.hero_id
+  )
+  select json_build_object(
+    'based_on', (select count(*) from engaged),
+    'publishers', coalesce((
+      select json_agg(p) from (
+        select publisher as name, sum(weight)::int as weight
+        from h where publisher is not null and publisher <> ''
+        group by publisher order by weight desc, name limit 5
+      ) p
+    ), '[]'::json),
+    'franchises', coalesce((
+      select json_agg(f) from (
+        select franchise as name, sum(weight)::int as weight
+        from h where franchise is not null and franchise <> ''
+        group by franchise order by weight desc, name limit 6
+      ) f
+    ), '[]'::json),
+    'tags', coalesce((
+      select json_agg(t) from (
+        select tg.tag as slug, coalesce(v.label, tg.tag) as label, sum(e.weight)::int as weight
+        from engaged e
+        join public.hero_tags tg on tg.hero_id = e.hero_id
+        left join public.hero_tag_vocab v on v.slug = tg.tag
+        group by tg.tag, v.label
+        order by weight desc, label limit 6
+      ) t
+    ), '[]'::json),
+    'alignment', json_build_object(
+      'good',    coalesce((select sum(weight) from h where lower(alignment) = 'good'), 0)::int,
+      'bad',     coalesce((select sum(weight) from h where lower(alignment) = 'bad'), 0)::int,
+      'neutral', coalesce((select sum(weight) from h where lower(alignment) like '%neutral%'), 0)::int
+    )
+  );
+$$;
+
+revoke all on function public.get_my_taste_profile() from public, anon;
+grant execute on function public.get_my_taste_profile() to authenticated, service_role;


### PR DESCRIPTION
## Summary

Second identity-layer piece (after the Battle Record): a **"Your Universe"** taste profile derived from the user's favourites + view history, surfaced on native and web profiles.

- New `get_my_taste_profile()` RPC (`SECURITY DEFINER`, `search_path` pinned, revoked from anon): aggregates engaged heroes (favourites 3×, views 1×) into top **publishers / franchises / tags** (labelled via `hero_tag_vocab`) + an **alignment lean**. Applied to the project and verified.
- `getTasteProfile()` client helper + pure `dominantAlignment()` / `shortPublisher()` helpers (unit-tested).
- "Your Universe" section on both profiles: a one-line lean ("Heroes · Marvel"), franchise/tag chips, and a "based on N heroes" footnote. Hidden until the user has engaged with heroes.

## Verification
- Migration applied; `database.generated.ts` updated
- RPC returns correct shape (empty unauthenticated; sensible aggregates on a sample)
- `yarn typecheck` clean · lint clean on changed files · **331/331 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_