### PR TITLE
Profile Badges (derived achievements)

### DIFF
--- a/__tests__/lib/profile/badges.test.ts
+++ b/__tests__/lib/profile/badges.test.ts
@@ -1,0 +1,71 @@
+import { computeBadges, earnedCount, type BadgeInput } from '../../../src/lib/profile/badges';
+
+const NOW = new Date('2026-06-17T00:00:00Z').getTime();
+
+const base: BadgeInput = {
+  accountCreatedAt: null,
+  favourites: 0,
+  votes: 0,
+  streak: 0,
+  topPublisher: null,
+};
+
+const find = (input: Partial<BadgeInput>, id: string, now = NOW) =>
+  computeBadges({ ...base, ...input }, now).find((b) => b.id === id)!;
+
+describe('computeBadges', () => {
+  it('earns Day One whenever the account exists', () => {
+    expect(find({ accountCreatedAt: '2026-06-01T00:00:00Z' }, 'day-one').earned).toBe(true);
+    expect(find({ accountCreatedAt: null }, 'day-one').earned).toBe(false);
+  });
+
+  it('earns Veteran only after 180 days of tenure', () => {
+    expect(find({ accountCreatedAt: '2026-06-01T00:00:00Z' }, 'veteran').earned).toBe(false);
+    expect(find({ accountCreatedAt: '2025-01-01T00:00:00Z' }, 'veteran').earned).toBe(true);
+  });
+
+  it('earns Curator at 10 favourites and Archivist at 50', () => {
+    expect(find({ favourites: 9 }, 'curator').earned).toBe(false);
+    expect(find({ favourites: 10 }, 'curator').earned).toBe(true);
+    expect(find({ favourites: 49 }, 'archivist').earned).toBe(false);
+    expect(find({ favourites: 50 }, 'archivist').earned).toBe(true);
+  });
+
+  it('earns Oracle at 10 votes and On Fire at a 3-day streak', () => {
+    expect(find({ votes: 10 }, 'oracle').earned).toBe(true);
+    expect(find({ streak: 3 }, 'on-fire').earned).toBe(true);
+    expect(find({ streak: 2 }, 'on-fire').earned).toBe(false);
+  });
+
+  it('labels the loyalty badge by top publisher and needs 5 favourites', () => {
+    expect(find({ topPublisher: 'Marvel', favourites: 5 }, 'loyalist').label).toBe('Marvel Loyalist');
+    expect(find({ topPublisher: 'DC', favourites: 5 }, 'loyalist').label).toBe('DC Devotee');
+    expect(find({ topPublisher: 'Image', favourites: 5 }, 'loyalist').label).toBe('Image Fan');
+    expect(find({ topPublisher: 'Marvel', favourites: 4 }, 'loyalist').earned).toBe(false);
+  });
+
+  it('exposes progress on locked count-based badges', () => {
+    expect(find({ favourites: 4 }, 'curator').progress).toEqual({ current: 4, target: 10 });
+  });
+
+  it('sorts earned badges ahead of locked ones', () => {
+    const badges = computeBadges(
+      { ...base, accountCreatedAt: '2026-06-01T00:00:00Z', favourites: 12 },
+      NOW,
+    );
+    const firstLocked = badges.findIndex((b) => !b.earned);
+    const lastEarned = badges.map((b) => b.earned).lastIndexOf(true);
+    expect(lastEarned).toBeLessThan(firstLocked);
+  });
+});
+
+describe('earnedCount', () => {
+  it('counts only earned badges', () => {
+    const badges = computeBadges(
+      { ...base, accountCreatedAt: '2026-06-01T00:00:00Z', favourites: 10, votes: 10 },
+      NOW,
+    );
+    // day-one, curator, oracle earned; veteran/archivist/on-fire/loyalist not.
+    expect(earnedCount(badges)).toBe(3);
+  });
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -39,6 +39,7 @@ import {
   shortPublisher,
   type TasteProfile,
 } from '../../src/lib/db/taste';
+import { computeBadges, earnedCount } from '../../src/lib/profile/badges';
 import { HeroImage } from '../../src/components/HeroImage';
 import { COLORS } from '../../src/constants/colors';
 import { Toast, useToast } from '../../src/components/ui/Toast';
@@ -387,6 +388,16 @@ export default function ProfileScreen() {
         .join(' · ')
     : '';
 
+  // Badges — derived from account age + favourites + matchup record + taste.
+  const badges = computeBadges({
+    accountCreatedAt: user?.created_at ?? null,
+    favourites: favourites.length,
+    votes: battle?.total ?? 0,
+    streak: battle?.streak ?? 0,
+    topPublisher: taste?.publishers[0]?.name ?? null,
+  });
+  const badgesEarned = earnedCount(badges);
+
   const handleUnfavourite = (hero: FavouriteHero) => {
     if (!user) return;
     const confirm = () => {
@@ -618,6 +629,50 @@ export default function ProfileScreen() {
             <View style={styles.hairline} />
           </>
         )}
+
+        {/* Badges — derived achievements (account age, favourites, votes, taste). */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Badges</Text>
+            <Text style={styles.sectionCount}>
+              {badgesEarned}/{badges.length}
+            </Text>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.badgeRow}
+          >
+            {badges.map((b) => (
+              <View key={b.id} style={[styles.badgeTile, !b.earned && styles.badgeTileLocked]}>
+                <View
+                  style={[styles.badgeIcon, b.earned ? styles.badgeIconEarned : styles.badgeIconLocked]}
+                >
+                  <Ionicons
+                    name={b.icon as keyof typeof Ionicons.glyphMap}
+                    size={22}
+                    color={b.earned ? '#fff' : COLORS.grey}
+                  />
+                </View>
+                <Text
+                  style={[styles.badgeLabel, !b.earned && styles.badgeLabelLocked]}
+                  numberOfLines={1}
+                >
+                  {b.label}
+                </Text>
+                <Text style={styles.badgeSub} numberOfLines={1}>
+                  {!b.earned && b.progress
+                    ? `${Math.min(b.progress.current, b.progress.target)}/${b.progress.target}`
+                    : b.earned
+                      ? 'Earned'
+                      : ''}
+                </Text>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+
+        <View style={styles.hairline} />
 
         {/* My Favourites */}
         <View style={styles.section}>
@@ -1157,6 +1212,34 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: COLORS.grey,
     marginTop: 12,
+  },
+
+  // Badges
+  badgeRow: { gap: 10, paddingRight: 16 },
+  badgeTile: { width: 92, alignItems: 'center', gap: 6 },
+  badgeTileLocked: { opacity: 0.55 },
+  badgeIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeIconEarned: { backgroundColor: COLORS.orange },
+  badgeIconLocked: { backgroundColor: '#e8ddd0' },
+  badgeLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    color: COLORS.navy,
+    textAlign: 'center',
+  },
+  badgeLabelLocked: { color: COLORS.grey },
+  badgeSub: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
   },
 
   // Favourites

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -29,6 +29,7 @@ import {
   shortPublisher,
   type TasteProfile,
 } from '../../src/lib/db/taste';
+import { computeBadges, earnedCount } from '../../src/lib/profile/badges';
 import { WebHeroCard } from '../../src/components/web/WebHeroCard';
 import { useSkeletonAnim, SkeletonBlock } from '../../src/components/web/Skeleton';
 import { COLORS } from '../../src/constants/colors';
@@ -396,6 +397,16 @@ export default function WebProfileScreen() {
     ? `Based on ${taste.basedOn} ${taste.basedOn === 1 ? 'hero' : 'heroes'} you've saved & viewed`
     : '';
 
+  // Badges — derived from account age + favourites + matchup record + taste.
+  const badges = computeBadges({
+    accountCreatedAt: user?.created_at ?? null,
+    favourites: favourites.length,
+    votes: battle?.total ?? 0,
+    streak: battle?.streak ?? 0,
+    topPublisher: taste?.publishers[0]?.name ?? null,
+  });
+  const badgesEarned = earnedCount(badges);
+
   const handleUpdateName = async (newName: string) => {
     await updateDisplayName(newName);
     showToast('Display name updated');
@@ -581,6 +592,48 @@ export default function WebProfileScreen() {
               <View style={mob.hairline} />
             </>
           )}
+
+          {/* ── Badges ── */}
+          <View style={mob.section}>
+            <View style={mob.sectionHeader}>
+              <Text style={mob.sectionTitle}>Badges</Text>
+              <Text style={mob.sectionCount}>
+                {badgesEarned}/{badges.length}
+              </Text>
+            </View>
+            <View style={mob.badgeWall}>
+              {badges.map((b) => (
+                <View key={b.id} style={[mob.badgeTile, !b.earned && (mob.badgeTileLocked as object)]}>
+                  <View
+                    style={[
+                      mob.badgeIcon,
+                      b.earned ? (mob.badgeIconEarned as object) : (mob.badgeIconLocked as object),
+                    ]}
+                  >
+                    <Ionicons
+                      name={b.icon as keyof typeof Ionicons.glyphMap}
+                      size={22}
+                      color={b.earned ? '#fff' : COLORS.grey}
+                    />
+                  </View>
+                  <Text
+                    style={[mob.badgeLabel, !b.earned && (mob.badgeLabelLocked as object)]}
+                    numberOfLines={1}
+                  >
+                    {b.label}
+                  </Text>
+                  <Text style={mob.badgeSub} numberOfLines={1}>
+                    {!b.earned && b.progress
+                      ? `${Math.min(b.progress.current, b.progress.target)}/${b.progress.target}`
+                      : b.earned
+                        ? 'Earned'
+                        : ''}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+          <View style={mob.hairline} />
 
           {/* ── My Favourites ── */}
           <View style={mob.section}>
@@ -1077,6 +1130,45 @@ export default function WebProfileScreen() {
                 <Text style={desk.tasteFootnote}>{tasteFootnote}</Text>
               </View>
             )}
+            <View style={desk.battleBlock}>
+              <View style={desk.badgeHead}>
+                <Text style={desk.sectionTitle}>Badges</Text>
+                <Text style={desk.sectionCount}>
+                  {badgesEarned}/{badges.length}
+                </Text>
+              </View>
+              <View style={desk.badgeWall}>
+                {badges.map((b) => (
+                  <View key={b.id} style={[desk.badgeTile, !b.earned && (desk.badgeTileLocked as object)]}>
+                    <View
+                      style={[
+                        desk.badgeIcon,
+                        b.earned ? (desk.badgeIconEarned as object) : (desk.badgeIconLocked as object),
+                      ]}
+                    >
+                      <Ionicons
+                        name={b.icon as keyof typeof Ionicons.glyphMap}
+                        size={24}
+                        color={b.earned ? '#fff' : COLORS.grey}
+                      />
+                    </View>
+                    <Text
+                      style={[desk.badgeLabel, !b.earned && (desk.badgeLabelLocked as object)]}
+                      numberOfLines={1}
+                    >
+                      {b.label}
+                    </Text>
+                    <Text style={desk.badgeSub} numberOfLines={1}>
+                      {!b.earned && b.progress
+                        ? `${Math.min(b.progress.current, b.progress.target)}/${b.progress.target}`
+                        : b.earned
+                          ? 'Earned'
+                          : ''}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            </View>
             <View style={desk.sectionHeader}>
               <Text style={desk.sectionTitle}>My Favourites</Text>
               {!loading && favourites.length > 0 && (
@@ -1365,6 +1457,34 @@ const mob = StyleSheet.create({
     color: COLORS.grey,
     marginTop: 12,
   },
+
+  // Badges
+  badgeWall: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  badgeTile: { width: 80, alignItems: 'center', gap: 6 },
+  badgeTileLocked: { opacity: 0.55 } as object,
+  badgeIcon: {
+    width: 54,
+    height: 54,
+    borderRadius: 27,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeIconEarned: { backgroundColor: COLORS.orange } as object,
+  badgeIconLocked: { backgroundColor: '#e8ddd0' } as object,
+  badgeLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 11,
+    color: COLORS.navy,
+    textAlign: 'center',
+  } as object,
+  badgeLabelLocked: { color: COLORS.grey } as object,
+  badgeSub: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+  } as object,
 
   // Favourites
   section: { paddingHorizontal: 16, marginBottom: 24 },
@@ -1793,6 +1913,34 @@ const desk = StyleSheet.create({
   },
   tasteChipText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
   tasteFootnote: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey },
+  // Badges
+  badgeHead: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  badgeWall: { flexDirection: 'row', flexWrap: 'wrap', gap: 16 },
+  badgeTile: { width: 88, alignItems: 'center', gap: 7 },
+  badgeTileLocked: { opacity: 0.55 } as object,
+  badgeIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeIconEarned: { backgroundColor: COLORS.orange } as object,
+  badgeIconLocked: { backgroundColor: '#e8ddd0' } as object,
+  badgeLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12,
+    color: COLORS.navy,
+    textAlign: 'center',
+  } as object,
+  badgeLabelLocked: { color: COLORS.grey } as object,
+  badgeSub: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+  } as object,
   sectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/lib/profile/badges.ts
+++ b/src/lib/profile/badges.ts
@@ -1,0 +1,122 @@
+// src/lib/profile/badges.ts — pure achievement logic for the profile.
+// Badges are *derived* from data we already store (account age, favourites,
+// matchup votes/streak, taste) — no new tables. Definitions live here so they're
+// easy to tune and unit-test; the profile screens just render the result.
+
+export interface BadgeInput {
+  /** auth user's created_at (ISO), for tenure badges. */
+  accountCreatedAt: string | null;
+  /** Number of favourited heroes. */
+  favourites: number;
+  /** Matchups voted on (Battle Record total). */
+  votes: number;
+  /** Current daily-vote streak. */
+  streak: number;
+  /** Short top-publisher name from the taste profile, or null. */
+  topPublisher: string | null;
+}
+
+export interface Badge {
+  id: string;
+  label: string;
+  description: string;
+  /** Ionicons glyph name. */
+  icon: string;
+  earned: boolean;
+  /** Progress toward earning, for locked count-based badges. */
+  progress?: { current: number; target: number };
+}
+
+const DAY = 86_400_000;
+
+function tenureDays(iso: string | null, now: number): number {
+  if (!iso) return 0;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return 0;
+  return Math.max(0, Math.floor((now - t) / DAY));
+}
+
+/** Flavourful label for the publisher-loyalty badge. */
+function loyaltyLabel(pub: string | null): string {
+  if (!pub) return 'True Believer';
+  const p = pub.toLowerCase();
+  if (p.includes('marvel')) return 'Marvel Loyalist';
+  if (p.includes('dc')) return 'DC Devotee';
+  return `${pub} Fan`;
+}
+
+/**
+ * Compute the full badge set (earned + locked-with-progress) for a user.
+ * `now` is injectable so tenure badges are deterministic in tests.
+ */
+export function computeBadges(input: BadgeInput, now: number = Date.now()): Badge[] {
+  const { accountCreatedAt, favourites, votes, streak, topPublisher } = input;
+  const days = tenureDays(accountCreatedAt, now);
+
+  const badges: Badge[] = [
+    {
+      id: 'day-one',
+      label: 'Day One',
+      description: 'Joined the Mythique community',
+      icon: 'sparkles',
+      earned: !!accountCreatedAt,
+    },
+    {
+      id: 'veteran',
+      label: 'Veteran',
+      description: 'Six months in the multiverse',
+      icon: 'ribbon',
+      earned: days >= 180,
+      progress: { current: days, target: 180 },
+    },
+    {
+      id: 'curator',
+      label: 'Curator',
+      description: 'Favourited 10 heroes',
+      icon: 'heart',
+      earned: favourites >= 10,
+      progress: { current: favourites, target: 10 },
+    },
+    {
+      id: 'archivist',
+      label: 'Archivist',
+      description: 'Favourited 50 heroes',
+      icon: 'library',
+      earned: favourites >= 50,
+      progress: { current: favourites, target: 50 },
+    },
+    {
+      id: 'oracle',
+      label: 'Oracle',
+      description: 'Called 10 daily battles',
+      icon: 'flash',
+      earned: votes >= 10,
+      progress: { current: votes, target: 10 },
+    },
+    {
+      id: 'on-fire',
+      label: 'On Fire',
+      description: 'A 3-day voting streak',
+      icon: 'flame',
+      earned: streak >= 3,
+      progress: { current: streak, target: 3 },
+    },
+    {
+      id: 'loyalist',
+      label: loyaltyLabel(topPublisher),
+      description: 'Your taste has a clear allegiance',
+      icon: 'shield',
+      earned: !!topPublisher && favourites >= 5,
+      progress: { current: favourites, target: 5 },
+    },
+  ];
+
+  // Earned first, otherwise keep definition order — gives a satisfying wall of
+  // unlocked badges with goals trailing.
+  return badges.sort((a, b) => Number(b.earned) - Number(a.earned));
+}
+
+/** How many of the computed badges are earned (for a "3 of 7" header). */
+export function earnedCount(badges: Badge[]): number {
+  return badges.filter((b) => b.earned).length;
+}


### PR DESCRIPTION
## Summary

Third identity-layer piece: a **Badges** wall on native + web profiles, derived purely from data we already have — **no new tables or RPCs**.

- New pure `src/lib/profile/badges.ts` → `computeBadges()` turns account age, favourites, matchup votes/streak, and top publisher into earned/locked badges with progress:
  - **Day One**, **Veteran** (6mo), **Curator** (10 favs), **Archivist** (50), **Oracle** (10 votes), **On Fire** (3-day streak), and a dynamic publisher-loyalty badge ("Marvel Loyalist" / "DC Devotee" / "{X} Fan")
- Badges section on both profiles: earned-first tiles, an "N/M earned" header, and a per-badge progress/Earned subline.
- 8 new unit tests (`now` injectable for deterministic tenure tests).

Completes the identity layer (Battle Record + Your Universe + Badges) — the groundwork the contribution layer depends on.

## Verification
- `yarn typecheck` clean · lint clean on changed files · **339/339 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_