### PR TITLE
Contributions backbone + admin Review (nested under Catalog)

### DIFF
--- a/app/admin/health.web.tsx
+++ b/app/admin/health.web.tsx
@@ -31,6 +31,7 @@ import { SpendDomain } from '../../src/components/admin/health/domains/SpendDoma
 import { SourcesDomain } from '../../src/components/admin/health/domains/SourcesDomain';
 import { fetchSourceCoverage } from '../../src/lib/db/catalogHealth';
 import { CampaignsDomain } from '../../src/components/admin/health/domains/CampaignsDomain';
+import { ReviewDomain } from '../../src/components/admin/health/domains/ReviewDomain';
 import { PlaceholderDomain } from '../../src/components/admin/health/domains/PlaceholderDomain';
 import {
   useActivityLog,
@@ -49,7 +50,9 @@ export default function AdminHealthScreen() {
   const { user, loading: authLoading } = useAuth();
 
   const [metric, setMetric] = useState<CoverageMetric>('portrait');
-  const [catSub, setCatSub] = useState<'coverage' | 'distributions' | 'hygiene'>('coverage');
+  const [catSub, setCatSub] = useState<'coverage' | 'distributions' | 'hygiene' | 'review'>(
+    'coverage',
+  );
   const [page, setPage] = useState(0);
   const [domain, setDomain] = useState<DomainKey>('command');
   const [heroQuery, setHeroQuery] = useState('');
@@ -326,6 +329,7 @@ export default function AdminHealthScreen() {
                 { key: 'coverage', label: 'Coverage', icon: 'stats-chart-outline' },
                 { key: 'distributions', label: 'Distributions', icon: 'pie-chart-outline' },
                 { key: 'hygiene', label: 'Hygiene', icon: 'git-merge-outline' },
+                { key: 'review', label: 'Review', icon: 'shield-checkmark-outline' },
               ]}
               active={catSub}
               onChange={setCatSub}
@@ -372,6 +376,14 @@ export default function AdminHealthScreen() {
                     }}
                   />
                 </View>
+              </ScrollView>
+            ) : null}
+            {catSub === 'review' ? (
+              <ScrollView
+                style={!narrow ? { flex: 1, minHeight: 0 } : undefined}
+                nestedScrollEnabled
+              >
+                <ReviewDomain />
               </ScrollView>
             ) : null}
           </Bento>

--- a/src/components/admin/health/domains/ReviewDomain.tsx
+++ b/src/components/admin/health/domains/ReviewDomain.tsx
@@ -1,0 +1,249 @@
+// Command-center domain: the community-contribution review queue. Admins approve
+// or reject pending suggestions (field edits, "Did You Know" facts, reports);
+// approval applies the change via the is_admin-gated admin_review_contribution
+// RPC. Web-only, like the rest of the command center.
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Panel } from '../Panel';
+import { COLORS } from '../../../../constants/colors';
+import {
+  getReviewQueue,
+  reviewContribution,
+  type ReviewItem,
+  type ContributionKind,
+} from '../../../../lib/db/contributions';
+
+const KIND_LABEL: Record<ContributionKind, string> = {
+  field: 'Field edit',
+  fact: 'New fact',
+  report: 'Report',
+};
+
+const KIND_COLOR: Record<ContributionKind, string> = {
+  field: COLORS.blue,
+  fact: COLORS.green,
+  report: COLORS.red,
+};
+
+export function ReviewDomain() {
+  const qc = useQueryClient();
+  const queueQ = useQuery({ queryKey: ['reviewQueue'], queryFn: () => getReviewQueue() });
+  const [rejectingId, setRejectingId] = useState<number | null>(null);
+  const [reason, setReason] = useState('');
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = () => qc.invalidateQueries({ queryKey: ['reviewQueue'] });
+
+  const decide = async (id: number, decision: 'approve' | 'reject', why?: string) => {
+    setErr(null);
+    setBusyId(id);
+    const res = await reviewContribution(id, decision, why);
+    setBusyId(null);
+    if (!res.ok) {
+      setErr(res.error ?? 'Action failed');
+      return;
+    }
+    setRejectingId(null);
+    setReason('');
+    refresh();
+  };
+
+  const queue = queueQ.data ?? [];
+
+  return (
+    <View style={s.wrap}>
+      <Panel
+        title="Review queue"
+        hint={
+          queueQ.isLoading
+            ? 'Loading…'
+            : queue.length === 0
+              ? 'Nothing awaiting review'
+              : `${queue.length} awaiting review`
+        }
+      >
+        {!!err && <Text style={s.err}>{err}</Text>}
+        {queueQ.isLoading ? (
+          <Text style={s.muted}>Loading…</Text>
+        ) : queue.length === 0 ? (
+          <Text style={s.muted}>The queue is clear — no pending contributions.</Text>
+        ) : (
+          <View style={{ gap: 10 }}>
+            {queue.map((item) => (
+              <ReviewRow
+                key={item.id}
+                item={item}
+                busy={busyId === item.id}
+                rejecting={rejectingId === item.id}
+                reason={reason}
+                onReason={setReason}
+                onApprove={() => decide(item.id, 'approve')}
+                onStartReject={() => {
+                  setRejectingId(item.id);
+                  setReason('');
+                }}
+                onCancelReject={() => setRejectingId(null)}
+                onConfirmReject={() => decide(item.id, 'reject', reason.trim() || undefined)}
+              />
+            ))}
+          </View>
+        )}
+      </Panel>
+    </View>
+  );
+}
+
+function ReviewRow({
+  item,
+  busy,
+  rejecting,
+  reason,
+  onReason,
+  onApprove,
+  onStartReject,
+  onCancelReject,
+  onConfirmReject,
+}: {
+  item: ReviewItem;
+  busy: boolean;
+  rejecting: boolean;
+  reason: string;
+  onReason: (v: string) => void;
+  onApprove: () => void;
+  onStartReject: () => void;
+  onCancelReject: () => void;
+  onConfirmReject: () => void;
+}) {
+  return (
+    <View style={s.row}>
+      <View style={s.rowHead}>
+        <View style={[s.kindTag, { backgroundColor: KIND_COLOR[item.kind] + '1c' }]}>
+          <Text style={[s.kindTagText, { color: KIND_COLOR[item.kind] }]}>
+            {KIND_LABEL[item.kind]}
+            {item.kind === 'field' && item.target_field ? ` · ${item.target_field}` : ''}
+          </Text>
+        </View>
+        <Text style={s.hero} numberOfLines={1}>
+          {item.hero_name}
+        </Text>
+        <Text style={s.meta} numberOfLines={1}>
+          {item.submitter ? `by ${item.submitter}` : 'by a member'} · {item.created_at.slice(0, 10)}
+        </Text>
+      </View>
+
+      {item.kind === 'field' ? (
+        <View style={s.diff}>
+          {!!item.old_value && (
+            <Text style={s.old} numberOfLines={3}>
+              {item.old_value}
+            </Text>
+          )}
+          <Text style={s.new}>{item.new_value}</Text>
+        </View>
+      ) : item.kind === 'fact' ? (
+        <Text style={s.new}>{item.new_value}</Text>
+      ) : (
+        <Text style={s.report}>{item.note || 'Flagged as incorrect.'}</Text>
+      )}
+
+      {item.kind !== 'report' && !!item.note && (
+        <Text style={s.note}>Note: {item.note}</Text>
+      )}
+
+      {rejecting ? (
+        <View style={s.rejectBox}>
+          <TextInput
+            value={reason}
+            onChangeText={onReason}
+            placeholder="Reason (optional, shown to the contributor)"
+            placeholderTextColor={COLORS.grey}
+            style={s.input as object}
+          />
+          <View style={s.actions}>
+            <Pressable
+              onPress={onConfirmReject}
+              disabled={busy}
+              style={[s.btn, s.btnDanger] as object}
+            >
+              <Text style={s.btnDangerText}>{busy ? 'Rejecting…' : 'Confirm reject'}</Text>
+            </Pressable>
+            <Pressable onPress={onCancelReject} style={s.btn as object}>
+              <Text style={s.btnText}>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : (
+        <View style={s.actions}>
+          <Pressable onPress={onApprove} disabled={busy} style={[s.btn, s.btnPrimary] as object}>
+            <Text style={s.btnPrimaryText}>{busy ? 'Working…' : 'Approve'}</Text>
+          </Pressable>
+          <Pressable onPress={onStartReject} disabled={busy} style={s.btn as object}>
+            <Text style={s.btnText}>Reject</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: { gap: 14 },
+  muted: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey, paddingVertical: 8 },
+  err: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.red, marginBottom: 8 },
+  row: {
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: '#f5efe3',
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.08)',
+  },
+  rowHead: { flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  kindTag: { paddingHorizontal: 8, paddingVertical: 3, borderRadius: 999 },
+  kindTagText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  hero: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.black, flex: 1 },
+  meta: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: COLORS.grey },
+  diff: { gap: 3 },
+  old: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 12,
+    color: COLORS.grey,
+    textDecorationLine: 'line-through',
+  },
+  new: { fontFamily: 'Nunito_400Regular', fontSize: 14, color: COLORS.black, lineHeight: 20 },
+  report: { fontFamily: 'Nunito_400Regular', fontSize: 14, color: COLORS.red, lineHeight: 20 },
+  note: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey, fontStyle: 'italic' },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.12)',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.black,
+  } as object,
+  rejectBox: { gap: 8 },
+  actions: { flexDirection: 'row', gap: 8, marginTop: 2 },
+  btn: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#efe6d6',
+    cursor: 'pointer',
+  } as object,
+  btnText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
+  btnPrimary: { backgroundColor: COLORS.green } as object,
+  btnPrimaryText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: '#fff' },
+  btnDanger: { backgroundColor: COLORS.red } as object,
+  btnDangerText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: '#fff' },
+});

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -1,0 +1,116 @@
+import { supabase } from '../supabase';
+
+// Community contributions (Phase 2a). Submission + the admin review queue go
+// through SECURITY DEFINER RPCs; everything is admin-vetted (no auto-approve).
+// The editable-field allow-list lives here as the single source of truth shared
+// by the submit flow and (later) the hero-page contribute mode.
+
+export type ContributionKind = 'field' | 'fact' | 'report';
+
+export interface EditableFieldDef {
+  field: string;
+  label: string;
+  guideline?: string;
+  multiline?: boolean;
+}
+
+/** The heroes text columns a contributor may propose. Mirrors the allow-list
+ *  enforced server-side in submit_contribution / admin_review_contribution. */
+export const EDITABLE_FIELDS: EditableFieldDef[] = [
+  { field: 'origin', label: 'Origin', guideline: 'Where this hero comes from — a sentence or two.', multiline: true },
+  { field: 'full_name', label: 'Full name', guideline: 'Their real or birth name.' },
+  { field: 'occupation', label: 'Occupation', guideline: 'What they do.' },
+  { field: 'base', label: 'Base of operations', guideline: 'Where they operate from.' },
+  { field: 'place_of_birth', label: 'Place of birth' },
+  { field: 'first_appearance', label: 'First appearance', guideline: 'The issue or title they debuted in.' },
+];
+
+export interface MyContribution {
+  id: number;
+  hero_id: string;
+  hero_name: string;
+  kind: ContributionKind;
+  target_field: string | null;
+  new_value: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'superseded';
+  reject_reason: string | null;
+  created_at: string;
+}
+
+export interface ReviewItem {
+  id: number;
+  hero_id: string;
+  hero_name: string;
+  kind: ContributionKind;
+  target_field: string | null;
+  old_value: string | null;
+  new_value: string | null;
+  note: string | null;
+  created_at: string;
+  user_id: string;
+  submitter: string | null;
+}
+
+export type SubmitResult = { ok: true; id: number } | { ok: false; error: string };
+
+/** Queue a contribution for admin review. */
+export async function submitContribution(opts: {
+  heroId: string;
+  kind: ContributionKind;
+  targetField?: string | null;
+  newValue?: string | null;
+  note?: string | null;
+}): Promise<SubmitResult> {
+  // RPC args are non-null text; pass '' for the slots a given kind doesn't use
+  // (the function only reads target_field for kind='field', etc.).
+  const { data, error } = await supabase.rpc('submit_contribution', {
+    p_hero_id: opts.heroId,
+    p_kind: opts.kind,
+    p_target_field: opts.targetField ?? '',
+    p_new_value: opts.newValue ?? '',
+    p_note: opts.note ?? '',
+  });
+  if (error) return { ok: false, error: error.message };
+  const d = (data ?? {}) as { id?: number };
+  return { ok: true, id: d.id ?? 0 };
+}
+
+/** The caller's own contributions, newest first. */
+export async function getMyContributions(): Promise<MyContribution[]> {
+  const { data, error } = await supabase.rpc('get_my_contributions');
+  if (error) {
+    console.warn('[getMyContributions] error:', error.message);
+    return [];
+  }
+  return (data ?? []) as unknown as MyContribution[];
+}
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+/** The pending review queue (admin-only; returns [] for non-admins). */
+export async function getReviewQueue(limit = 50, offset = 0): Promise<ReviewItem[]> {
+  const { data, error } = await supabase.rpc('admin_review_queue', {
+    p_limit: limit,
+    p_offset: offset,
+  });
+  if (error) {
+    console.warn('[getReviewQueue] error:', error.message);
+    return [];
+  }
+  return (data ?? []) as unknown as ReviewItem[];
+}
+
+/** Approve or reject a contribution (admin-only). Applies the change on approve. */
+export async function reviewContribution(
+  id: number,
+  decision: 'approve' | 'reject',
+  reason?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const { error } = await supabase.rpc('admin_review_contribution', {
+    p_id: id,
+    p_decision: decision,
+    p_reason: reason ?? '',
+  });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -71,6 +71,81 @@ export type Database = {
         }
         Relationships: []
       }
+      contributions: {
+        Row: {
+          created_at: string
+          hero_id: string
+          id: number
+          kind: string
+          new_value: string | null
+          note: string | null
+          old_value: string | null
+          reject_reason: string | null
+          reviewed_at: string | null
+          reviewed_by: string | null
+          status: string
+          target_field: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          hero_id: string
+          id?: never
+          kind: string
+          new_value?: string | null
+          note?: string | null
+          old_value?: string | null
+          reject_reason?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: string
+          target_field?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          hero_id?: string
+          id?: never
+          kind?: string
+          new_value?: string | null
+          note?: string | null
+          old_value?: string | null
+          reject_reason?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: string
+          target_field?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      contributor_stats: {
+        Row: {
+          approved: number
+          level: string
+          pending: number
+          rejected: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          approved?: number
+          level?: string
+          pending?: number
+          rejected?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          approved?: number
+          level?: string
+          pending?: number
+          rejected?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       cv_ingestion_state: {
         Row: {
           error: string | null
@@ -999,6 +1074,11 @@ export type Database = {
         Returns: string
       }
       admin_retry_failed: { Args: never; Returns: number }
+      admin_review_contribution: {
+        Args: { p_id: number; p_decision: string; p_reason: string }
+        Returns: Json
+      }
+      admin_review_queue: { Args: { p_limit?: number; p_offset?: number }; Returns: Json }
       admin_run_drain: { Args: { p_limit?: number }; Returns: string }
       admin_run_wikidata_enrich: { Args: { p_limit?: number }; Returns: string }
       admin_run_wikidata_resolve: {
@@ -1116,6 +1196,7 @@ export type Database = {
         }[]
       }
       get_my_battle_record: { Args: never; Returns: Json }
+      get_my_contributions: { Args: never; Returns: Json }
       get_my_taste_profile: { Args: never; Returns: Json }
       get_pending_build_ids: { Args: { p_limit?: number }; Returns: string[] }
       get_related_heroes: {
@@ -1256,6 +1337,16 @@ export type Database = {
       show_limit: { Args: never; Returns: number }
       show_trgm: { Args: { "": string }; Returns: string[] }
       snapshot_catalog_health: { Args: never; Returns: undefined }
+      submit_contribution: {
+        Args: {
+          p_hero_id: string
+          p_kind: string
+          p_new_value: string
+          p_note: string
+          p_target_field: string
+        }
+        Returns: Json
+      }
     }
     Enums: {
       relation_kind:

--- a/supabase/migrations/20260617150000_contributions_backbone.sql
+++ b/supabase/migrations/20260617150000_contributions_backbone.sql
@@ -1,0 +1,188 @@
+-- Community contributions backbone (Phase 2a of the profiles/contributions spec).
+-- Review-queued, ALWAYS admin-vetted (no auto-approve). v1 intake is deliberately
+-- narrow + low-risk: edit an allow-listed heroes text field, propose a
+-- "Did You Know" fact, or flag bad data. Applied changes are attributed to the
+-- community; reputation (contributor_stats.level) is cosmetic only.
+
+create table if not exists public.contributions (
+  id            bigint generated always as identity primary key,
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  hero_id       text not null references public.heroes(id) on delete cascade,
+  kind          text not null,        -- 'field' | 'fact' | 'report'
+  target_field  text,                 -- for kind='field'
+  old_value     text,                 -- snapshot at submit time
+  new_value     text,                 -- proposed value / fact content
+  note          text,                 -- submitter note / report reason
+  status        text not null default 'pending',
+  reviewed_by   uuid references auth.users(id),
+  reviewed_at   timestamptz,
+  reject_reason text,
+  created_at    timestamptz not null default now(),
+  constraint contributions_kind_chk   check (kind in ('field','fact','report')),
+  constraint contributions_status_chk check (status in ('pending','approved','rejected','superseded'))
+);
+create index if not exists contributions_status_idx on public.contributions (status, created_at);
+create index if not exists contributions_user_idx   on public.contributions (user_id);
+create index if not exists contributions_hero_idx   on public.contributions (hero_id);
+
+create table if not exists public.contributor_stats (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  approved   int not null default 0,
+  rejected   int not null default 0,
+  pending    int not null default 0,
+  level      text not null default 'new',  -- cosmetic (new|curator|steward); NEVER gates review
+  updated_at timestamptz not null default now()
+);
+
+alter table public.contributions     enable row level security;
+alter table public.contributor_stats enable row level security;
+
+drop policy if exists contributions_own_select on public.contributions;
+create policy contributions_own_select on public.contributions
+  for select to authenticated using (user_id = auth.uid());
+
+drop policy if exists contributor_stats_read on public.contributor_stats;
+create policy contributor_stats_read on public.contributor_stats
+  for select to authenticated using (true);
+
+-- ── Submit a contribution (auth required; queues as pending) ──────────────────
+create or replace function public.submit_contribution(
+  p_hero_id text, p_kind text, p_target_field text, p_new_value text, p_note text
+) returns json
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_old text;
+  v_id  bigint;
+  v_pending int;
+begin
+  if v_uid is null then raise exception 'not authenticated'; end if;
+  if p_kind not in ('field','fact','report') then raise exception 'invalid kind'; end if;
+  if not exists (select 1 from public.heroes where id = p_hero_id) then
+    raise exception 'unknown hero';
+  end if;
+
+  select count(*) into v_pending from public.contributions
+    where user_id = v_uid and status = 'pending';
+  if v_pending >= 20 then raise exception 'too many pending contributions'; end if;
+
+  if p_kind = 'field' then
+    if p_target_field not in
+      ('origin','occupation','base','place_of_birth','first_appearance','full_name') then
+      raise exception 'field not editable';
+    end if;
+    if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+    if exists (select 1 from public.contributions
+               where user_id = v_uid and hero_id = p_hero_id and kind = 'field'
+                 and target_field = p_target_field and status = 'pending') then
+      raise exception 'you already have a pending suggestion for this field';
+    end if;
+    execute format('select %I from public.heroes where id = $1', p_target_field)
+      into v_old using p_hero_id;
+  elsif p_kind = 'fact' then
+    if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+  end if;
+
+  insert into public.contributions (user_id, hero_id, kind, target_field, old_value, new_value, note)
+  values (v_uid, p_hero_id, p_kind, p_target_field, v_old, p_new_value, p_note)
+  returning id into v_id;
+
+  insert into public.contributor_stats (user_id, pending)
+  values (v_uid, 1)
+  on conflict (user_id) do update
+    set pending = public.contributor_stats.pending + 1, updated_at = now();
+
+  return json_build_object('id', v_id, 'status', 'pending');
+end;
+$$;
+
+-- ── The caller's own contributions (for the profile "Contributions" section) ──
+create or replace function public.get_my_contributions()
+returns json language sql security definer set search_path = public stable
+as $$
+  select coalesce(json_agg(r), '[]'::json) from (
+    select c.id, c.hero_id, h.name as hero_name, c.kind, c.target_field,
+           c.new_value, c.status, c.reject_reason, c.created_at
+    from public.contributions c
+    join public.heroes h on h.id = c.hero_id
+    where c.user_id = auth.uid()
+    order by c.created_at desc
+  ) r;
+$$;
+
+-- ── Admin: the pending review queue ───────────────────────────────────────────
+create or replace function public.admin_review_queue(p_limit int default 50, p_offset int default 0)
+returns json language sql security definer set search_path = public stable
+as $$
+  select coalesce(json_agg(r), '[]'::json) from (
+    select c.id, c.hero_id, h.name as hero_name, c.kind, c.target_field,
+           c.old_value, c.new_value, c.note, c.created_at, c.user_id,
+           p.display_name as submitter
+    from public.contributions c
+    join public.heroes h on h.id = c.hero_id
+    left join public.user_profiles p on p.id = c.user_id
+    where c.status = 'pending'
+      and exists (select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin)
+    order by c.created_at asc
+    limit p_limit offset p_offset
+  ) r;
+$$;
+
+-- ── Admin: approve/reject a contribution (applies the change on approve) ──────
+create or replace function public.admin_review_contribution(p_id bigint, p_decision text, p_reason text)
+returns json language plpgsql security definer set search_path = public
+as $$
+declare
+  c public.contributions;
+  v_admin uuid := auth.uid();
+begin
+  if not exists (select 1 from public.user_profiles where id = v_admin and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  if p_decision not in ('approve','reject') then raise exception 'invalid decision'; end if;
+
+  select * into c from public.contributions where id = p_id for update;
+  if not found then raise exception 'not found'; end if;
+  if c.status <> 'pending' then raise exception 'already reviewed'; end if;
+
+  if p_decision = 'approve' then
+    if c.kind = 'field' then
+      execute format('update public.heroes set %I = $1 where id = $2', c.target_field)
+        using c.new_value, c.hero_id;
+    elsif c.kind = 'fact' then
+      insert into public.hero_narrative_facts (hero_id, kind, content, source_model, needs_review)
+      values (c.hero_id, 'did_you_know', c.new_value, 'community', false);
+    end if;  -- 'report' approval = acknowledged, no data mutation
+    update public.contributions
+      set status = 'approved', reviewed_by = v_admin, reviewed_at = now() where id = p_id;
+    update public.contributor_stats
+      set approved = approved + 1, pending = greatest(pending - 1, 0), updated_at = now()
+      where user_id = c.user_id;
+  else
+    update public.contributions
+      set status = 'rejected', reviewed_by = v_admin, reviewed_at = now(), reject_reason = p_reason
+      where id = p_id;
+    update public.contributor_stats
+      set rejected = rejected + 1, pending = greatest(pending - 1, 0), updated_at = now()
+      where user_id = c.user_id;
+  end if;
+
+  update public.contributor_stats
+    set level = case when approved >= 50 then 'steward'
+                     when approved >= 10 then 'curator' else 'new' end
+    where user_id = c.user_id;
+
+  return json_build_object('id', p_id,
+    'status', case when p_decision = 'approve' then 'approved' else 'rejected' end);
+end;
+$$;
+
+revoke all on function public.submit_contribution(text, text, text, text, text)   from public, anon;
+revoke all on function public.get_my_contributions()                              from public, anon;
+revoke all on function public.admin_review_queue(int, int)                        from public, anon;
+revoke all on function public.admin_review_contribution(bigint, text, text)       from public, anon;
+grant execute on function public.submit_contribution(text, text, text, text, text)  to authenticated, service_role;
+grant execute on function public.get_my_contributions()                             to authenticated, service_role;
+grant execute on function public.admin_review_queue(int, int)                       to authenticated, service_role;
+grant execute on function public.admin_review_contribution(bigint, text, text)      to authenticated, service_role;


### PR DESCRIPTION
## Summary

Phase 2a of the profiles/contributions spec — the review-queued, **always admin-vetted** contribution backend plus the moderator tool. No contributor-facing UI yet (that's 2b); the queue is exercised via the submit RPC.

### Backend (migration applied + verified)
- `contributions` + `contributor_stats` tables (RLS: users read their own; stats world-readable). v1 intake is narrow/low-risk: edit an allow-listed `heroes` text field, propose a Did-You-Know fact, or flag a report.
- `submit_contribution` / `get_my_contributions` / `admin_review_queue` / `admin_review_contribution` RPCs — `SECURITY DEFINER`, `search_path` pinned, revoked from anon; admin RPCs guarded by `is_admin`. Approval applies the change (field update / fact insert) and attributes it to the community. No auto-approve.

### Admin tool
- `ReviewDomain`: approve/reject queue with old→new diff, per-item reject reason, react-query refresh.
- Surfaced as a **Catalog sub-tab** (Coverage · Distributions · Hygiene · Review) rather than a 7th top-level domain — keeps the command-center nav at 6 (off the crowded mobile bottom bar) and is the correct hierarchy (review is catalog stewardship).

## Verification
- Migration applied; `database.generated.ts` updated; advisors clean (new tables have RLS+policies; RPCs not anon-executable)
- `yarn typecheck` clean · lint clean on changed files · **339/339 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_