### PR TITLE
On-page contribute UX + admin direct-edit + profile contributions

### DIFF
--- a/__tests__/lib/contribute/missingFields.test.ts
+++ b/__tests__/lib/contribute/missingFields.test.ts
@@ -1,0 +1,39 @@
+import { isBlankValue, missingFields, presentFields } from '../../../src/lib/contribute/missingFields';
+
+describe('isBlankValue', () => {
+  it('treats null/undefined/empty and DB sentinels as blank', () => {
+    expect(isBlankValue(null)).toBe(true);
+    expect(isBlankValue(undefined)).toBe(true);
+    expect(isBlankValue('')).toBe(true);
+    expect(isBlankValue('   ')).toBe(true);
+    expect(isBlankValue('-')).toBe(true);
+    expect(isBlankValue('null')).toBe(true);
+  });
+
+  it('treats real values as present', () => {
+    expect(isBlankValue('Krypton')).toBe(false);
+    expect(isBlankValue('0')).toBe(false);
+  });
+});
+
+describe('missingFields / presentFields', () => {
+  it('splits editable fields by presence', () => {
+    const values = {
+      origin: 'Born on Krypton',
+      occupation: '',
+      base: null,
+      place_of_birth: 'Krypton',
+      first_appearance: '-',
+      full_name: 'Kal-El',
+    };
+    const missing = missingFields(values).map((f) => f.field);
+    const present = presentFields(values).map((f) => f.field);
+    expect(missing.sort()).toEqual(['base', 'first_appearance', 'occupation']);
+    expect(present.sort()).toEqual(['full_name', 'origin', 'place_of_birth']);
+  });
+
+  it('reports every editable field missing for an empty hero', () => {
+    expect(missingFields({}).length).toBe(6);
+    expect(presentFields({}).length).toBe(0);
+  });
+});

--- a/__tests__/lib/contribute/reward.test.ts
+++ b/__tests__/lib/contribute/reward.test.ts
@@ -1,0 +1,33 @@
+import { ordinal, rewardLine } from '../../../src/lib/contribute/reward';
+
+describe('ordinal', () => {
+  it('suffixes 1/2/3 correctly', () => {
+    expect(ordinal(1)).toBe('1st');
+    expect(ordinal(2)).toBe('2nd');
+    expect(ordinal(3)).toBe('3rd');
+    expect(ordinal(4)).toBe('4th');
+  });
+
+  it('handles the 11–13 exceptions', () => {
+    expect(ordinal(11)).toBe('11th');
+    expect(ordinal(12)).toBe('12th');
+    expect(ordinal(13)).toBe('13th');
+  });
+
+  it('handles larger numbers by last digit', () => {
+    expect(ordinal(21)).toBe('21st');
+    expect(ordinal(42)).toBe('42nd');
+    expect(ordinal(113)).toBe('113th');
+  });
+});
+
+describe('rewardLine', () => {
+  it('welcomes the first contribution', () => {
+    expect(rewardLine(1)).toMatch(/first contribution/i);
+    expect(rewardLine(0)).toMatch(/first contribution/i);
+  });
+
+  it('celebrates the running tally afterward', () => {
+    expect(rewardLine(3)).toContain('3rd');
+  });
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -34,6 +34,11 @@ import {
 } from '../../src/lib/db/favourites';
 import { getBattleRecord, type BattleRecord } from '../../src/lib/db/matchupVotes';
 import {
+  getMyContributions,
+  describeContribution,
+  type MyContribution,
+} from '../../src/lib/db/contributions';
+import {
   getTasteProfile,
   dominantAlignment,
   shortPublisher,
@@ -56,6 +61,21 @@ const HERO_LOGO_PATH =
 function username(email: string) {
   return email.split('@')[0] ?? email;
 }
+
+// ── My Contributions presentation ───────────────────────────────────────────
+const STATUS_BG: Record<MyContribution['status'], string> = {
+  pending: 'rgba(231,115,51,0.14)',
+  approved: 'rgba(99,169,54,0.16)',
+  rejected: '#e8ddd0',
+  superseded: '#e8ddd0',
+};
+const STATUS_FG: Record<MyContribution['status'], string> = {
+  pending: COLORS.orange,
+  approved: COLORS.green,
+  rejected: COLORS.grey,
+  superseded: COLORS.grey,
+};
+
 
 function FavouriteThumb({
   hero,
@@ -264,6 +284,7 @@ export default function ProfileScreen() {
   } = useProfile(user?.id);
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
   const [battle, setBattle] = useState<BattleRecord | null>(null);
+  const [contributions, setContributions] = useState<MyContribution[]>([]);
   const [taste, setTaste] = useState<TasteProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -280,6 +301,9 @@ export default function ProfileScreen() {
       .catch(() => {});
     getTasteProfile()
       .then(setTaste)
+      .catch(() => {});
+    getMyContributions()
+      .then(setContributions)
       .catch(() => {});
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
@@ -676,6 +700,38 @@ export default function ProfileScreen() {
         </View>
 
         <View style={styles.hairline} />
+
+        {/* My Contributions — submissions + their review status. */}
+        {contributions.length > 0 && (
+          <>
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <Text style={styles.sectionTitle}>My Contributions</Text>
+                <Text style={styles.sectionCount}>{contributions.length}</Text>
+              </View>
+              <View style={styles.contribList}>
+                {contributions.slice(0, 12).map((c) => (
+                  <View key={c.id} style={styles.contribRow}>
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.contribHero} numberOfLines={1}>
+                        {c.hero_name}
+                      </Text>
+                      <Text style={styles.contribWhat} numberOfLines={1}>
+                        {describeContribution(c)}
+                      </Text>
+                    </View>
+                    <View style={[styles.statusPill, { backgroundColor: STATUS_BG[c.status] }]}>
+                      <Text style={[styles.statusText, { color: STATUS_FG[c.status] }]}>
+                        {c.status}
+                      </Text>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            </View>
+            <View style={styles.hairline} />
+          </>
+        )}
 
         {/* My Favourites */}
         <View style={styles.section}>
@@ -1218,6 +1274,29 @@ const styles = StyleSheet.create({
   },
 
   // Badges
+  // My Contributions
+  contribList: { gap: 8 },
+  contribRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.08)',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  contribHero: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.navy },
+  contribWhat: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey, marginTop: 1 },
+  statusPill: { borderRadius: 999, paddingHorizontal: 10, paddingVertical: 4 },
+  statusText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+
   badgeRow: { gap: 10, paddingRight: 16 },
   badgeTile: { width: 92, alignItems: 'center', gap: 6 },
   badgeTileLocked: { opacity: 0.55 },

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -24,6 +24,11 @@ import {
 } from '../../src/lib/db/favourites';
 import { getBattleRecord, type BattleRecord } from '../../src/lib/db/matchupVotes';
 import {
+  getMyContributions,
+  describeContribution,
+  type MyContribution,
+} from '../../src/lib/db/contributions';
+import {
   getTasteProfile,
   dominantAlignment,
   shortPublisher,
@@ -77,6 +82,19 @@ function DeskFavSkeleton() {
 function username(email: string) {
   return email.split('@')[0] ?? email;
 }
+
+const STATUS_BG: Record<MyContribution['status'], string> = {
+  pending: 'rgba(231,115,51,0.14)',
+  approved: 'rgba(99,169,54,0.16)',
+  rejected: '#e8ddd0',
+  superseded: '#e8ddd0',
+};
+const STATUS_FG: Record<MyContribution['status'], string> = {
+  pending: COLORS.orange,
+  approved: COLORS.green,
+  rejected: COLORS.grey,
+  superseded: COLORS.grey,
+};
 
 function GuestWebProfileScreen() {
   const router = useRouter();
@@ -289,6 +307,7 @@ export default function WebProfileScreen() {
   const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
   const [battle, setBattle] = useState<BattleRecord | null>(null);
   const [taste, setTaste] = useState<TasteProfile | null>(null);
+  const [contributions, setContributions] = useState<MyContribution[]>([]);
   const [loading, setLoading] = useState(true);
   const [signingOut, setSigningOut] = useState(false);
   const [deletingAccount, setDeletingAccount] = useState(false);
@@ -303,6 +322,9 @@ export default function WebProfileScreen() {
       .catch(() => {});
     getTasteProfile()
       .then(setTaste)
+      .catch(() => {});
+    getMyContributions()
+      .then(setContributions)
       .catch(() => {});
     getUserFavouriteHeroes(user.id)
       .then(setFavourites)
@@ -637,6 +659,38 @@ export default function WebProfileScreen() {
             </View>
           </View>
           <View style={mob.hairline} />
+
+          {/* ── My Contributions ── */}
+          {contributions.length > 0 && (
+            <>
+              <View style={mob.section}>
+                <View style={mob.sectionHeader}>
+                  <Text style={mob.sectionTitle}>My Contributions</Text>
+                  <Text style={mob.sectionCount}>{contributions.length}</Text>
+                </View>
+                <View style={mob.contribList}>
+                  {contributions.slice(0, 12).map((c) => (
+                    <View key={c.id} style={mob.contribRow}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={mob.contribHero} numberOfLines={1}>
+                          {c.hero_name}
+                        </Text>
+                        <Text style={mob.contribWhat} numberOfLines={1}>
+                          {describeContribution(c)}
+                        </Text>
+                      </View>
+                      <View style={[mob.statusPill, { backgroundColor: STATUS_BG[c.status] }]}>
+                        <Text style={[mob.statusText, { color: STATUS_FG[c.status] }]}>
+                          {c.status}
+                        </Text>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </View>
+              <View style={mob.hairline} />
+            </>
+          )}
 
           {/* ── My Favourites ── */}
           <View style={mob.section}>
@@ -1177,6 +1231,30 @@ export default function WebProfileScreen() {
                 ))}
               </View>
             </View>
+            {contributions.length > 0 && (
+              <View style={desk.battleBlock}>
+                <Text style={desk.sectionTitle}>My Contributions</Text>
+                <View style={desk.contribList}>
+                  {contributions.slice(0, 12).map((c) => (
+                    <View key={c.id} style={desk.contribRow}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={desk.contribHero} numberOfLines={1}>
+                          {c.hero_name}
+                        </Text>
+                        <Text style={desk.contribWhat} numberOfLines={1}>
+                          {describeContribution(c)}
+                        </Text>
+                      </View>
+                      <View style={[desk.statusPill, { backgroundColor: STATUS_BG[c.status] }]}>
+                        <Text style={[desk.statusText, { color: STATUS_FG[c.status] }]}>
+                          {c.status}
+                        </Text>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            )}
             <View style={desk.sectionHeader}>
               <Text style={desk.sectionTitle}>My Favourites</Text>
               {!loading && favourites.length > 0 && (
@@ -1467,6 +1545,27 @@ const mob = StyleSheet.create({
   },
 
   // Badges
+  contribList: { gap: 8 },
+  contribRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.08)',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  contribHero: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.navy },
+  contribWhat: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey, marginTop: 1 },
+  statusPill: { borderRadius: 999, paddingHorizontal: 10, paddingVertical: 4 },
+  statusText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
   badgeWall: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
   badgeTile: { width: 80, alignItems: 'center', gap: 6 },
   badgeTileLocked: { opacity: 0.55 } as object,
@@ -1923,6 +2022,27 @@ const desk = StyleSheet.create({
   tasteFootnote: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey },
   // Badges
   badgeHead: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  contribList: { gap: 8 },
+  contribRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.08)',
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+  },
+  contribHero: { fontFamily: 'Flame-Regular', fontSize: 16, color: COLORS.navy },
+  contribWhat: { fontFamily: 'Nunito_400Regular', fontSize: 13, color: COLORS.grey, marginTop: 1 },
+  statusPill: { borderRadius: 999, paddingHorizontal: 11, paddingVertical: 5 },
+  statusText: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
   badgeWall: { flexDirection: 'row', flexWrap: 'wrap', gap: 16 },
   badgeTile: { width: 88, alignItems: 'center', gap: 7 },
   badgeTileLocked: { opacity: 0.55 } as object,

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -1340,6 +1340,7 @@ export default function CharacterScreen() {
                 }}
                 user={user}
                 onRequestSignIn={() => router.push('/(auth)/login')}
+                onEdited={() => heroRowQuery.refetch()}
               />
 
               {/* Enemies, Allies & Teams — full-bleed card strips off the

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -63,6 +63,7 @@ import {
 import { PortrayedBySection } from '../../src/components/PortrayedBySection';
 import { HeroLinksRow, heroLinksHasContent } from '../../src/components/HeroLinksRow';
 import { useAuth } from '../../src/hooks/useAuth';
+import { HelpCompleteCard } from '../../src/components/contribute/HelpCompleteCard';
 import { useRecordView } from '../../src/hooks/useViewHistory';
 import { HeroImage } from '../../src/components/HeroImage';
 import { COLORS } from '../../src/constants/colors';
@@ -1324,6 +1325,22 @@ export default function CharacterScreen() {
                   eraSummary={narrative?.eraSummary}
                 />
               </View>
+
+              {/* Help complete this page — contributor entry point (gaps + facts). */}
+              <HelpCompleteCard
+                heroId={data.stats.id}
+                heroName={data.stats.name}
+                values={{
+                  origin: data.details.origin,
+                  occupation: data.stats.work.occupation,
+                  base: data.stats.work.base,
+                  place_of_birth: data.stats.biography['place-of-birth'],
+                  first_appearance: data.stats.biography['first-appearance'],
+                  full_name: data.stats.biography['full-name'],
+                }}
+                user={user}
+                onRequestSignIn={() => router.push('/(auth)/login')}
+              />
 
               {/* Enemies, Allies & Teams — full-bleed card strips off the
                   relationship graph (same-universe, popularity-ranked). */}

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -666,6 +666,12 @@ export default function WebCharacterScreen() {
       }}
       user={user}
       onRequestSignIn={() => router.push('/(auth)/login')}
+      onEdited={() => {
+        // Re-derive from the freshly-edited DB row so the page reflects the change.
+        getHeroById(stats.id)
+          .then((hero) => hero && setData(heroRowToCharacterData(hero)))
+          .catch(() => {});
+      }}
       style={{ marginHorizontal: 0 }}
     />
   );

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -19,6 +19,7 @@ import { supabase } from '../../src/lib/supabase';
 import { isFavourited, addFavourite, removeFavourite } from '../../src/lib/db/favourites';
 import { getPowerIcon, groupPowers } from '../../src/constants/powerIcons';
 import { useAuth } from '../../src/hooks/useAuth';
+import { HelpCompleteCard } from '../../src/components/contribute/HelpCompleteCard';
 import { heroImageSource } from '../../src/constants/heroImages';
 import { HeroImage } from '../../src/components/HeroImage';
 import { COLORS } from '../../src/constants/colors';
@@ -649,6 +650,26 @@ export default function WebCharacterScreen() {
 
   const { stats, details } = data;
 
+  // Contributor entry point — defined once, placed in both the desktop and
+  // mobile-web content trees below. Flush (no side margin) to sit in the column.
+  const contributeCard = (
+    <HelpCompleteCard
+      heroId={stats.id}
+      heroName={stats.name}
+      values={{
+        origin: details.origin,
+        occupation: stats.work.occupation,
+        base: stats.work.base,
+        place_of_birth: stats.biography['place-of-birth'],
+        first_appearance: stats.biography['first-appearance'],
+        full_name: stats.biography['full-name'],
+      }}
+      user={user}
+      onRequestSignIn={() => router.push('/(auth)/login')}
+      style={{ marginHorizontal: 0 }}
+    />
+  );
+
   // Affiliations live in the main "Enemies, Allies & Teams" card (not Quick Facts)
   // so the sticky side rail stays short enough to fit the viewport.
   const affiliations: string[] = details.teams?.length
@@ -1027,6 +1048,8 @@ export default function WebCharacterScreen() {
                       <DidYouKnowDeck facts={narrative.didYouKnow} />
                     </View>
                   ) : null}
+
+                  {contributeCard}
 
                   {/* Enemies & Allies */}
                   {comicVineLoading ? (
@@ -1701,6 +1724,8 @@ export default function WebCharacterScreen() {
                     <DidYouKnowDeck facts={narrative.didYouKnow} contentInset={20} />
                   </View>
                 ) : null}
+
+                <View style={{ paddingHorizontal: 20 }}>{contributeCard}</View>
 
                 {/* Family tree */}
                 {family.length > 0 ? (

--- a/src/components/contribute/ContributeSheet.tsx
+++ b/src/components/contribute/ContributeSheet.tsx
@@ -1,0 +1,242 @@
+// Cross-platform contribution sheet — a bottom sheet that asks one
+// question-framed thing (a field edit or a "Did You Know" fact) and submits it
+// for review. Everything is admin-vetted, so copy makes clear it's a suggestion;
+// the reward is immediate (a warm, status-building confirmation) since the live
+// change is deferred. Used by HelpCompleteCard (native + web via RNW).
+import { useEffect, useState } from 'react';
+import { Modal, View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { COLORS } from '../../constants/colors';
+import { submitContribution, type EditableFieldDef } from '../../lib/db/contributions';
+import { rewardLine } from '../../lib/contribute/reward';
+
+export interface ContributeSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  heroId: string;
+  heroName: string;
+  /** Field edit when set; a "Did You Know" fact when null. */
+  field: EditableFieldDef | null;
+  user: { id: string } | null | undefined;
+  /** The user's contribution count BEFORE this one (for the reward number). */
+  priorCount: number;
+  onRequestSignIn: () => void;
+  /** Called after a successful submit (so the card can mark the field pending). */
+  onSubmitted?: (field: EditableFieldDef | null) => void;
+}
+
+export function ContributeSheet({
+  visible,
+  onClose,
+  heroId,
+  heroName,
+  field,
+  user,
+  priorCount,
+  onRequestSignIn,
+  onSubmitted,
+}: ContributeSheetProps) {
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setValue('');
+      setError(null);
+      setDone(false);
+      setSubmitting(false);
+    }
+  }, [visible, field]);
+
+  const isFact = !field;
+  const prompt = isFact ? 'Know a fun fact about this hero?' : field!.question;
+  const guideline = isFact
+    ? 'Share a "Did You Know" — one or two sentences.'
+    : (field!.guideline ?? '');
+  const multiline = isFact || !!field?.multiline;
+
+  const submit = async () => {
+    if (!value.trim()) {
+      setError('Add something first.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    const res = await submitContribution({
+      heroId,
+      kind: isFact ? 'fact' : 'field',
+      targetField: field?.field ?? null,
+      newValue: value.trim(),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      setError(res.error ?? 'Could not submit — please try again.');
+      return;
+    }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {});
+    setDone(true);
+    onSubmitted?.(field);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={s.backdrop} onPress={onClose}>
+        <Pressable style={s.sheet} onPress={(e) => e.stopPropagation?.()}>
+          <View style={s.grabber} />
+
+          {!user ? (
+            <View style={s.body}>
+              <Text style={s.kicker}>{heroName}</Text>
+              <Text style={s.prompt}>Help complete this page</Text>
+              <Text style={s.guideline}>
+                Sign in to add what you know — it helps everyone who looks this hero up.
+              </Text>
+              <Pressable onPress={onRequestSignIn} style={[s.btn, s.btnPrimary]}>
+                <Text style={s.btnPrimaryText}>Sign in to contribute</Text>
+              </Pressable>
+            </View>
+          ) : done ? (
+            <View style={s.body}>
+              <View style={s.doneIcon}>
+                <Ionicons name="checkmark" size={28} color="#fff" />
+              </View>
+              <Text style={s.doneTitle}>Sent for review</Text>
+              <Text style={s.doneSub}>{rewardLine(priorCount + 1)}</Text>
+              <Text style={s.doneMeta}>A moderator will take a look before it goes live.</Text>
+              <Pressable onPress={onClose} style={[s.btn, s.btnPrimary]}>
+                <Text style={s.btnPrimaryText}>Done</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View style={s.body}>
+              <Text style={s.kicker}>{heroName}</Text>
+              <Text style={s.prompt}>{prompt}</Text>
+              {!!guideline && <Text style={s.guideline}>{guideline}</Text>}
+              <TextInput
+                value={value}
+                onChangeText={setValue}
+                placeholder={isFact ? 'Did you know…' : 'Type your answer'}
+                placeholderTextColor={COLORS.grey}
+                multiline={multiline}
+                style={[s.input, multiline && s.inputMultiline]}
+                autoFocus
+                onSubmitEditing={multiline ? undefined : submit}
+                returnKeyType="done"
+              />
+              {!!error && <Text style={s.error}>{error}</Text>}
+              <Pressable
+                onPress={submit}
+                disabled={submitting}
+                style={[s.btn, s.btnPrimary, submitting && s.btnDisabled]}
+              >
+                <Text style={s.btnPrimaryText}>{submitting ? 'Submitting…' : 'Submit for review'}</Text>
+              </Pressable>
+              <Text style={s.reviewNote}>Suggestions are reviewed before they appear.</Text>
+            </View>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(11,24,32,0.55)', justifyContent: 'flex-end' },
+  sheet: {
+    width: '100%',
+    maxWidth: 520,
+    alignSelf: 'center',
+    backgroundColor: COLORS.beige,
+    borderTopLeftRadius: 22,
+    borderTopRightRadius: 22,
+    borderCurve: 'continuous',
+    paddingBottom: 28,
+  },
+  grabber: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(41,60,67,0.25)',
+    alignSelf: 'center',
+    marginTop: 10,
+    marginBottom: 6,
+  },
+  body: { paddingHorizontal: 22, paddingTop: 10 },
+  kicker: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    color: COLORS.orange,
+    marginBottom: 4,
+  },
+  prompt: { fontFamily: 'Flame-Regular', fontSize: 26, color: COLORS.navy, lineHeight: 30 },
+  guideline: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 14,
+    color: 'rgba(41,60,67,0.7)',
+    lineHeight: 20,
+    marginTop: 6,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.12)',
+    paddingHorizontal: 14,
+    paddingVertical: 13,
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 16,
+    color: COLORS.black,
+    marginTop: 16,
+  },
+  inputMultiline: { minHeight: 110, textAlignVertical: 'top' },
+  error: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.red, marginTop: 10 },
+  btn: { paddingVertical: 14, borderRadius: 26, alignItems: 'center', marginTop: 16 },
+  btnPrimary: { backgroundColor: COLORS.orange },
+  btnPrimaryText: { fontFamily: 'Nunito_700Bold', fontSize: 15, color: '#fff', letterSpacing: 0.3 },
+  btnDisabled: { opacity: 0.6 },
+  reviewNote: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 12,
+    color: COLORS.grey,
+    textAlign: 'center',
+    marginTop: 12,
+  },
+  doneIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: COLORS.green,
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'center',
+    marginTop: 8,
+    marginBottom: 14,
+  },
+  doneTitle: {
+    fontFamily: 'Flame-Regular',
+    fontSize: 24,
+    color: COLORS.navy,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  doneSub: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 15,
+    color: COLORS.navy,
+    textAlign: 'center',
+    lineHeight: 21,
+    marginBottom: 6,
+  },
+  doneMeta: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: 'rgba(41,60,67,0.7)',
+    textAlign: 'center',
+    lineHeight: 19,
+  },
+});

--- a/src/components/contribute/ContributeSheet.tsx
+++ b/src/components/contribute/ContributeSheet.tsx
@@ -8,7 +8,7 @@ import { Modal, View, Text, TextInput, Pressable, StyleSheet } from 'react-nativ
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { COLORS } from '../../constants/colors';
-import { submitContribution, type EditableFieldDef } from '../../lib/db/contributions';
+import { submitContribution, adminEditHero, type EditableFieldDef } from '../../lib/db/contributions';
 import { rewardLine } from '../../lib/contribute/reward';
 
 export interface ContributeSheetProps {
@@ -21,8 +21,12 @@ export interface ContributeSheetProps {
   user: { id: string } | null | undefined;
   /** The user's contribution count BEFORE this one (for the reward number). */
   priorCount: number;
+  /** Admin = direct apply (no queue): "Save" instead of "Submit for review". */
+  isAdmin?: boolean;
+  /** Current value when editing a field that already has one. */
+  currentValue?: string | null;
   onRequestSignIn: () => void;
-  /** Called after a successful submit (so the card can mark the field pending). */
+  /** Called after a successful submit (so the card can mark the field pending/saved). */
   onSubmitted?: (field: EditableFieldDef | null) => void;
 }
 
@@ -34,6 +38,8 @@ export function ContributeSheet({
   field,
   user,
   priorCount,
+  isAdmin = false,
+  currentValue,
   onRequestSignIn,
   onSubmitted,
 }: ContributeSheetProps) {
@@ -65,12 +71,13 @@ export function ContributeSheet({
     }
     setSubmitting(true);
     setError(null);
-    const res = await submitContribution({
+    const payload = {
       heroId,
-      kind: isFact ? 'fact' : 'field',
+      kind: (isFact ? 'fact' : 'field') as 'fact' | 'field',
       targetField: field?.field ?? null,
       newValue: value.trim(),
-    });
+    };
+    const res = isAdmin ? await adminEditHero(payload) : await submitContribution(payload);
     setSubmitting(false);
     if (!res.ok) {
       setError(res.error ?? 'Could not submit — please try again.');
@@ -103,9 +110,13 @@ export function ContributeSheet({
               <View style={s.doneIcon}>
                 <Ionicons name="checkmark" size={28} color="#fff" />
               </View>
-              <Text style={s.doneTitle}>Sent for review</Text>
-              <Text style={s.doneSub}>{rewardLine(priorCount + 1)}</Text>
-              <Text style={s.doneMeta}>A moderator will take a look before it goes live.</Text>
+              <Text style={s.doneTitle}>{isAdmin ? 'Saved' : 'Sent for review'}</Text>
+              <Text style={s.doneSub}>
+                {isAdmin ? "It's live now." : rewardLine(priorCount + 1)}
+              </Text>
+              {!isAdmin && (
+                <Text style={s.doneMeta}>A moderator will take a look before it goes live.</Text>
+              )}
               <Pressable onPress={onClose} style={[s.btn, s.btnPrimary]}>
                 <Text style={s.btnPrimaryText}>Done</Text>
               </Pressable>
@@ -115,6 +126,12 @@ export function ContributeSheet({
               <Text style={s.kicker}>{heroName}</Text>
               <Text style={s.prompt}>{prompt}</Text>
               {!!guideline && <Text style={s.guideline}>{guideline}</Text>}
+              {isAdmin && !!currentValue && (
+                <View style={s.current}>
+                  <Text style={s.currentLabel}>Current</Text>
+                  <Text style={s.currentValue}>{currentValue}</Text>
+                </View>
+              )}
               <TextInput
                 value={value}
                 onChangeText={setValue}
@@ -132,9 +149,13 @@ export function ContributeSheet({
                 disabled={submitting}
                 style={[s.btn, s.btnPrimary, submitting && s.btnDisabled]}
               >
-                <Text style={s.btnPrimaryText}>{submitting ? 'Submitting…' : 'Submit for review'}</Text>
+                <Text style={s.btnPrimaryText}>
+                  {submitting ? 'Saving…' : isAdmin ? 'Save' : 'Submit for review'}
+                </Text>
               </Pressable>
-              <Text style={s.reviewNote}>Suggestions are reviewed before they appear.</Text>
+              {!isAdmin && (
+                <Text style={s.reviewNote}>Suggestions are reviewed before they appear.</Text>
+              )}
             </View>
           )}
         </Pressable>
@@ -194,6 +215,21 @@ const s = StyleSheet.create({
     marginTop: 16,
   },
   inputMultiline: { minHeight: 110, textAlignVertical: 'top' },
+  current: { backgroundColor: '#e8ddd0', borderRadius: 10, padding: 12, marginTop: 14 },
+  currentLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 9,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+    marginBottom: 3,
+  },
+  currentValue: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.navy,
+    lineHeight: 18,
+  },
   error: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.red, marginTop: 10 },
   btn: { paddingVertical: 14, borderRadius: 26, alignItems: 'center', marginTop: 16 },
   btnPrimary: { backgroundColor: COLORS.orange },

--- a/src/components/contribute/HelpCompleteCard.tsx
+++ b/src/components/contribute/HelpCompleteCard.tsx
@@ -1,0 +1,193 @@
+// "Help complete this page" — the contributor entry point on the character
+// screen. Surfaces the hero's missing editable fields as question chips; each
+// opens the ContributeSheet. After a user submits, that gap flips to an
+// author-only "in review" chip right here — so they see their fingerprint on the
+// page instantly, even though the live change is admin-gated. Shown to logged-out
+// visitors too (as a sign-in hook). Cross-platform (RNW).
+import { useCallback, useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/colors';
+import { missingFields } from '../../lib/contribute/missingFields';
+import { getMyContributions, type EditableFieldDef } from '../../lib/db/contributions';
+import { ContributeSheet } from './ContributeSheet';
+
+export interface HelpCompleteCardProps {
+  heroId: string;
+  heroName: string;
+  /** Map of editable field → current value (origin, occupation, base, …). */
+  values: Record<string, string | null | undefined>;
+  user: { id: string } | null | undefined;
+  onRequestSignIn: () => void;
+  /** Override container style — web columns pass marginHorizontal:0 to sit flush. */
+  style?: StyleProp<ViewStyle>;
+}
+
+// undefined = closed; { field } = open (field null ⇒ fact mode).
+type SheetTarget = { field: EditableFieldDef | null } | undefined;
+
+export function HelpCompleteCard({
+  heroId,
+  heroName,
+  values,
+  user,
+  onRequestSignIn,
+  style,
+}: HelpCompleteCardProps) {
+  const [target, setTarget] = useState<SheetTarget>(undefined);
+  const [pendingFields, setPendingFields] = useState<Set<string>>(new Set());
+  const [pendingFact, setPendingFact] = useState(false);
+  const [total, setTotal] = useState(0);
+
+  // Pull the user's contributions so already-submitted gaps show as "in review"
+  // (and to seed the reward count). Re-runs after each submit.
+  const load = useCallback(() => {
+    if (!user) {
+      setPendingFields(new Set());
+      setPendingFact(false);
+      setTotal(0);
+      return;
+    }
+    getMyContributions()
+      .then((list) => {
+        setTotal(list.length);
+        const pf = new Set<string>();
+        let fact = false;
+        for (const c of list) {
+          if (c.status !== 'pending' || c.hero_id !== heroId) continue;
+          if (c.kind === 'field' && c.target_field) pf.add(c.target_field);
+          if (c.kind === 'fact') fact = true;
+        }
+        setPendingFields(pf);
+        setPendingFact(fact);
+      })
+      .catch(() => {});
+  }, [user, heroId]);
+
+  useEffect(load, [load]);
+
+  const missing = missingFields(values);
+  const openMissing = missing.filter((f) => !pendingFields.has(f.field));
+
+  const onSubmitted = (field: EditableFieldDef | null) => {
+    setTotal((t) => t + 1);
+    if (field) setPendingFields((prev) => new Set(prev).add(field.field));
+    else setPendingFact(true);
+    load(); // re-sync with the server in the background
+  };
+
+  const headTitle = openMissing.length > 0
+    ? 'Help complete this page'
+    : missing.length > 0
+      ? 'Thanks for helping'
+      : "Know something we don't?";
+  const headSub = openMissing.length > 0
+    ? `${openMissing.length} ${openMissing.length === 1 ? 'detail is' : 'details are'} missing — add what you know.`
+    : missing.length > 0
+      ? 'Your suggestions are under review.'
+      : 'Suggest a fact to make this page even better.';
+
+  return (
+    <View style={[s.card, style]}>
+      <View style={s.head}>
+        <View style={s.iconWrap}>
+          <Ionicons
+            name={openMissing.length > 0 ? 'construct' : 'sparkles'}
+            size={18}
+            color={COLORS.orange}
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={s.title}>{headTitle}</Text>
+          <Text style={s.sub}>{headSub}</Text>
+        </View>
+      </View>
+
+      <View style={s.chipRow}>
+        {missing.map((f) =>
+          pendingFields.has(f.field) ? (
+            <View key={f.field} style={[s.chip, s.chipPending]}>
+              <Ionicons name="time-outline" size={14} color={COLORS.grey} />
+              <Text style={[s.chipText, s.chipTextPending]}>{f.label} · in review</Text>
+            </View>
+          ) : (
+            <Pressable key={f.field} style={s.chip} onPress={() => setTarget({ field: f })}>
+              <Ionicons name="add" size={14} color={COLORS.navy} />
+              <Text style={s.chipText}>{f.label}</Text>
+            </Pressable>
+          ),
+        )}
+        {pendingFact ? (
+          <View style={[s.chip, s.chipPending]}>
+            <Ionicons name="time-outline" size={14} color={COLORS.grey} />
+            <Text style={[s.chipText, s.chipTextPending]}>Fact · in review</Text>
+          </View>
+        ) : (
+          <Pressable style={[s.chip, s.chipAccent]} onPress={() => setTarget({ field: null })}>
+            <Ionicons name="bulb-outline" size={14} color="#fff" />
+            <Text style={[s.chipText, s.chipTextAccent]}>Add a fact</Text>
+          </Pressable>
+        )}
+      </View>
+
+      <ContributeSheet
+        visible={target !== undefined}
+        onClose={() => setTarget(undefined)}
+        heroId={heroId}
+        heroName={heroName}
+        field={target?.field ?? null}
+        user={user}
+        priorCount={total}
+        onRequestSignIn={onRequestSignIn}
+        onSubmitted={onSubmitted}
+      />
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  card: {
+    marginHorizontal: 16,
+    marginVertical: 14,
+    padding: 16,
+    borderRadius: 16,
+    borderCurve: 'continuous',
+    backgroundColor: '#fbf4e7',
+    borderWidth: 1,
+    borderColor: 'rgba(231,115,51,0.25)',
+  },
+  head: { flexDirection: 'row', alignItems: 'flex-start', gap: 12, marginBottom: 14 },
+  iconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: 'rgba(231,115,51,0.14)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 18, color: COLORS.navy, lineHeight: 22 },
+  sub: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: 'rgba(41,60,67,0.7)',
+    lineHeight: 18,
+    marginTop: 2,
+  },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 999,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.12)',
+  },
+  chipAccent: { backgroundColor: COLORS.orange, borderColor: COLORS.orange },
+  chipPending: { backgroundColor: 'transparent', borderColor: 'rgba(41,60,67,0.18)', borderStyle: 'dashed' },
+  chipText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
+  chipTextAccent: { color: '#fff' },
+  chipTextPending: { color: COLORS.grey },
+});

--- a/src/components/contribute/HelpCompleteCard.tsx
+++ b/src/components/contribute/HelpCompleteCard.tsx
@@ -1,30 +1,38 @@
 // "Help complete this page" — the contributor entry point on the character
-// screen. Surfaces the hero's missing editable fields as question chips; each
-// opens the ContributeSheet. After a user submits, that gap flips to an
-// author-only "in review" chip right here — so they see their fingerprint on the
-// page instantly, even though the live change is admin-gated. Shown to logged-out
-// visitors too (as a sign-in hook). Cross-platform (RNW).
+// screen.
+//
+//  • Community users see the hero's *missing* editable fields as question chips
+//    (+ "Add a fact"); each opens the ContributeSheet, and after submitting that
+//    gap flips to an author-only "in review" chip right here.
+//  • Admins see *every* editable field (add the empty ones, fix the filled
+//    ones) and their edits apply immediately (the sheet handles direct-apply);
+//    a saved field shows a ✓ until the page reloads with the new value.
+//
+// Shown to logged-out visitors too (a sign-in hook). Cross-platform (RNW).
 import { useCallback, useEffect, useState } from 'react';
 import { View, Text, Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/colors';
-import { missingFields } from '../../lib/contribute/missingFields';
-import { getMyContributions, type EditableFieldDef } from '../../lib/db/contributions';
+import { isBlankValue, missingFields } from '../../lib/contribute/missingFields';
+import {
+  EDITABLE_FIELDS,
+  getMyContributions,
+  type EditableFieldDef,
+} from '../../lib/db/contributions';
+import { getProfile } from '../../lib/db/profiles';
 import { ContributeSheet } from './ContributeSheet';
 
 export interface HelpCompleteCardProps {
   heroId: string;
   heroName: string;
-  /** Map of editable field → current value (origin, occupation, base, …). */
   values: Record<string, string | null | undefined>;
   user: { id: string } | null | undefined;
   onRequestSignIn: () => void;
-  /** Override container style — web columns pass marginHorizontal:0 to sit flush. */
   style?: StyleProp<ViewStyle>;
 }
 
-// undefined = closed; { field } = open (field null ⇒ fact mode).
-type SheetTarget = { field: EditableFieldDef | null } | undefined;
+const FACT_KEY = '__fact__';
+type SheetTarget = { field: EditableFieldDef | null; current?: string | null } | undefined;
 
 export function HelpCompleteCard({
   heroId,
@@ -35,12 +43,28 @@ export function HelpCompleteCard({
   style,
 }: HelpCompleteCardProps) {
   const [target, setTarget] = useState<SheetTarget>(undefined);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [pendingFields, setPendingFields] = useState<Set<string>>(new Set());
   const [pendingFact, setPendingFact] = useState(false);
+  const [savedKeys, setSavedKeys] = useState<Set<string>>(new Set()); // admin just-saved
   const [total, setTotal] = useState(0);
 
-  // Pull the user's contributions so already-submitted gaps show as "in review"
-  // (and to seed the reward count). Re-runs after each submit.
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false);
+      return;
+    }
+    let active = true;
+    getProfile(user.id)
+      .then((p) => active && setIsAdmin(!!p?.is_admin))
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  // Community pending marks + reward count. (Admins apply directly, so they don't
+  // accrue pending rows; this just seeds the count harmlessly.)
   const load = useCallback(() => {
     if (!user) {
       setPendingFields(new Set());
@@ -70,29 +94,38 @@ export function HelpCompleteCard({
   const openMissing = missing.filter((f) => !pendingFields.has(f.field));
 
   const onSubmitted = (field: EditableFieldDef | null) => {
+    if (isAdmin) {
+      setSavedKeys((prev) => new Set(prev).add(field ? field.field : FACT_KEY));
+      return;
+    }
     setTotal((t) => t + 1);
     if (field) setPendingFields((prev) => new Set(prev).add(field.field));
     else setPendingFact(true);
-    load(); // re-sync with the server in the background
+    load();
   };
 
-  const headTitle = openMissing.length > 0
-    ? 'Help complete this page'
-    : missing.length > 0
-      ? 'Thanks for helping'
-      : "Know something we don't?";
-  const headSub = openMissing.length > 0
-    ? `${openMissing.length} ${openMissing.length === 1 ? 'detail is' : 'details are'} missing — add what you know.`
-    : missing.length > 0
-      ? 'Your suggestions are under review.'
-      : 'Suggest a fact to make this page even better.';
+  // Header copy differs by role.
+  const headTitle = isAdmin
+    ? 'Edit this page'
+    : openMissing.length > 0
+      ? 'Help complete this page'
+      : missing.length > 0
+        ? 'Thanks for helping'
+        : "Know something we don't?";
+  const headSub = isAdmin
+    ? 'Add or fix any field — changes go live instantly.'
+    : openMissing.length > 0
+      ? `${openMissing.length} ${openMissing.length === 1 ? 'detail is' : 'details are'} missing — add what you know.`
+      : missing.length > 0
+        ? 'Your suggestions are under review.'
+        : 'Suggest a fact to make this page even better.';
 
   return (
     <View style={[s.card, style]}>
       <View style={s.head}>
         <View style={s.iconWrap}>
           <Ionicons
-            name={openMissing.length > 0 ? 'construct' : 'sparkles'}
+            name={isAdmin ? 'shield-checkmark' : openMissing.length > 0 ? 'construct' : 'sparkles'}
             size={18}
             color={COLORS.orange}
           />
@@ -104,27 +137,55 @@ export function HelpCompleteCard({
       </View>
 
       <View style={s.chipRow}>
-        {missing.map((f) =>
-          pendingFields.has(f.field) ? (
-            <View key={f.field} style={[s.chip, s.chipPending]}>
-              <Ionicons name="time-outline" size={14} color={COLORS.grey} />
-              <Text style={[s.chipText, s.chipTextPending]}>{f.label} · in review</Text>
-            </View>
-          ) : (
-            <Pressable key={f.field} style={s.chip} onPress={() => setTarget({ field: f })}>
-              <Ionicons name="add" size={14} color={COLORS.navy} />
-              <Text style={s.chipText}>{f.label}</Text>
-            </Pressable>
-          ),
-        )}
-        {pendingFact ? (
+        {isAdmin
+          ? EDITABLE_FIELDS.map((f) => {
+              const cur = values[f.field];
+              const filled = !isBlankValue(cur);
+              const saved = savedKeys.has(f.field);
+              return (
+                <Pressable
+                  key={f.field}
+                  style={[s.chip, saved && s.chipSaved]}
+                  onPress={() => setTarget({ field: f, current: filled ? cur : null })}
+                >
+                  <Ionicons
+                    name={saved ? 'checkmark' : filled ? 'pencil' : 'add'}
+                    size={14}
+                    color={saved ? COLORS.green : COLORS.navy}
+                  />
+                  <Text style={s.chipText}>{f.label}</Text>
+                </Pressable>
+              );
+            })
+          : missing.map((f) =>
+              pendingFields.has(f.field) ? (
+                <View key={f.field} style={[s.chip, s.chipPending]}>
+                  <Ionicons name="time-outline" size={14} color={COLORS.grey} />
+                  <Text style={[s.chipText, s.chipTextPending]}>{f.label} · in review</Text>
+                </View>
+              ) : (
+                <Pressable key={f.field} style={s.chip} onPress={() => setTarget({ field: f })}>
+                  <Ionicons name="add" size={14} color={COLORS.navy} />
+                  <Text style={s.chipText}>{f.label}</Text>
+                </Pressable>
+              ),
+            )}
+
+        {!isAdmin && pendingFact ? (
           <View style={[s.chip, s.chipPending]}>
             <Ionicons name="time-outline" size={14} color={COLORS.grey} />
             <Text style={[s.chipText, s.chipTextPending]}>Fact · in review</Text>
           </View>
         ) : (
-          <Pressable style={[s.chip, s.chipAccent]} onPress={() => setTarget({ field: null })}>
-            <Ionicons name="bulb-outline" size={14} color="#fff" />
+          <Pressable
+            style={[s.chip, s.chipAccent, savedKeys.has(FACT_KEY) && s.chipSaved]}
+            onPress={() => setTarget({ field: null })}
+          >
+            <Ionicons
+              name={savedKeys.has(FACT_KEY) ? 'checkmark' : 'bulb-outline'}
+              size={14}
+              color="#fff"
+            />
             <Text style={[s.chipText, s.chipTextAccent]}>Add a fact</Text>
           </Pressable>
         )}
@@ -136,7 +197,9 @@ export function HelpCompleteCard({
         heroId={heroId}
         heroName={heroName}
         field={target?.field ?? null}
+        currentValue={target?.current ?? null}
         user={user}
+        isAdmin={isAdmin}
         priorCount={total}
         onRequestSignIn={onRequestSignIn}
         onSubmitted={onSubmitted}
@@ -186,7 +249,12 @@ const s = StyleSheet.create({
     borderColor: 'rgba(41,60,67,0.12)',
   },
   chipAccent: { backgroundColor: COLORS.orange, borderColor: COLORS.orange },
-  chipPending: { backgroundColor: 'transparent', borderColor: 'rgba(41,60,67,0.18)', borderStyle: 'dashed' },
+  chipPending: {
+    backgroundColor: 'transparent',
+    borderColor: 'rgba(41,60,67,0.18)',
+    borderStyle: 'dashed',
+  },
+  chipSaved: { borderColor: COLORS.green },
   chipText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
   chipTextAccent: { color: '#fff' },
   chipTextPending: { color: COLORS.grey },

--- a/src/components/contribute/HelpCompleteCard.tsx
+++ b/src/components/contribute/HelpCompleteCard.tsx
@@ -28,6 +28,8 @@ export interface HelpCompleteCardProps {
   values: Record<string, string | null | undefined>;
   user: { id: string } | null | undefined;
   onRequestSignIn: () => void;
+  /** Called after an admin direct-edit so the screen can refresh the hero. */
+  onEdited?: () => void;
   style?: StyleProp<ViewStyle>;
 }
 
@@ -40,6 +42,7 @@ export function HelpCompleteCard({
   values,
   user,
   onRequestSignIn,
+  onEdited,
   style,
 }: HelpCompleteCardProps) {
   const [target, setTarget] = useState<SheetTarget>(undefined);
@@ -96,6 +99,7 @@ export function HelpCompleteCard({
   const onSubmitted = (field: EditableFieldDef | null) => {
     if (isAdmin) {
       setSavedKeys((prev) => new Set(prev).add(field ? field.field : FACT_KEY));
+      onEdited?.(); // let the screen refetch so the live value updates too
       return;
     }
     setTotal((t) => t + 1);

--- a/src/lib/contribute/missingFields.ts
+++ b/src/lib/contribute/missingFields.ts
@@ -1,0 +1,20 @@
+import { EDITABLE_FIELDS, type EditableFieldDef } from '../db/contributions';
+
+// Which contributor-editable fields a hero is missing — the engine behind the
+// "Help complete this page" card. A field is "blank" using the same sentinels
+// the character screen treats as empty ('-' / 'null' / whitespace), so the card
+// only ever asks for genuinely-absent data.
+
+export function isBlankValue(v?: string | null): boolean {
+  return !v || v === '-' || v === 'null' || v.trim() === '';
+}
+
+/** The editable fields that are currently empty for this hero. */
+export function missingFields(values: Record<string, string | null | undefined>): EditableFieldDef[] {
+  return EDITABLE_FIELDS.filter((f) => isBlankValue(values[f.field]));
+}
+
+/** The editable fields that already have a value (candidates for "suggest a fix"). */
+export function presentFields(values: Record<string, string | null | undefined>): EditableFieldDef[] {
+  return EDITABLE_FIELDS.filter((f) => !isBlankValue(values[f.field]));
+}

--- a/src/lib/contribute/reward.ts
+++ b/src/lib/contribute/reward.ts
@@ -1,0 +1,16 @@
+// Small pure helpers for the contribute reward copy. Kept separate so the
+// celebratory messaging is easy to tune and unit-test.
+
+/** 1 → "1st", 2 → "2nd", 3 → "3rd", 11 → "11th", 42 → "42nd". */
+export function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+}
+
+/** Warm, status-building line shown after a submission (reward is deferred, so
+ *  we celebrate the act + their growing tally rather than a live change). */
+export function rewardLine(contributionNumber: number): string {
+  if (contributionNumber <= 1) return 'Your first contribution — welcome to the archive.';
+  return `That's your ${ordinal(contributionNumber)} contribution. Keep it up!`;
+}

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -10,6 +10,9 @@ export type ContributionKind = 'field' | 'fact' | 'report';
 export interface EditableFieldDef {
   field: string;
   label: string;
+  /** A friendly question used as the prompt — "Where was X born?" reads easier
+   *  than a form label and makes the ask feel like a one-tap answer. */
+  question: string;
   guideline?: string;
   multiline?: boolean;
 }
@@ -17,12 +20,23 @@ export interface EditableFieldDef {
 /** The heroes text columns a contributor may propose. Mirrors the allow-list
  *  enforced server-side in submit_contribution / admin_review_contribution. */
 export const EDITABLE_FIELDS: EditableFieldDef[] = [
-  { field: 'origin', label: 'Origin', guideline: 'Where this hero comes from — a sentence or two.', multiline: true },
-  { field: 'full_name', label: 'Full name', guideline: 'Their real or birth name.' },
-  { field: 'occupation', label: 'Occupation', guideline: 'What they do.' },
-  { field: 'base', label: 'Base of operations', guideline: 'Where they operate from.' },
-  { field: 'place_of_birth', label: 'Place of birth' },
-  { field: 'first_appearance', label: 'First appearance', guideline: 'The issue or title they debuted in.' },
+  {
+    field: 'origin',
+    label: 'Origin',
+    question: 'Where does this hero come from?',
+    guideline: 'Their origin story — a sentence or two.',
+    multiline: true,
+  },
+  { field: 'full_name', label: 'Full name', question: "What's their real name?" },
+  { field: 'occupation', label: 'Occupation', question: 'What do they do?' },
+  { field: 'base', label: 'Base of operations', question: 'Where do they operate from?' },
+  { field: 'place_of_birth', label: 'Place of birth', question: 'Where were they born?' },
+  {
+    field: 'first_appearance',
+    label: 'First appearance',
+    question: 'Where did they first appear?',
+    guideline: 'The issue or title they debuted in.',
+  },
 ];
 
 export interface MyContribution {

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -128,3 +128,24 @@ export async function reviewContribution(
   if (error) return { ok: false, error: error.message };
   return { ok: true };
 }
+
+/**
+ * Admin direct-edit — applies a field edit or fact immediately (no queue) and
+ * logs an auto-approved contribution for the audit trail. Admin-only (guarded
+ * server-side). Used by the on-page contribute flow when the viewer is an admin.
+ */
+export async function adminEditHero(opts: {
+  heroId: string;
+  kind: 'field' | 'fact';
+  targetField?: string | null;
+  newValue: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const { error } = await supabase.rpc('admin_edit_hero', {
+    p_hero_id: opts.heroId,
+    p_kind: opts.kind,
+    p_target_field: opts.targetField ?? '',
+    p_new_value: opts.newValue,
+  });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -39,6 +39,20 @@ export const EDITABLE_FIELDS: EditableFieldDef[] = [
   },
 ];
 
+const FIELD_LABEL: Record<string, string> = Object.fromEntries(
+  EDITABLE_FIELDS.map((f) => [f.field, f.label]),
+);
+
+/** Human description of what a contribution changed, for the profile list. */
+export function describeContribution(c: {
+  kind: ContributionKind;
+  target_field: string | null;
+}): string {
+  if (c.kind === 'fact') return 'Did You Know fact';
+  if (c.kind === 'report') return 'Reported an issue';
+  return FIELD_LABEL[c.target_field ?? ''] ?? c.target_field ?? 'Edit';
+}
+
 export interface MyContribution {
   id: number;
   hero_id: string;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1064,6 +1064,10 @@ export type Database = {
       admin_cron_status: { Args: never; Returns: Json }
       admin_delete_campaign: { Args: { p_id: string }; Returns: number }
       admin_delete_hero: { Args: { p_hero_id: string }; Returns: number }
+      admin_edit_hero: {
+        Args: { p_hero_id: string; p_kind: string; p_new_value: string; p_target_field: string }
+        Returns: Json
+      }
       admin_merge_heroes: {
         Args: { p_loser: string; p_winner: string }
         Returns: undefined

--- a/supabase/migrations/20260617160000_admin_edit_hero.sql
+++ b/supabase/migrations/20260617160000_admin_edit_hero.sql
@@ -1,0 +1,48 @@
+-- Admin direct-edit: a moderator IS the vetting step, so their on-page edits
+-- apply immediately (no queue) — but every change is still logged to
+-- `contributions` as an auto-approved row (user_id = reviewed_by = the admin),
+-- giving one unified per-hero audit trail alongside community edits. Does NOT
+-- touch contributor_stats (admin edits aren't community reputation).
+create or replace function public.admin_edit_hero(
+  p_hero_id text, p_kind text, p_target_field text, p_new_value text
+) returns json
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_admin uuid := auth.uid();
+  v_old text;
+begin
+  if not exists (select 1 from public.user_profiles where id = v_admin and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  if p_kind not in ('field','fact') then raise exception 'invalid kind'; end if;
+  if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+  if not exists (select 1 from public.heroes where id = p_hero_id) then
+    raise exception 'unknown hero';
+  end if;
+
+  if p_kind = 'field' then
+    if p_target_field not in
+      ('origin','occupation','base','place_of_birth','first_appearance','full_name') then
+      raise exception 'field not editable';
+    end if;
+    execute format('select %I from public.heroes where id = $1', p_target_field)
+      into v_old using p_hero_id;
+    execute format('update public.heroes set %I = $1 where id = $2', p_target_field)
+      using p_new_value, p_hero_id;
+  else
+    insert into public.hero_narrative_facts (hero_id, kind, content, source_model, needs_review)
+    values (p_hero_id, 'did_you_know', p_new_value, 'admin', false);
+  end if;
+
+  insert into public.contributions
+    (user_id, hero_id, kind, target_field, old_value, new_value, status, reviewed_by, reviewed_at)
+  values
+    (v_admin, p_hero_id, p_kind, p_target_field, v_old, p_new_value, 'approved', v_admin, now());
+
+  return json_build_object('ok', true);
+end;
+$$;
+
+revoke all on function public.admin_edit_hero(text, text, text, text) from public, anon;
+grant execute on function public.admin_edit_hero(text, text, text, text) to authenticated, service_role;


### PR DESCRIPTION
## Summary

Phase 2b — the contributor-facing UX — plus the admin editing model, designed for low friction and immediate reward despite the deferred (admin-vetted) payoff.

### On-page contribute flow (community)
- **HelpCompleteCard** on the character screen (native + both web layouts): a hero's missing editable fields as **question-framed** chips + "Add a fact".
- **ContributeSheet**: a question-framed bottom sheet, one autofocused field, no busywork. Submits via `submit_contribution`.
- **Reward at submit time** (live change is gated): success haptic + a warm, status-building line ("your Nth contribution").
- **On-page "in review" mark**: after submitting, the gap flips to an author-only "· in review" chip right where it was.
- Shown to logged-out visitors too (sign-in hook).

### Admin editing (direct + audited)
- **`admin_edit_hero` RPC**: admins are the vetting step, so their edits apply immediately (no queue) and are logged as auto-approved `contributions` rows for one unified audit trail. `contributor_stats` untouched.
- Card is admin-aware: admins edit **every** field (add empty / fix filled) + facts; sheet shows the current value and swaps copy to "Save" / "it's live now".
- **Live refresh**: after an admin edit the page re-derives the hero (native refetch / web `getHeroById`).

### Profile
- **"My Contributions"** (native + web): submissions with hero, what changed, and a Pending/Approved/Rejected status pill.

## Verification
- `admin_edit_hero` migration applied + guard-verified (rejects non-admins, no row leak)
- Merged latest `main` (command-center ui-primitives refactor); resolved the one `EDITABLE_FIELDS` conflict
- `yarn typecheck` clean · lint 0 errors · **348/348 tests pass** (new missingFields + reward helpers unit-tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_