### PR TITLE
feat(analytics): group dynamic routes in Vercel Analytics

### DIFF
--- a/src/components/Analytics.web.tsx
+++ b/src/components/Analytics.web.tsx
@@ -1,5 +1,14 @@
 import { Analytics } from '@vercel/analytics/react';
+import { usePathname, useSegments } from 'expo-router';
 
 export default function AnalyticsProvider() {
-  return <Analytics />;
+  // path is the concrete URL (e.g. /character/123); route is the matched
+  // pattern (e.g. /character/[id]). Passing both lets Vercel group dynamic
+  // routes instead of logging every id as a distinct page. Route-group
+  // segments like (tabs) aren't part of the URL, so strip them.
+  const path = usePathname();
+  const segments = useSegments();
+  const route = '/' + segments.filter((segment) => !segment.startsWith('(')).join('/');
+
+  return <Analytics route={route} path={path} />;
 }


### PR DESCRIPTION
## Summary

Vercel Analytics was already set up and working end-to-end (verified the script endpoint, the beacon collector, and the production-mode bundle on the live deploy). This adds the one missing refinement: **route grouping** for dynamic routes.

Previously the `<Analytics>` component had no `route` prop, so Vercel logged every dynamic URL — `/character/123`, `/character/456`, … — as a distinct page, making the **Routes** tab useless for detail screens.

## Change

`src/components/Analytics.web.tsx` now passes both:
- `path` — the concrete URL (`usePathname()`)
- `route` — the matched pattern (`/character/[id]`), built from expo-router `useSegments()` with route-group segments like `(tabs)` stripped (they aren't part of the URL)

Passing `route` also switches the component to explicit tracking, firing a clean pageview on each client-side navigation.

## Verification

- `yarn typecheck` ✅
- `yarn eslint` on the analytics components ✅
- Native (`Analytics.tsx`) unchanged — still a no-op off web

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdsLizf8EZY8wQXfRuU53B)_