### PR TITLE
Widen inline edit: Summary, Power Stats, Abilities + finish Dossier fields

### DIFF
--- a/__tests__/lib/contribute/missingFields.test.ts
+++ b/__tests__/lib/contribute/missingFields.test.ts
@@ -1,8 +1,4 @@
-import {
-  isBlankValue,
-  missingFields,
-  presentFields,
-} from '../../../src/lib/contribute/missingFields';
+import { isBlankValue } from '../../../src/lib/contribute/missingFields';
 
 describe('isBlankValue', () => {
   it('treats null/undefined/empty and DB sentinels as blank', () => {
@@ -17,27 +13,5 @@ describe('isBlankValue', () => {
   it('treats real values as present', () => {
     expect(isBlankValue('Krypton')).toBe(false);
     expect(isBlankValue('0')).toBe(false);
-  });
-});
-
-describe('missingFields / presentFields', () => {
-  it('splits editable fields by presence', () => {
-    const values = {
-      origin: 'Born on Krypton',
-      occupation: '',
-      base: null,
-      place_of_birth: 'Krypton',
-      first_appearance: '-',
-      full_name: 'Kal-El',
-    };
-    const missing = missingFields(values).map((f) => f.field);
-    const present = presentFields(values).map((f) => f.field);
-    expect(missing.sort()).toEqual(['base', 'first_appearance', 'occupation']);
-    expect(present.sort()).toEqual(['full_name', 'origin', 'place_of_birth']);
-  });
-
-  it('reports every editable field missing for an empty hero', () => {
-    expect(missingFields({}).length).toBe(6);
-    expect(presentFields({}).length).toBe(0);
   });
 });

--- a/__tests__/lib/db/contributions.fields.test.ts
+++ b/__tests__/lib/db/contributions.fields.test.ts
@@ -1,0 +1,76 @@
+import {
+  EDITABLE_FIELDS,
+  SUMMARY_FIELD,
+  POWERS_FIELD,
+  STAT_FIELDS,
+  DOSSIER_GROUPS,
+} from '../../../src/lib/db/contributions';
+
+// Mirror of the server-side allow-list in _contrib_field_type (migration
+// 20260618130000). This test fails if the TS field registry and the SQL
+// classifier drift apart — they MUST stay in lockstep or edits will be rejected.
+const SERVER = {
+  list: ['aliases', 'powers'],
+  stat: ['intelligence', 'strength', 'speed', 'durability', 'power', 'combat'],
+  text: [
+    'origin',
+    'full_name',
+    'occupation',
+    'base',
+    'place_of_birth',
+    'first_appearance',
+    'alter_egos',
+    'gender',
+    'race',
+    'height_imperial',
+    'weight_imperial',
+    'eye_color',
+    'hair_color',
+    'group_affiliation',
+    'summary',
+    'description',
+  ],
+};
+
+function serverType(field: string): 'text' | 'list' | 'stat' | null {
+  if (SERVER.list.includes(field)) return 'list';
+  if (SERVER.stat.includes(field)) return 'stat';
+  if (SERVER.text.includes(field)) return 'text';
+  return null;
+}
+
+describe('contribution field registry ↔ server allow-list', () => {
+  const all = [...EDITABLE_FIELDS, SUMMARY_FIELD, POWERS_FIELD, ...STAT_FIELDS];
+
+  it('every editable field is allow-listed server-side with a matching type', () => {
+    for (const f of all) {
+      const expected = serverType(f.field);
+      expect(expected).not.toBeNull();
+      // A field with no explicit type defaults to 'text'.
+      expect(f.type ?? 'text').toBe(expected);
+    }
+  });
+
+  it('no community Dossier field is a stat (stats are admin-only)', () => {
+    for (const f of EDITABLE_FIELDS) {
+      expect(f.type).not.toBe('stat');
+      expect(SERVER.stat).not.toContain(f.field);
+    }
+  });
+
+  it('all six power stats are present and typed as stat', () => {
+    expect(STAT_FIELDS.map((f) => f.field).sort()).toEqual([...SERVER.stat].sort());
+    expect(STAT_FIELDS.every((f) => f.type === 'stat')).toBe(true);
+  });
+
+  it('summary and powers carry the right shape', () => {
+    expect(SUMMARY_FIELD.field).toBe('summary');
+    expect(POWERS_FIELD.field).toBe('powers');
+    expect(POWERS_FIELD.type).toBe('list');
+  });
+
+  it('Dossier groups cover exactly the editable Dossier fields', () => {
+    const grouped = DOSSIER_GROUPS.flatMap((g) => g.fields.map((f) => f.field)).sort();
+    expect(grouped).toEqual(EDITABLE_FIELDS.map((f) => f.field).sort());
+  });
+});

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -65,7 +65,13 @@ import { HeroLinksRow, heroLinksHasContent } from '../../src/components/HeroLink
 import { useAuth } from '../../src/hooks/useAuth';
 import { ContributeSheet } from '../../src/components/contribute/ContributeSheet';
 import { isBlankValue } from '../../src/lib/contribute/missingFields';
-import { EDITABLE_FIELDS, type EditableFieldDef } from '../../src/lib/db/contributions';
+import {
+  DOSSIER_GROUPS,
+  SUMMARY_FIELD,
+  POWERS_FIELD,
+  STAT_FIELDS,
+  type EditableFieldDef,
+} from '../../src/lib/db/contributions';
 import { getProfile } from '../../src/lib/db/profiles';
 import { useRecordView } from '../../src/hooks/useViewHistory';
 import { HeroImage } from '../../src/components/HeroImage';
@@ -196,10 +202,37 @@ function StatDial({ label, value, tint }: { label: string; value: string; tint: 
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+// Subtle pen that sits to the left of a right-aligned section title, opening that
+// section's inline edit. Reading view stays pristine; the pen is the only tell.
+function SectionPen({ onPress, active }: { onPress: () => void; active?: boolean }) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      hitSlop={8}
+      style={styles.sectionPen}
+      accessibilityRole="button"
+      accessibilityLabel="Edit section"
+    >
+      <Ionicons name="create-outline" size={16} color={active ? COLORS.orange : COLORS.navy} />
+    </TouchableOpacity>
+  );
+}
+
+function Section({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={styles.sectionTitleRow}>
+        {action ?? null}
+        <Text style={[styles.sectionTitle, styles.sectionTitleGrow]}>{title}</Text>
+      </View>
       <View style={styles.divider} />
       {children}
     </View>
@@ -208,10 +241,13 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 // Padded title + divider with no body padding — used for sections whose body is
 // a full-bleed horizontal scroller (the scroller carries its own edge insets).
-function SectionHeader({ title }: { title: string }) {
+function SectionHeader({ title, action }: { title: string; action?: React.ReactNode }) {
   return (
     <View style={styles.sectionHeaderPad}>
-      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={styles.sectionTitleRow}>
+        {action ?? null}
+        <Text style={[styles.sectionTitle, styles.sectionTitleGrow]}>{title}</Text>
+      </View>
       <View style={styles.divider} />
     </View>
   );
@@ -462,30 +498,37 @@ function Dossier({
       </TouchableOpacity>
       {open && editing ? (
         <View style={styles.dossierBody}>
-          <Text style={styles.dossierGroupLabel}>Edit details</Text>
-          {EDITABLE_FIELDS.map((f) => {
-            const v = editValues?.[f.field];
-            const filled = !isBlankValue(v);
-            return (
-              <TouchableOpacity
-                key={f.field}
-                onPress={() => onEditField?.(f, filled ? (v ?? null) : null)}
-                style={styles.editRow}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.editRowLabel}>{f.label}</Text>
-                <View style={styles.editRowRight}>
-                  <Text
-                    style={filled ? styles.editRowValue : styles.editRowAdd}
-                    numberOfLines={1}
+          {DOSSIER_GROUPS.map((group, gi) => (
+            <Fragment key={group.key}>
+              <Text style={[styles.dossierGroupLabel, gi > 0 && styles.dossierGroupSpacing]}>
+                {group.label}
+              </Text>
+              {group.fields.map((f) => {
+                const v = editValues?.[f.field];
+                const filled = !isBlankValue(v);
+                return (
+                  <TouchableOpacity
+                    key={f.field}
+                    onPress={() => onEditField?.(f, filled ? (v ?? null) : null)}
+                    style={styles.editRow}
+                    activeOpacity={0.7}
                   >
-                    {filled ? v : 'Add'}
-                  </Text>
-                  <Ionicons name={filled ? 'pencil' : 'add'} size={14} color={COLORS.orange} />
-                </View>
-              </TouchableOpacity>
-            );
-          })}
+                    <Text style={styles.editRowLabel}>{f.label}</Text>
+                    <View style={styles.editRowRight}>
+                      <Text
+                        style={filled ? styles.editRowValue : styles.editRowAdd}
+                        numberOfLines={1}
+                      >
+                        {filled ? v : 'Add'}
+                      </Text>
+                      <Ionicons name={filled ? 'pencil' : 'add'} size={14} color={COLORS.orange} />
+                    </View>
+                  </TouchableOpacity>
+                );
+              })}
+            </Fragment>
+          ))}
+          <Text style={[styles.dossierGroupLabel, styles.dossierGroupSpacing]}>Trivia</Text>
           <TouchableOpacity
             onPress={() => onEditField?.(null, null)}
             style={styles.editRow}
@@ -575,6 +618,7 @@ export default function CharacterScreen() {
     current: string | null;
   } | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [editingStats, setEditingStats] = useState(false);
   const [narrative, setNarrative] = useState<HeroNarrative | null>(null);
   const [family, setFamily] = useState<FamilyMember[]>([]);
   const [comicVineLoading, setComicVineLoading] = useState(true);
@@ -1357,6 +1401,13 @@ export default function CharacterScreen() {
                   </SkeletonProvider>
                 ) : data.details.summary || data.details.description ? (
                   <View style={styles.summaryBlock}>
+                    <View style={styles.summaryHead}>
+                      <SectionPen
+                        onPress={() =>
+                          setEditTarget({ field: SUMMARY_FIELD, current: data.details.summary ?? null })
+                        }
+                      />
+                    </View>
                     {data.details.summary ? (
                       <Text style={styles.summary}>{data.details.summary}</Text>
                     ) : null}
@@ -1370,43 +1421,103 @@ export default function CharacterScreen() {
                       </TouchableOpacity>
                     ) : null}
                   </View>
-                ) : null}
+                ) : (
+                  <View style={styles.summaryBlock}>
+                    <View style={styles.summaryHead}>
+                      <SectionPen
+                        onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                      />
+                    </View>
+                    <TouchableOpacity
+                      onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={styles.summaryEmpty}>Add a short summary for this hero.</Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
               </View>
 
-              {/* Power Stats — circular dials, 3×2 grid + percentile hook */}
+              {/* Power Stats — circular dials, 3×2 grid + percentile hook. Admins
+                  get a pen that swaps the dials for an editable list (0–100). */}
               <View onLayout={registerAnchor('stats')}>
-                <Section title="Power Stats">
-                  <View style={styles.statsCard}>
-                    <View style={styles.statsGrid}>
-                      {STAT_CONFIG.map(({ key, label, tint }) => (
-                        <StatDial
-                          key={key}
-                          label={label}
-                          value={(data.stats.powerstats as Record<string, string>)[key] ?? '0'}
-                          tint={tint}
-                        />
-                      ))}
+                <Section
+                  title="Power Stats"
+                  action={
+                    isAdmin ? (
+                      <SectionPen
+                        active={editingStats}
+                        onPress={() => setEditingStats((s) => !s)}
+                      />
+                    ) : undefined
+                  }
+                >
+                  {isAdmin && editingStats ? (
+                    <View style={styles.statsCard}>
+                      {STAT_FIELDS.map((f) => {
+                        const cur =
+                          (data.stats.powerstats as Record<string, string>)[f.field] ?? '0';
+                        return (
+                          <TouchableOpacity
+                            key={f.field}
+                            onPress={() => setEditTarget({ field: f, current: cur })}
+                            style={styles.editRow}
+                            activeOpacity={0.7}
+                          >
+                            <Text style={styles.editRowLabel}>{f.label}</Text>
+                            <View style={styles.editRowRight}>
+                              <Text style={styles.editRowValue}>{cur}</Text>
+                              <Ionicons name="pencil" size={14} color={COLORS.orange} />
+                            </View>
+                          </TouchableOpacity>
+                        );
+                      })}
                     </View>
-                    {powerTotal > 0 ? (
-                      <View style={styles.statTotalRow}>
-                        <Text style={styles.statTotal}>Total {powerTotal} / 600</Text>
-                        {percentile != null && percentile > 0 ? (
-                          <Text style={styles.statPercentile}>
-                            Stronger than {percentile}% of heroes
-                          </Text>
-                        ) : null}
+                  ) : (
+                    <View style={styles.statsCard}>
+                      <View style={styles.statsGrid}>
+                        {STAT_CONFIG.map(({ key, label, tint }) => (
+                          <StatDial
+                            key={key}
+                            label={label}
+                            value={(data.stats.powerstats as Record<string, string>)[key] ?? '0'}
+                            tint={tint}
+                          />
+                        ))}
                       </View>
-                    ) : null}
-                  </View>
+                      {powerTotal > 0 ? (
+                        <View style={styles.statTotalRow}>
+                          <Text style={styles.statTotal}>Total {powerTotal} / 600</Text>
+                          {percentile != null && percentile > 0 ? (
+                            <Text style={styles.statPercentile}>
+                              Stronger than {percentile}% of heroes
+                            </Text>
+                          ) : null}
+                        </View>
+                      ) : null}
+                    </View>
+                  )}
                 </Section>
               </View>
 
-              {/* Abilities — power explainers fold in as the "Decoded" strip */}
+              {/* Abilities — power explainers fold in as the "Decoded" strip. The
+                  pen edits the whole powers list (one per line). */}
               <View onLayout={registerAnchor('abilities')}>
                 <AbilitiesSection
                   powers={data.details.powers}
                   loading={comicVineLoading}
                   explainers={narrative?.powerExplainers ?? []}
+                  onEdit={
+                    comicVineLoading
+                      ? undefined
+                      : () =>
+                          setEditTarget({
+                            field: POWERS_FIELD,
+                            current: data.details.powers?.length
+                              ? data.details.powers.join('\n')
+                              : null,
+                          })
+                  }
                 />
               </View>
 
@@ -1431,12 +1542,24 @@ export default function CharacterScreen() {
                   editing={editing}
                   onToggleEdit={() => setEditing((e) => !e)}
                   editValues={{
-                    origin: data.details.origin,
-                    occupation: data.stats.work.occupation,
-                    base: data.stats.work.base,
+                    // Profile
+                    full_name: data.stats.biography['full-name'],
+                    alter_egos: data.stats.biography['alter-egos'],
+                    aliases: (data.stats.biography.aliases ?? []).filter(valid).join('\n'),
                     place_of_birth: data.stats.biography['place-of-birth'],
                     first_appearance: data.stats.biography['first-appearance'],
-                    full_name: data.stats.biography['full-name'],
+                    origin: data.details.origin,
+                    // Appearance
+                    gender: data.stats.appearance.gender,
+                    race: data.stats.appearance.race,
+                    height_imperial: data.stats.appearance.height?.[0],
+                    weight_imperial: data.stats.appearance.weight?.[0],
+                    eye_color: data.stats.appearance['eye-color'],
+                    hair_color: data.stats.appearance['hair-color'],
+                    // Connections
+                    occupation: data.stats.work.occupation,
+                    base: data.stats.work.base,
+                    group_affiliation: data.stats.connections['group-affiliation'],
                   }}
                   onEditField={(field, current) => setEditTarget({ field, current })}
                 />
@@ -1755,8 +1878,12 @@ export default function CharacterScreen() {
           isAdmin={isAdmin}
           priorCount={0}
           onRequestSignIn={() => router.push('/(auth)/login')}
-          onSubmitted={() => {
-            if (isAdmin) heroRowQuery.refetch();
+          onSubmitted={async () => {
+            // Admin edits apply immediately — pull the fresh row so the change
+            // shows on the page without a manual reload.
+            if (!isAdmin) return;
+            const { data: fresh } = await heroRowQuery.refetch();
+            if (fresh) setData(heroRowToCharacterData(fresh));
           }}
         />
       ) : null}
@@ -1945,6 +2072,14 @@ const styles = StyleSheet.create({
 
   // Summary
   summaryBlock: { paddingHorizontal: 20, paddingTop: 14, paddingBottom: 10 },
+  summaryHead: { alignItems: 'flex-end', marginBottom: 2 },
+  summaryEmpty: {
+    fontFamily: 'FlameSans-Regular',
+    fontSize: 14,
+    color: COLORS.grey,
+    fontStyle: 'italic',
+    lineHeight: 22,
+  },
   biographyLink: { alignSelf: 'flex-end', paddingTop: 8 },
   biographyLinkText: {
     fontFamily: 'FlameSans-Regular',
@@ -1962,6 +2097,16 @@ const styles = StyleSheet.create({
   // Sections
   section: { paddingHorizontal: 20, paddingTop: 20, paddingBottom: 12 },
   traitBandWrap: { paddingHorizontal: 20, paddingTop: 18, paddingBottom: 4 },
+  sectionTitleRow: { flexDirection: 'row', alignItems: 'center' },
+  sectionTitleGrow: { flex: 1 },
+  sectionPen: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(41,60,67,0.06)',
+  },
   sectionTitle: {
     fontFamily: 'Flame-Regular',
     fontSize: 20,

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useCallback, useMemo, type ComponentProps } from 'react';
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  Fragment,
+  type ComponentProps,
+} from 'react';
 import { View, Text, Pressable, StyleSheet, Animated, useWindowDimensions } from 'react-native';
 import { useSkeletonAnim, SkeletonBlock } from '../../src/components/web/Skeleton';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -21,7 +28,13 @@ import { getPowerIcon, groupPowers } from '../../src/constants/powerIcons';
 import { useAuth } from '../../src/hooks/useAuth';
 import { ContributeSheet } from '../../src/components/contribute/ContributeSheet';
 import { isBlankValue } from '../../src/lib/contribute/missingFields';
-import { EDITABLE_FIELDS, type EditableFieldDef } from '../../src/lib/db/contributions';
+import {
+  DOSSIER_GROUPS,
+  SUMMARY_FIELD,
+  POWERS_FIELD,
+  STAT_FIELDS,
+  type EditableFieldDef,
+} from '../../src/lib/db/contributions';
 import { getProfile } from '../../src/lib/db/profiles';
 import { heroImageSource } from '../../src/constants/heroImages';
 import { HeroImage } from '../../src/components/HeroImage';
@@ -188,29 +201,40 @@ function MobileDossier({
       </Pressable>
       {open && editing ? (
         <View style={styles.dossierBody}>
-          <Text style={styles.dossierGroupLabel}>Edit details</Text>
-          {EDITABLE_FIELDS.map((f) => {
-            const v = editValues?.[f.field];
-            const filled = !isBlankValue(v);
-            return (
-              <Pressable
-                key={f.field}
-                onPress={() => onEditField?.(f, filled ? (v ?? null) : null)}
-                style={s2.editRow as object}
+          {DOSSIER_GROUPS.map((group, gi) => (
+            <Fragment key={group.key}>
+              <Text
+                style={[styles.dossierGroupLabel, gi > 0 && (styles.dossierGroupSpacing as object)]}
               >
-                <Text style={s2.editRowLabel}>{f.label}</Text>
-                <View style={s2.editRowRight as object}>
-                  <Text
-                    style={(filled ? s2.editRowValue : s2.editRowAdd) as object}
-                    numberOfLines={1}
+                {group.label}
+              </Text>
+              {group.fields.map((f) => {
+                const v = editValues?.[f.field];
+                const filled = !isBlankValue(v);
+                return (
+                  <Pressable
+                    key={f.field}
+                    onPress={() => onEditField?.(f, filled ? (v ?? null) : null)}
+                    style={s2.editRow as object}
                   >
-                    {filled ? v : 'Add'}
-                  </Text>
-                  <Ionicons name={filled ? 'pencil' : 'add'} size={14} color={COLORS.orange} />
-                </View>
-              </Pressable>
-            );
-          })}
+                    <Text style={s2.editRowLabel}>{f.label}</Text>
+                    <View style={s2.editRowRight as object}>
+                      <Text
+                        style={(filled ? s2.editRowValue : s2.editRowAdd) as object}
+                        numberOfLines={1}
+                      >
+                        {filled ? v : 'Add'}
+                      </Text>
+                      <Ionicons name={filled ? 'pencil' : 'add'} size={14} color={COLORS.orange} />
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </Fragment>
+          ))}
+          <Text style={[styles.dossierGroupLabel, styles.dossierGroupSpacing as object]}>
+            Trivia
+          </Text>
           <Pressable onPress={() => onEditField?.(null, null)} style={s2.editRow as object}>
             <Text style={s2.editRowLabel}>Did You Know fact</Text>
             <View style={s2.editRowRight as object}>
@@ -301,6 +325,15 @@ const s2 = StyleSheet.create({
     borderBottomColor: 'rgba(41,60,67,0.1)',
     cursor: 'pointer',
   } as object,
+  editGroupLabel: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: COLORS.orange,
+    marginTop: 14,
+    marginBottom: 2,
+  } as object,
   editRowLabel: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
   editRowRight: {
     flexDirection: 'row',
@@ -319,7 +352,42 @@ const s2 = StyleSheet.create({
     fontSize: 13,
     color: COLORS.orange,
   } as object,
+  summaryHead: { alignItems: 'flex-end', marginBottom: 4 } as object,
+  summaryEmpty: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: COLORS.grey,
+    cursor: 'pointer',
+  } as object,
 });
+
+// Admin-only editable power-stat list — swaps in for the dial/bar view when an
+// admin taps the stats pen. Shared by the desktop and mobile-web layouts.
+function StatEditList({
+  stats,
+  onPick,
+}: {
+  stats: HeroStats;
+  onPick: (field: EditableFieldDef, current: string) => void;
+}) {
+  return (
+    <View>
+      {STAT_FIELDS.map((f) => {
+        const cur = (stats.powerstats as Record<string, string>)[f.field] ?? '0';
+        return (
+          <Pressable key={f.field} onPress={() => onPick(f, cur)} style={s2.editRow as object}>
+            <Text style={s2.editRowLabel}>{f.label}</Text>
+            <View style={s2.editRowRight as object}>
+              <Text style={s2.editRowValue as object}>{cur}</Text>
+              <Ionicons name="pencil" size={14} color={COLORS.orange} />
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
 
 type IoniconName = ComponentProps<typeof Ionicons>['name'];
 
@@ -429,6 +497,7 @@ export default function WebCharacterScreen() {
     current: string | null;
   } | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [editingStats, setEditingStats] = useState(false);
   const [showIssueModal, setShowIssueModal] = useState(false);
   const [comicVineLoading, setComicVineLoading] = useState(true);
   const [statsGenerating, setStatsGenerating] = useState(false);
@@ -790,12 +859,26 @@ export default function WebCharacterScreen() {
   // Editable-field → current value, shared by the mobile dossier editor and the
   // desktop contribute card (the screen has both stats + details).
   const editValues: Record<string, string | null | undefined> = {
-    origin: details.origin,
-    occupation: stats.work.occupation,
-    base: stats.work.base,
+    // Profile
+    full_name: stats.biography['full-name'],
+    alter_egos: stats.biography['alter-egos'],
+    aliases: (stats.biography.aliases ?? [])
+      .filter((a) => a && !JUNK_VALUES.has(a.toLowerCase().trim()))
+      .join('\n'),
     place_of_birth: stats.biography['place-of-birth'],
     first_appearance: stats.biography['first-appearance'],
-    full_name: stats.biography['full-name'],
+    origin: details.origin,
+    // Appearance
+    gender: stats.appearance.gender,
+    race: stats.appearance.race,
+    height_imperial: stats.appearance.height?.[0],
+    weight_imperial: stats.appearance.weight?.[0],
+    eye_color: stats.appearance['eye-color'],
+    hair_color: stats.appearance['hair-color'],
+    // Connections
+    occupation: stats.work.occupation,
+    base: stats.work.base,
+    group_affiliation: stats.connections['group-affiliation'],
   };
 
   // Re-derive from the freshly-edited DB row so the page reflects the change.
@@ -1035,6 +1118,20 @@ export default function WebCharacterScreen() {
                         ) : null}
                       </View>
                       <View style={styles.statHeaderRight}>
+                        {isAdmin ? (
+                          <Pressable
+                            onPress={() => setEditingStats((s) => !s)}
+                            hitSlop={8}
+                            style={s2.penBtn as object}
+                            accessibilityLabel="Edit power stats"
+                          >
+                            <Ionicons
+                              name="create-outline"
+                              size={16}
+                              color={editingStats ? COLORS.orange : COLORS.navy}
+                            />
+                          </Pressable>
+                        ) : null}
                         {powerScore !== null || statsGenerating ? (
                           <Pressable
                             onPress={() =>
@@ -1070,6 +1167,12 @@ export default function WebCharacterScreen() {
                       </View>
                     </View>
                     <View style={styles.cardDivider} />
+                    {isAdmin && editingStats ? (
+                      <StatEditList
+                        stats={stats}
+                        onPick={(field, current) => setEditTarget({ field, current })}
+                      />
+                    ) : (
                     <View style={styles.statBand}>
                       {STAT_CONFIG.map(({ key, label, color }) => {
                         if (statsGenerating) {
@@ -1122,6 +1225,7 @@ export default function WebCharacterScreen() {
                         );
                       })}
                     </View>
+                    )}
                     {percentile != null && percentile > 0 ? (
                       <Text style={styles.percentileText}>
                         Stronger than {percentile}% of heroes
@@ -1147,6 +1251,21 @@ export default function WebCharacterScreen() {
                     </View>
                   ) : details.summary || details.description ? (
                     <View style={styles.summaryBox}>
+                      <View style={s2.summaryHead as object}>
+                        <Pressable
+                          onPress={() =>
+                            setEditTarget({
+                              field: SUMMARY_FIELD,
+                              current: details.summary ?? null,
+                            })
+                          }
+                          hitSlop={8}
+                          style={s2.penBtn as object}
+                          accessibilityLabel="Edit summary"
+                        >
+                          <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+                        </Pressable>
+                      </View>
                       {details.summary ? (
                         <Text style={styles.summaryText}>{details.summary}</Text>
                       ) : null}
@@ -1165,7 +1284,27 @@ export default function WebCharacterScreen() {
                         </Pressable>
                       ) : null}
                     </View>
-                  ) : null}
+                  ) : (
+                    <View style={styles.summaryBox}>
+                      <View style={s2.summaryHead as object}>
+                        <Pressable
+                          onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                          hitSlop={8}
+                          style={s2.penBtn as object}
+                          accessibilityLabel="Edit summary"
+                        >
+                          <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+                        </Pressable>
+                      </View>
+                      <Pressable
+                        onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                      >
+                        <Text style={s2.summaryEmpty as object}>
+                          Add a short summary for this hero.
+                        </Text>
+                      </Pressable>
+                    </View>
+                  )}
 
                   {/* Abilities — power explainers fold in as the "Decoded" strip */}
                   <WebAbilitiesCard
@@ -1173,6 +1312,15 @@ export default function WebCharacterScreen() {
                     loading={comicVineLoading}
                     skeletonOpacity={skeletonOpacity}
                     explainers={narrative?.powerExplainers ?? []}
+                    onEdit={
+                      comicVineLoading
+                        ? undefined
+                        : () =>
+                            setEditTarget({
+                              field: POWERS_FIELD,
+                              current: details.powers?.length ? details.powers.join('\n') : null,
+                            })
+                    }
                   />
 
                   {/* Did You Know — swipeable trivia deck */}
@@ -1532,34 +1680,43 @@ export default function WebCharacterScreen() {
                       <View>
                         <Text style={styles.cardTitle}>Edit details</Text>
                         <View style={styles.cardDivider} />
-                        {EDITABLE_FIELDS.map((f) => {
-                          const v = editValues[f.field];
-                          const filled = !isBlankValue(v);
-                          return (
-                            <Pressable
-                              key={f.field}
-                              onPress={() =>
-                                setEditTarget({ field: f, current: filled ? (v ?? null) : null })
-                              }
-                              style={s2.editRow as object}
-                            >
-                              <Text style={s2.editRowLabel}>{f.label}</Text>
-                              <View style={s2.editRowRight as object}>
-                                <Text
-                                  style={(filled ? s2.editRowValue : s2.editRowAdd) as object}
-                                  numberOfLines={1}
+                        {DOSSIER_GROUPS.map((group) => (
+                          <Fragment key={group.key}>
+                            <Text style={s2.editGroupLabel}>{group.label}</Text>
+                            {group.fields.map((f) => {
+                              const v = editValues[f.field];
+                              const filled = !isBlankValue(v);
+                              return (
+                                <Pressable
+                                  key={f.field}
+                                  onPress={() =>
+                                    setEditTarget({
+                                      field: f,
+                                      current: filled ? (v ?? null) : null,
+                                    })
+                                  }
+                                  style={s2.editRow as object}
                                 >
-                                  {filled ? v : 'Add'}
-                                </Text>
-                                <Ionicons
-                                  name={filled ? 'pencil' : 'add'}
-                                  size={14}
-                                  color={COLORS.orange}
-                                />
-                              </View>
-                            </Pressable>
-                          );
-                        })}
+                                  <Text style={s2.editRowLabel}>{f.label}</Text>
+                                  <View style={s2.editRowRight as object}>
+                                    <Text
+                                      style={(filled ? s2.editRowValue : s2.editRowAdd) as object}
+                                      numberOfLines={1}
+                                    >
+                                      {filled ? v : 'Add'}
+                                    </Text>
+                                    <Ionicons
+                                      name={filled ? 'pencil' : 'add'}
+                                      size={14}
+                                      color={COLORS.orange}
+                                    />
+                                  </View>
+                                </Pressable>
+                              );
+                            })}
+                          </Fragment>
+                        ))}
+                        <Text style={s2.editGroupLabel}>Trivia</Text>
                         <Pressable
                           onPress={() => setEditTarget({ field: null, current: null })}
                           style={s2.editRow as object}
@@ -1804,6 +1961,18 @@ export default function WebCharacterScreen() {
                   </View>
                 ) : details.summary || details.description ? (
                   <View style={styles.mBlock}>
+                    <View style={s2.summaryHead as object}>
+                      <Pressable
+                        onPress={() =>
+                          setEditTarget({ field: SUMMARY_FIELD, current: details.summary ?? null })
+                        }
+                        hitSlop={8}
+                        style={s2.penBtn as object}
+                        accessibilityLabel="Edit summary"
+                      >
+                        <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+                      </Pressable>
+                    </View>
                     {details.summary ? (
                       <Text style={styles.mSummary}>{details.summary}</Text>
                     ) : null}
@@ -1822,7 +1991,25 @@ export default function WebCharacterScreen() {
                       </Pressable>
                     ) : null}
                   </View>
-                ) : null}
+                ) : (
+                  <View style={styles.mBlock}>
+                    <View style={s2.summaryHead as object}>
+                      <Pressable
+                        onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                        hitSlop={8}
+                        style={s2.penBtn as object}
+                        accessibilityLabel="Edit summary"
+                      >
+                        <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+                      </Pressable>
+                    </View>
+                    <Pressable onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}>
+                      <Text style={s2.summaryEmpty as object}>
+                        Add a short summary for this hero.
+                      </Text>
+                    </Pressable>
+                  </View>
+                )}
 
                 {/* Power Stats */}
                 <View style={styles.mBlock}>
@@ -1837,6 +2024,20 @@ export default function WebCharacterScreen() {
                         ) : null}
                       </View>
                       <View style={styles.statHeaderRight}>
+                        {isAdmin ? (
+                          <Pressable
+                            onPress={() => setEditingStats((s) => !s)}
+                            hitSlop={8}
+                            style={s2.penBtn as object}
+                            accessibilityLabel="Edit power stats"
+                          >
+                            <Ionicons
+                              name="create-outline"
+                              size={16}
+                              color={editingStats ? COLORS.orange : COLORS.navy}
+                            />
+                          </Pressable>
+                        ) : null}
                         {powerScore !== null || statsGenerating ? (
                           <Pressable
                             onPress={() =>
@@ -1872,24 +2073,31 @@ export default function WebCharacterScreen() {
                       </View>
                     </View>
                     <View style={styles.cardDivider} />
-                    {statsGenerating
-                      ? STAT_CONFIG.map(({ key }) => (
-                          <SkeletonBlock
-                            key={key}
-                            opacity={skeletonOpacity}
-                            height={10}
-                            borderRadius={5}
-                            style={{ marginBottom: 14 }}
-                          />
-                        ))
-                      : STAT_CONFIG.map(({ key, label, color }) => (
-                          <StatBar
-                            key={key}
-                            label={label}
-                            value={(stats.powerstats as Record<string, string>)[key] ?? '0'}
-                            color={color}
-                          />
-                        ))}
+                    {isAdmin && editingStats ? (
+                      <StatEditList
+                        stats={stats}
+                        onPick={(field, current) => setEditTarget({ field, current })}
+                      />
+                    ) : statsGenerating ? (
+                      STAT_CONFIG.map(({ key }) => (
+                        <SkeletonBlock
+                          key={key}
+                          opacity={skeletonOpacity}
+                          height={10}
+                          borderRadius={5}
+                          style={{ marginBottom: 14 }}
+                        />
+                      ))
+                    ) : (
+                      STAT_CONFIG.map(({ key, label, color }) => (
+                        <StatBar
+                          key={key}
+                          label={label}
+                          value={(stats.powerstats as Record<string, string>)[key] ?? '0'}
+                          color={color}
+                        />
+                      ))
+                    )}
                     {percentile != null && percentile > 0 ? (
                       <Text style={styles.percentileText}>
                         Stronger than {percentile}% of heroes
@@ -1903,6 +2111,15 @@ export default function WebCharacterScreen() {
                   powers={details.powers}
                   loading={comicVineLoading}
                   explainers={narrative?.powerExplainers ?? []}
+                  onEdit={
+                    comicVineLoading
+                      ? undefined
+                      : () =>
+                          setEditTarget({
+                            field: POWERS_FIELD,
+                            current: details.powers?.length ? details.powers.join('\n') : null,
+                          })
+                  }
                 />
 
                 {/* Did You Know — swipeable trivia deck */}
@@ -2144,18 +2361,51 @@ export default function WebCharacterScreen() {
 }
 
 // ── Web abilities card — categorized power profile (card-styled) ─────────────
+function AbilitiesHead({ onEdit }: { onEdit?: () => void }) {
+  return (
+    <>
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Text style={styles.cardTitle}>Abilities</Text>
+        {onEdit ? (
+          <Pressable
+            onPress={onEdit}
+            hitSlop={8}
+            style={s2.penBtn as object}
+            accessibilityLabel="Edit abilities"
+          >
+            <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+          </Pressable>
+        ) : null}
+      </View>
+      <View style={styles.cardDivider} />
+    </>
+  );
+}
+
 function WebAbilitiesCard({
   powers,
   loading,
   skeletonOpacity,
   explainers = [],
+  onEdit,
 }: {
   powers: string[] | null;
   loading: boolean;
   skeletonOpacity: ReturnType<typeof useSkeletonAnim>;
   explainers?: PowerExplainer[];
+  onEdit?: () => void;
 }) {
-  if (!loading && (!powers || powers.length === 0)) return null;
+  if (!loading && (!powers || powers.length === 0)) {
+    if (!onEdit) return null;
+    return (
+      <View style={styles.card}>
+        <AbilitiesHead onEdit={onEdit} />
+        <Pressable onPress={onEdit}>
+          <Text style={s2.summaryEmpty as object}>Add powers & abilities for this hero.</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   const groups = powers ? groupPowers(powers) : [];
 
@@ -2188,8 +2438,7 @@ function WebAbilitiesCard({
         </>
       ) : powers && powers.length > 0 ? (
         <>
-          <Text style={styles.cardTitle}>Abilities</Text>
-          <View style={styles.cardDivider} />
+          <AbilitiesHead onEdit={onEdit} />
           {groups.map((g, gi) => (
             <View
               key={g.category}

--- a/src/components/AbilitiesSection.tsx
+++ b/src/components/AbilitiesSection.tsx
@@ -1,5 +1,5 @@
-import { View, Text, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../constants/colors';
 import { getPowerIcon, groupPowers } from '../constants/powerIcons';
 import { Skeleton } from './ui/Skeleton';
@@ -11,19 +11,55 @@ interface Props {
   powers: string[] | null;
   loading: boolean;
   explainers?: PowerExplainer[];
+  /** When set, a subtle pen appears in the header to edit the whole powers list
+   *  (one per line) — and an empty section still renders so it can be filled. */
+  onEdit?: () => void;
 }
 
-export function AbilitiesSection({ powers, loading, explainers = [] }: Props) {
-  if (!loading && (!powers || powers.length === 0)) return null;
+function Header({ onEdit }: { onEdit?: () => void }) {
+  return (
+    <View style={styles.sectionHeader}>
+      <View style={styles.headerRow}>
+        {onEdit ? (
+          <TouchableOpacity
+            onPress={onEdit}
+            hitSlop={8}
+            style={styles.pen}
+            accessibilityRole="button"
+            accessibilityLabel="Edit abilities"
+          >
+            <Ionicons name="create-outline" size={16} color={COLORS.navy} />
+          </TouchableOpacity>
+        ) : null}
+        <Text style={styles.sectionTitle}>Abilities</Text>
+      </View>
+      <View style={styles.divider} />
+    </View>
+  );
+}
+
+export function AbilitiesSection({ powers, loading, explainers = [], onEdit }: Props) {
+  if (!loading && (!powers || powers.length === 0)) {
+    // Nothing to show and nothing to add → hide entirely. With an editor, keep
+    // the section so a contributor can fill it.
+    if (!onEdit) return null;
+    return (
+      <View style={styles.container}>
+        <Header onEdit={onEdit} />
+        <View style={styles.body}>
+          <TouchableOpacity onPress={onEdit} activeOpacity={0.7}>
+            <Text style={styles.emptyAdd}>Add powers & abilities for this hero.</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
 
   const groups = powers ? groupPowers(powers) : [];
 
   return (
     <View style={styles.container}>
-      <View style={styles.sectionHeader}>
-        <Text style={styles.sectionTitle}>Abilities</Text>
-        <View style={styles.divider} />
-      </View>
+      <Header onEdit={onEdit} />
 
       <View style={styles.body}>
         {loading && !powers ? (
@@ -79,12 +115,29 @@ const styles = StyleSheet.create({
   sectionHeader: {
     paddingHorizontal: 20,
   },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  pen: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(41,60,67,0.06)',
+  },
   sectionTitle: {
+    flex: 1,
     fontFamily: 'Flame-Regular',
     fontSize: 20,
     color: COLORS.navy,
     textAlign: 'right',
     paddingVertical: 5,
+  },
+  emptyAdd: {
+    fontFamily: 'FlameSans-Regular',
+    fontSize: 14,
+    color: COLORS.grey,
+    fontStyle: 'italic',
+    paddingBottom: 8,
   },
   divider: {
     height: 2,

--- a/src/components/contribute/ContributeSheet.tsx
+++ b/src/components/contribute/ContributeSheet.tsx
@@ -55,24 +55,45 @@ export function ContributeSheet({
 
   useEffect(() => {
     if (visible) {
-      setValue('');
+      // Lists and stats are edited in place (retyping a whole list is hostile),
+      // so seed the input with the current value. Free text starts blank — the
+      // "Current" reference is shown separately for admins.
+      const seed =
+        (field?.type === 'list' || field?.type === 'stat') && currentValue ? currentValue : '';
+      setValue(seed);
       setError(null);
       setDone(false);
       setSubmitting(false);
     }
-  }, [visible, field]);
+  }, [visible, field, currentValue]);
 
   const isFact = !field;
+  const isStat = field?.type === 'stat';
+  const isList = field?.type === 'list';
   const prompt = isFact ? 'Know a fun fact about this hero?' : field!.question;
   const guideline = isFact
     ? 'Share a "Did You Know" — one or two sentences.'
     : (field!.guideline ?? '');
   const multiline = isFact || !!field?.multiline;
+  const placeholder = isFact
+    ? 'Did you know…'
+    : isStat
+      ? '0–100'
+      : isList
+        ? 'One per line'
+        : 'Type your answer';
 
   const submit = async () => {
     if (!value.trim()) {
       setError('Add something first.');
       return;
+    }
+    if (isStat) {
+      const n = Number(value.trim());
+      if (!/^\d{1,3}$/.test(value.trim()) || !Number.isInteger(n) || n < 0 || n > 100) {
+        setError('Enter a whole number from 0 to 100.');
+        return;
+      }
     }
     setSubmitting(true);
     setError(null);
@@ -140,9 +161,11 @@ export function ContributeSheet({
               <TextInput
                 value={value}
                 onChangeText={setValue}
-                placeholder={isFact ? 'Did you know…' : 'Type your answer'}
+                placeholder={placeholder}
                 placeholderTextColor={COLORS.grey}
                 multiline={multiline}
+                keyboardType={isStat ? 'number-pad' : 'default'}
+                maxLength={isStat ? 3 : undefined}
                 style={[s.input, multiline && s.inputMultiline]}
                 autoFocus
                 onSubmitEditing={multiline ? undefined : submit}

--- a/src/lib/contribute/missingFields.ts
+++ b/src/lib/contribute/missingFields.ts
@@ -1,24 +1,6 @@
-import { EDITABLE_FIELDS, type EditableFieldDef } from '../db/contributions';
-
-// Which contributor-editable fields a hero is missing — the engine behind the
-// "Help complete this page" card. A field is "blank" using the same sentinels
-// the character screen treats as empty ('-' / 'null' / whitespace), so the card
-// only ever asks for genuinely-absent data.
-
+// A value is "blank" using the same sentinels the character screen treats as
+// empty ('-' / 'null' / whitespace), so inline edit only marks genuinely-absent
+// fields as needing input.
 export function isBlankValue(v?: string | null): boolean {
   return !v || v === '-' || v === 'null' || v.trim() === '';
-}
-
-/** The editable fields that are currently empty for this hero. */
-export function missingFields(
-  values: Record<string, string | null | undefined>,
-): EditableFieldDef[] {
-  return EDITABLE_FIELDS.filter((f) => isBlankValue(values[f.field]));
-}
-
-/** The editable fields that already have a value (candidates for "suggest a fix"). */
-export function presentFields(
-  values: Record<string, string | null | undefined>,
-): EditableFieldDef[] {
-  return EDITABLE_FIELDS.filter((f) => !isBlankValue(values[f.field]));
 }

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -7,6 +7,10 @@ import { supabase } from '../supabase';
 
 export type ContributionKind = 'field' | 'fact' | 'report';
 
+/** How a field's value is shaped — drives both the editor input and the
+ *  server-side apply path (text column / text[] column / int powerstat). */
+export type FieldType = 'text' | 'list' | 'stat';
+
 export interface EditableFieldDef {
   field: string;
   label: string;
@@ -15,32 +19,137 @@ export interface EditableFieldDef {
   question: string;
   guideline?: string;
   multiline?: boolean;
+  /** Defaults to 'text'. 'list' edits a whole text[] (one per line); 'stat' is a
+   *  0–100 integer powerstat (admin-only — refused for community submissions). */
+  type?: FieldType;
+  /** Dossier grouping, so the edit list reads like the read view. */
+  group?: 'profile' | 'appearance' | 'connections';
 }
 
-/** The heroes text columns a contributor may propose. Mirrors the allow-list
- *  enforced server-side in submit_contribution / admin_review_contribution. */
+/** The Dossier's editable columns, grouped to mirror the read view. Mirrors the
+ *  allow-list enforced server-side in _contrib_field_type. */
 export const EDITABLE_FIELDS: EditableFieldDef[] = [
+  // Profile
+  { field: 'full_name', label: 'Full name', question: "What's their real name?", group: 'profile' },
+  {
+    field: 'alter_egos',
+    label: 'Alter egos',
+    question: 'Any other identities they go by?',
+    group: 'profile',
+  },
+  {
+    field: 'aliases',
+    label: 'Aliases',
+    question: 'What else are they called?',
+    guideline: 'One alias per line.',
+    type: 'list',
+    multiline: true,
+    group: 'profile',
+  },
+  {
+    field: 'place_of_birth',
+    label: 'Place of birth',
+    question: 'Where were they born?',
+    group: 'profile',
+  },
+  {
+    field: 'first_appearance',
+    label: 'First appearance',
+    question: 'Where did they first appear?',
+    guideline: 'The issue or title they debuted in.',
+    group: 'profile',
+  },
   {
     field: 'origin',
     label: 'Origin',
     question: 'Where does this hero come from?',
     guideline: 'Their origin story — a sentence or two.',
     multiline: true,
+    group: 'profile',
   },
-  { field: 'full_name', label: 'Full name', question: "What's their real name?" },
-  { field: 'occupation', label: 'Occupation', question: 'What do they do?' },
-  { field: 'base', label: 'Base of operations', question: 'Where do they operate from?' },
-  { field: 'place_of_birth', label: 'Place of birth', question: 'Where were they born?' },
+  // Appearance
+  { field: 'gender', label: 'Gender', question: 'How do they identify?', group: 'appearance' },
+  { field: 'race', label: 'Race', question: 'What is their race or species?', group: 'appearance' },
   {
-    field: 'first_appearance',
-    label: 'First appearance',
-    question: 'Where did they first appear?',
-    guideline: 'The issue or title they debuted in.',
+    field: 'height_imperial',
+    label: 'Height',
+    question: 'How tall are they?',
+    guideline: 'e.g. 6′2″',
+    group: 'appearance',
+  },
+  {
+    field: 'weight_imperial',
+    label: 'Weight',
+    question: 'How much do they weigh?',
+    guideline: 'e.g. 200 lb',
+    group: 'appearance',
+  },
+  { field: 'eye_color', label: 'Eyes', question: 'What colour are their eyes?', group: 'appearance' },
+  { field: 'hair_color', label: 'Hair', question: 'What colour is their hair?', group: 'appearance' },
+  // Connections
+  { field: 'occupation', label: 'Occupation', question: 'What do they do?', group: 'connections' },
+  {
+    field: 'base',
+    label: 'Base of operations',
+    question: 'Where do they operate from?',
+    group: 'connections',
+  },
+  {
+    field: 'group_affiliation',
+    label: 'Affiliations',
+    question: 'Which teams or groups do they belong to?',
+    guideline: 'Teams or allies, comma-separated.',
+    multiline: true,
+    group: 'connections',
+  },
+];
+
+/** The Summary section's lede — its own pen on the hero page. */
+export const SUMMARY_FIELD: EditableFieldDef = {
+  field: 'summary',
+  label: 'Summary',
+  question: 'How would you sum up this hero?',
+  guideline: 'A short overview — two or three sentences.',
+  multiline: true,
+};
+
+/** The Abilities section — the whole powers list, edited one per line. */
+export const POWERS_FIELD: EditableFieldDef = {
+  field: 'powers',
+  label: 'Powers & abilities',
+  question: 'What are their powers?',
+  guideline: 'One power per line.',
+  type: 'list',
+  multiline: true,
+};
+
+/** Power Stats — admin-only (they feed matchups). Each is a 0–100 integer. */
+export const STAT_FIELDS: EditableFieldDef[] = [
+  { field: 'intelligence', label: 'Intelligence', question: 'Set intelligence', type: 'stat' },
+  { field: 'strength', label: 'Strength', question: 'Set strength', type: 'stat' },
+  { field: 'speed', label: 'Speed', question: 'Set speed', type: 'stat' },
+  { field: 'durability', label: 'Durability', question: 'Set durability', type: 'stat' },
+  { field: 'power', label: 'Power', question: 'Set power', type: 'stat' },
+  { field: 'combat', label: 'Combat', question: 'Set combat', type: 'stat' },
+].map((f) => ({ ...f, guideline: 'A whole number from 0 to 100.' }) as EditableFieldDef);
+
+/** Dossier edit list, grouped to read like the section it replaces. */
+export const DOSSIER_GROUPS: { key: string; label: string; fields: EditableFieldDef[] }[] = [
+  { key: 'profile', label: 'Profile', fields: EDITABLE_FIELDS.filter((f) => f.group === 'profile') },
+  {
+    key: 'appearance',
+    label: 'Appearance',
+    fields: EDITABLE_FIELDS.filter((f) => f.group === 'appearance'),
+  },
+  {
+    key: 'connections',
+    label: 'Connections',
+    fields: EDITABLE_FIELDS.filter((f) => f.group === 'connections'),
   },
 ];
 
 const FIELD_LABEL: Record<string, string> = Object.fromEntries(
-  EDITABLE_FIELDS.map((f) => [f.field, f.label]),
+  [...EDITABLE_FIELDS, SUMMARY_FIELD, POWERS_FIELD, ...STAT_FIELDS].map((f) => [f.field, f.label]),
 );
 
 /** Human description of what a contribution changed, for the profile list. */

--- a/supabase/migrations/20260618130000_widen_editable_fields.sql
+++ b/supabase/migrations/20260618130000_widen_editable_fields.sql
@@ -1,0 +1,224 @@
+-- Widen the contributor-editable surface beyond the original 6 text fields.
+-- The hero page now exposes inline edit on more sections (Dossier appearance +
+-- connections, Summary, Abilities, Power Stats), so the contribution backbone
+-- must apply three shapes of value, not just plain text:
+--   • text  — a scalar text column (origin, gender, summary, …)
+--   • list  — a text[] column (aliases, powers); intake is "one per line"
+--   • stat  — an int powerstat 0–100 (intelligence … combat), ADMIN-ONLY
+-- Apply logic is centralised in _apply_hero_field so the review-approve path and
+-- the admin direct-edit path can never drift. Stats stay admin-only: they feed
+-- matchups, so community submissions of them are refused server-side.
+
+-- ── Field classification (single source of truth for the allow-list) ──────────
+create or replace function public._contrib_field_type(p_field text)
+returns text language sql immutable set search_path = public as $$
+  select case
+    when p_field in ('aliases','powers') then 'list'
+    when p_field in ('intelligence','strength','speed','durability','power','combat') then 'stat'
+    when p_field in (
+      'origin','full_name','occupation','base','place_of_birth','first_appearance',
+      'alter_egos','gender','race','height_imperial','weight_imperial',
+      'eye_color','hair_color','group_affiliation','summary','description'
+    ) then 'text'
+    else null
+  end;
+$$;
+
+-- Split a "one per line" (or comma-separated) intake into a trimmed text[],
+-- dropping blank entries. Newlines are normalised to commas first.
+create or replace function public._parse_str_list(p_raw text)
+returns text[] language sql immutable set search_path = public as $$
+  select array(
+    select btrim(x)
+    from unnest(string_to_array(replace(p_raw, E'\n', ','), ',')) as x
+    where btrim(x) <> ''
+  );
+$$;
+
+-- Apply one approved/admin field change to a hero, by field type. Centralised so
+-- both the review-approve path and admin_edit_hero share identical semantics.
+create or replace function public._apply_hero_field(p_hero_id text, p_field text, p_value text)
+returns void language plpgsql set search_path = public as $$
+declare
+  v_type text := public._contrib_field_type(p_field);
+begin
+  if v_type is null then raise exception 'field not editable'; end if;
+
+  if v_type = 'text' then
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using p_value, p_hero_id;
+
+  elsif v_type = 'list' then
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using public._parse_str_list(p_value), p_hero_id;
+
+  elsif v_type = 'stat' then
+    if p_value !~ '^\d{1,3}$' or p_value::int > 100 then
+      raise exception 'stat must be a whole number 0–100';
+    end if;
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using p_value::int, p_hero_id;
+    -- Keep the cached total in step so matchups / percentiles stay correct.
+    update public.heroes set powerstats_total =
+        coalesce(intelligence,0) + coalesce(strength,0) + coalesce(speed,0)
+      + coalesce(durability,0) + coalesce(power,0) + coalesce(combat,0)
+      where id = p_hero_id;
+  end if;
+end;
+$$;
+
+-- ── Submit (community): text + list fields only; stats are admin-only ─────────
+create or replace function public.submit_contribution(
+  p_hero_id text, p_kind text, p_target_field text, p_new_value text, p_note text
+) returns json
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_old text;
+  v_id  bigint;
+  v_pending int;
+  v_type text;
+begin
+  if v_uid is null then raise exception 'not authenticated'; end if;
+  if p_kind not in ('field','fact','report') then raise exception 'invalid kind'; end if;
+  if not exists (select 1 from public.heroes where id = p_hero_id) then
+    raise exception 'unknown hero';
+  end if;
+
+  select count(*) into v_pending from public.contributions
+    where user_id = v_uid and status = 'pending';
+  if v_pending >= 20 then raise exception 'too many pending contributions'; end if;
+
+  if p_kind = 'field' then
+    v_type := public._contrib_field_type(p_target_field);
+    if v_type is null then raise exception 'field not editable'; end if;
+    if v_type = 'stat' then raise exception 'power stats can only be edited by an admin'; end if;
+    if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+    if exists (select 1 from public.contributions
+               where user_id = v_uid and hero_id = p_hero_id and kind = 'field'
+                 and target_field = p_target_field and status = 'pending') then
+      raise exception 'you already have a pending suggestion for this field';
+    end if;
+    execute format('select %I::text from public.heroes where id = $1', p_target_field)
+      into v_old using p_hero_id;
+  elsif p_kind = 'fact' then
+    if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+  end if;
+
+  insert into public.contributions (user_id, hero_id, kind, target_field, old_value, new_value, note)
+  values (v_uid, p_hero_id, p_kind, p_target_field, v_old, p_new_value, p_note)
+  returning id into v_id;
+
+  insert into public.contributor_stats (user_id, pending)
+  values (v_uid, 1)
+  on conflict (user_id) do update
+    set pending = public.contributor_stats.pending + 1, updated_at = now();
+
+  return json_build_object('id', v_id, 'status', 'pending');
+end;
+$$;
+
+-- ── Admin: approve/reject (applies via the shared helper on approve) ──────────
+create or replace function public.admin_review_contribution(p_id bigint, p_decision text, p_reason text)
+returns json language plpgsql security definer set search_path = public
+as $$
+declare
+  c public.contributions;
+  v_admin uuid := auth.uid();
+begin
+  if not exists (select 1 from public.user_profiles where id = v_admin and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  if p_decision not in ('approve','reject') then raise exception 'invalid decision'; end if;
+
+  select * into c from public.contributions where id = p_id for update;
+  if not found then raise exception 'not found'; end if;
+  if c.status <> 'pending' then raise exception 'already reviewed'; end if;
+
+  if p_decision = 'approve' then
+    if c.kind = 'field' then
+      perform public._apply_hero_field(c.hero_id, c.target_field, c.new_value);
+    elsif c.kind = 'fact' then
+      insert into public.hero_narrative_facts (hero_id, kind, content, source_model, needs_review)
+      values (c.hero_id, 'did_you_know', c.new_value, 'community', false);
+    end if;  -- 'report' approval = acknowledged, no data mutation
+    update public.contributions
+      set status = 'approved', reviewed_by = v_admin, reviewed_at = now() where id = p_id;
+    update public.contributor_stats
+      set approved = approved + 1, pending = greatest(pending - 1, 0), updated_at = now()
+      where user_id = c.user_id;
+  else
+    update public.contributions
+      set status = 'rejected', reviewed_by = v_admin, reviewed_at = now(), reject_reason = p_reason
+      where id = p_id;
+    update public.contributor_stats
+      set rejected = rejected + 1, pending = greatest(pending - 1, 0), updated_at = now()
+      where user_id = c.user_id;
+  end if;
+
+  update public.contributor_stats
+    set level = case when approved >= 50 then 'steward'
+                     when approved >= 10 then 'curator' else 'new' end
+    where user_id = c.user_id;
+
+  return json_build_object('id', p_id,
+    'status', case when p_decision = 'approve' then 'approved' else 'rejected' end);
+end;
+$$;
+
+-- ── Admin direct-edit: applies immediately; stats permitted here ──────────────
+create or replace function public.admin_edit_hero(
+  p_hero_id text, p_kind text, p_target_field text, p_new_value text
+) returns json
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_admin uuid := auth.uid();
+  v_old text;
+  v_type text;
+begin
+  if not exists (select 1 from public.user_profiles where id = v_admin and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  if p_kind not in ('field','fact') then raise exception 'invalid kind'; end if;
+  if coalesce(btrim(p_new_value), '') = '' then raise exception 'value required'; end if;
+  if not exists (select 1 from public.heroes where id = p_hero_id) then
+    raise exception 'unknown hero';
+  end if;
+
+  if p_kind = 'field' then
+    v_type := public._contrib_field_type(p_target_field);
+    if v_type is null then raise exception 'field not editable'; end if;
+    execute format('select %I::text from public.heroes where id = $1', p_target_field)
+      into v_old using p_hero_id;
+    perform public._apply_hero_field(p_hero_id, p_target_field, p_new_value);
+  else
+    insert into public.hero_narrative_facts (hero_id, kind, content, source_model, needs_review)
+    values (p_hero_id, 'did_you_know', p_new_value, 'admin', false);
+  end if;
+
+  insert into public.contributions
+    (user_id, hero_id, kind, target_field, old_value, new_value, status, reviewed_by, reviewed_at)
+  values
+    (v_admin, p_hero_id, p_kind, p_target_field, v_old, p_new_value, 'approved', v_admin, now());
+
+  return json_build_object('ok', true);
+end;
+$$;
+
+-- Lock down the new internal helpers (callable only by the definer RPCs).
+revoke all on function public._contrib_field_type(text)            from public, anon, authenticated;
+revoke all on function public._parse_str_list(text)                from public, anon, authenticated;
+revoke all on function public._apply_hero_field(text, text, text)  from public, anon, authenticated;
+grant execute on function public._contrib_field_type(text)           to service_role;
+grant execute on function public._parse_str_list(text)               to service_role;
+grant execute on function public._apply_hero_field(text, text, text) to service_role;
+
+-- Re-assert RPC grants (function bodies were replaced above).
+revoke all on function public.submit_contribution(text, text, text, text, text)   from public, anon;
+revoke all on function public.admin_review_contribution(bigint, text, text)       from public, anon;
+revoke all on function public.admin_edit_hero(text, text, text, text)             from public, anon;
+grant execute on function public.submit_contribution(text, text, text, text, text)  to authenticated, service_role;
+grant execute on function public.admin_review_contribution(bigint, text, text)      to authenticated, service_role;
+grant execute on function public.admin_edit_hero(text, text, text, text)            to authenticated, service_role;


### PR DESCRIPTION
## Summary

Extends the pen-on-section inline-edit pattern beyond the Dossier's original 6 fields to cover the rest of the hero page — Summary, Power Stats, Abilities — and finishes the Dossier's own field set. Parity across **native, web mobile, and web desktop**.

### Backend (migration `20260618130000`, already applied)
- Centralises field-apply in `_apply_hero_field` so the review-approve path and the admin direct-edit path share one allow-list and can never drift. Supports three field shapes:
  - **text** — scalar columns
  - **list** — `text[]` (`aliases`, `powers`), parsed "one per line"
  - **stat** — `intelligence`…`combat`, validated 0–100, recomputes `powerstats_total`
- **Stats are admin-only** — community submissions of them are refused server-side (they feed matchups).

### UI
- **Dossier** edit list is now grouped (Profile / Appearance / Connections) and covers alter egos, aliases, gender, race, height, weight, eyes, hair and affiliations on top of the originals.
- **Summary**, **Power Stats** (admin pen), and **Abilities** each gain their own header pen. Stats swap the dial/bar view for an editable list; Abilities/aliases edit the whole list one-per-line; empty sections still surface so they can be filled.
- `ContributeSheet` gains numeric (stat, 0–100 validated) and list input modes, and seeds the field for list/stat edits so existing values aren't retyped.
- Native admin edits reload the row so changes show without a manual refresh.

### Hygiene
- Retires the now-dead `missingFields`/`presentFields` helpers (keeps `isBlankValue`).
- Adds a guard test locking the TS field registry to the SQL allow-list so they stay in lockstep.

## Verification
- `yarn typecheck` clean · lint 0 errors · **351/351 tests pass**
- Web is previewable on the PR (desktop + mobile); native mirrors the same component logic.

## To try
Open a hero → tap the pen on the Summary, Abilities, or Quick Facts/Dossier sections. As an admin, the Power Stats pen turns the dials into an editable 0–100 list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_