### PR TITLE
Fix: don't write generated powerstats_total in _apply_hero_field

### DIFF
--- a/supabase/migrations/20260618140000_fix_apply_hero_field_generated_total.sql
+++ b/supabase/migrations/20260618140000_fix_apply_hero_field_generated_total.sql
@@ -1,0 +1,33 @@
+-- Fix: heroes.powerstats_total is a GENERATED ALWAYS column (sum of the six
+-- powerstats), so the stat-apply path in _apply_hero_field must NOT write to it
+-- directly — Postgres rejects updates to generated columns, which would make
+-- every admin power-stat edit throw. Updating the underlying stat column
+-- recomputes the total automatically, so we simply drop the manual update.
+create or replace function public._apply_hero_field(p_hero_id text, p_field text, p_value text)
+returns void language plpgsql set search_path = public as $$
+declare
+  v_type text := public._contrib_field_type(p_field);
+begin
+  if v_type is null then raise exception 'field not editable'; end if;
+
+  if v_type = 'text' then
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using p_value, p_hero_id;
+
+  elsif v_type = 'list' then
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using public._parse_str_list(p_value), p_hero_id;
+
+  elsif v_type = 'stat' then
+    if p_value !~ '^\d{1,3}$' or p_value::int > 100 then
+      raise exception 'stat must be a whole number 0–100';
+    end if;
+    execute format('update public.heroes set %I = $1 where id = $2', p_field)
+      using p_value::int, p_hero_id;
+    -- powerstats_total recomputes itself (GENERATED ALWAYS) — no manual update.
+  end if;
+end;
+$$;
+
+revoke all on function public._apply_hero_field(text, text, text) from public, anon, authenticated;
+grant execute on function public._apply_hero_field(text, text, text) to service_role;


### PR DESCRIPTION
## Summary

Hotfix for a bug found while verifying the widened inline-edit work (#32).

`heroes.powerstats_total` is a **`GENERATED ALWAYS`** column (the sum of the six powerstats). The stat-apply path added in migration `20260618130000` wrote to it directly:

```sql
update public.heroes set powerstats_total = coalesce(intelligence,0) + ... ;
```

Postgres rejects updates to generated columns, so **every admin power-stat edit would throw** (`cannot insert a non-DEFAULT value into column "powerstats_total"`). Updating the underlying stat column already recomputes the total automatically, so the manual update is simply removed.

## Verification (live DB)

Exercised `_apply_hero_field` against a throwaway hero for all three field shapes:

- **text** → `occupation` set ✓
- **list** → `powers` split on newlines *and* commas, blanks dropped ✓
- **stat** → `intelligence` set, and `powerstats_total` auto-recomputed 210 → 288 ✓
- out-of-range stat (`150`) correctly rejected ✓

Throwaway hero removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_