### PR TITLE
Make the admin review queue first-class for the widened edit surface

### DIFF
--- a/__tests__/lib/db/contributions.diff.test.ts
+++ b/__tests__/lib/db/contributions.diff.test.ts
@@ -1,0 +1,87 @@
+import {
+  parsePgArrayLiteral,
+  splitListInput,
+  diffListValues,
+  fieldTypeOf,
+  fieldLabelOf,
+} from '../../../src/lib/db/contributions';
+
+describe('parsePgArrayLiteral', () => {
+  it('parses a plain array literal', () => {
+    expect(parsePgArrayLiteral('{Flight,Healing}')).toEqual(['Flight', 'Healing']);
+  });
+
+  it('unquotes elements with whitespace or special chars', () => {
+    expect(parsePgArrayLiteral('{Telepathy,"Time travel",Healing}')).toEqual([
+      'Telepathy',
+      'Time travel',
+      'Healing',
+    ]);
+  });
+
+  it('unescapes embedded quotes and backslashes', () => {
+    expect(parsePgArrayLiteral('{"say \\"hi\\""}')).toEqual(['say "hi"']);
+  });
+
+  it('drops NULL and empty, handles empty array', () => {
+    expect(parsePgArrayLiteral('{}')).toEqual([]);
+    expect(parsePgArrayLiteral('{A,NULL,B}')).toEqual(['A', 'B']);
+  });
+
+  it('falls back to line/comma split when not a literal', () => {
+    expect(parsePgArrayLiteral('Flight\nHealing')).toEqual(['Flight', 'Healing']);
+    expect(parsePgArrayLiteral(null)).toEqual([]);
+  });
+});
+
+describe('splitListInput', () => {
+  it('splits on newlines and commas, trims, drops blanks', () => {
+    expect(splitListInput('Flight\nSuper strength, Healing\n\n')).toEqual([
+      'Flight',
+      'Super strength',
+      'Healing',
+    ]);
+  });
+  it('handles empty', () => {
+    expect(splitListInput('')).toEqual([]);
+    expect(splitListInput(null)).toEqual([]);
+  });
+});
+
+describe('diffListValues', () => {
+  it('computes added/removed against the stored array literal', () => {
+    const d = diffListValues('{Flight,"Super strength"}', 'Flight\nHealing\nTelepathy');
+    expect(d.added).toEqual(['Healing', 'Telepathy']);
+    expect(d.removed).toEqual(['Super strength']);
+    expect(d.next).toEqual(['Flight', 'Healing', 'Telepathy']);
+  });
+
+  it('is case-insensitive for membership', () => {
+    const d = diffListValues('{flight}', 'Flight');
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('treats an empty old value as all-added', () => {
+    const d = diffListValues(null, 'Flight\nHealing');
+    expect(d.added).toEqual(['Flight', 'Healing']);
+    expect(d.removed).toEqual([]);
+  });
+});
+
+describe('fieldTypeOf / fieldLabelOf', () => {
+  it('classifies known fields and labels them', () => {
+    expect(fieldTypeOf('powers')).toBe('list');
+    expect(fieldTypeOf('aliases')).toBe('list');
+    expect(fieldTypeOf('intelligence')).toBe('stat');
+    expect(fieldTypeOf('place_of_birth')).toBe('text');
+    expect(fieldLabelOf('place_of_birth')).toBe('Place of birth');
+    expect(fieldLabelOf('group_affiliation')).toBe('Affiliations');
+  });
+
+  it('returns null/echo for unknown fields', () => {
+    expect(fieldTypeOf('not_a_field')).toBeNull();
+    expect(fieldTypeOf(null)).toBeNull();
+    expect(fieldLabelOf('mystery')).toBe('mystery');
+  });
+});

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -487,11 +487,7 @@ function Dossier({
           {hasAny ? (
             <>
               <Text style={styles.dossierToggleText}>{open ? 'Hide' : 'View'}</Text>
-              <Ionicons
-                name={open ? 'chevron-up' : 'chevron-down'}
-                size={15}
-                color={COLORS.navy}
-              />
+              <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={15} color={COLORS.navy} />
             </>
           ) : null}
         </View>
@@ -1404,7 +1400,10 @@ export default function CharacterScreen() {
                     <View style={styles.summaryHead}>
                       <SectionPen
                         onPress={() =>
-                          setEditTarget({ field: SUMMARY_FIELD, current: data.details.summary ?? null })
+                          setEditTarget({
+                            field: SUMMARY_FIELD,
+                            current: data.details.summary ?? null,
+                          })
                         }
                       />
                     </View>

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -1,11 +1,4 @@
-import {
-  useEffect,
-  useState,
-  useCallback,
-  useMemo,
-  Fragment,
-  type ComponentProps,
-} from 'react';
+import { useEffect, useState, useCallback, useMemo, Fragment, type ComponentProps } from 'react';
 import { View, Text, Pressable, StyleSheet, Animated, useWindowDimensions } from 'react-native';
 import { useSkeletonAnim, SkeletonBlock } from '../../src/components/web/Skeleton';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -1173,58 +1166,58 @@ export default function WebCharacterScreen() {
                         onPick={(field, current) => setEditTarget({ field, current })}
                       />
                     ) : (
-                    <View style={styles.statBand}>
-                      {STAT_CONFIG.map(({ key, label, color }) => {
-                        if (statsGenerating) {
+                      <View style={styles.statBand}>
+                        {STAT_CONFIG.map(({ key, label, color }) => {
+                          if (statsGenerating) {
+                            return (
+                              <View key={key} style={styles.bandCell}>
+                                <SkeletonBlock
+                                  opacity={skeletonOpacity}
+                                  width={42}
+                                  height={28}
+                                  borderRadius={5}
+                                />
+                                <SkeletonBlock
+                                  opacity={skeletonOpacity}
+                                  width="70%"
+                                  height={5}
+                                  borderRadius={3}
+                                />
+                                <SkeletonBlock
+                                  opacity={skeletonOpacity}
+                                  width={28}
+                                  height={9}
+                                  borderRadius={3}
+                                />
+                              </View>
+                            );
+                          }
+                          const raw = parseInt(
+                            (stats.powerstats as Record<string, string>)[key] ?? '0',
+                            10,
+                          );
+                          const fill = isNaN(raw) ? 0 : Math.min(raw, 100);
                           return (
                             <View key={key} style={styles.bandCell}>
-                              <SkeletonBlock
-                                opacity={skeletonOpacity}
-                                width={42}
-                                height={28}
-                                borderRadius={5}
-                              />
-                              <SkeletonBlock
-                                opacity={skeletonOpacity}
-                                width="70%"
-                                height={5}
-                                borderRadius={3}
-                              />
-                              <SkeletonBlock
-                                opacity={skeletonOpacity}
-                                width={28}
-                                height={9}
-                                borderRadius={3}
-                              />
+                              <Text style={[styles.bandVal, { color }]}>
+                                {isNaN(raw) ? '—' : raw}
+                              </Text>
+                              <View style={styles.bandTrack}>
+                                <View
+                                  style={[
+                                    styles.bandFill,
+                                    {
+                                      width: `${fill}%` as unknown as number,
+                                      backgroundColor: color,
+                                    },
+                                  ]}
+                                />
+                              </View>
+                              <Text style={styles.bandLabel}>{label}</Text>
                             </View>
                           );
-                        }
-                        const raw = parseInt(
-                          (stats.powerstats as Record<string, string>)[key] ?? '0',
-                          10,
-                        );
-                        const fill = isNaN(raw) ? 0 : Math.min(raw, 100);
-                        return (
-                          <View key={key} style={styles.bandCell}>
-                            <Text style={[styles.bandVal, { color }]}>
-                              {isNaN(raw) ? '—' : raw}
-                            </Text>
-                            <View style={styles.bandTrack}>
-                              <View
-                                style={[
-                                  styles.bandFill,
-                                  {
-                                    width: `${fill}%` as unknown as number,
-                                    backgroundColor: color,
-                                  },
-                                ]}
-                              />
-                            </View>
-                            <Text style={styles.bandLabel}>{label}</Text>
-                          </View>
-                        );
-                      })}
-                    </View>
+                        })}
+                      </View>
                     )}
                     {percentile != null && percentile > 0 ? (
                       <Text style={styles.percentileText}>
@@ -1667,7 +1660,12 @@ export default function WebCharacterScreen() {
                     <Pressable
                       onPress={() => setEditing(true)}
                       hitSlop={8}
-                      style={[s2.penBtn, { position: 'absolute', top: 10, right: 10, zIndex: 2 }] as object}
+                      style={
+                        [
+                          s2.penBtn,
+                          { position: 'absolute', top: 10, right: 10, zIndex: 2 },
+                        ] as object
+                      }
                       accessibilityLabel="Edit details"
                     >
                       <Ionicons
@@ -1729,77 +1727,81 @@ export default function WebCharacterScreen() {
                         </Pressable>
                       </View>
                     ) : (
-                    <View style={styles.factGrid}>
-                      {(() => {
-                        const rows = (
-                          [
-                            {
-                              icon: 'shield-half-outline',
-                              label: 'Alignment',
-                              value: stats.biography.alignment,
-                              accent: alignmentColor,
-                            },
-                            { icon: 'planet-outline', label: 'Origin', value: details.origin },
-                            {
-                              icon: genderIcon(stats.appearance.gender),
-                              label: 'Gender',
-                              value: stats.appearance.gender,
-                            },
-                            { icon: 'people-outline', label: 'Race', value: stats.appearance.race },
-                            {
-                              icon: 'swap-vertical-outline',
-                              label: 'Height',
-                              value: stats.appearance.height.join(' / '),
-                            },
-                            {
-                              icon: 'barbell-outline',
-                              label: 'Weight',
-                              value: stats.appearance.weight.join(' / '),
-                            },
-                            {
-                              icon: 'id-card-outline',
-                              label: 'Full name',
-                              value: stats.biography['full-name'],
-                              wide: true,
-                            },
-                            {
-                              icon: 'location-outline',
-                              label: 'Place of birth',
-                              value: stats.biography['place-of-birth'],
-                              wide: true,
-                            },
-                            {
-                              icon: 'briefcase-outline',
-                              label: 'Occupation',
-                              value: stats.work.occupation,
-                              wide: true,
-                            },
-                            {
-                              icon: 'business-outline',
-                              label: 'Base',
-                              value: stats.work.base,
-                              wide: true,
-                            },
-                          ] as {
-                            icon: IoniconName;
-                            label: string;
-                            value: string | null | undefined;
-                            wide?: boolean;
-                            accent?: string;
-                          }[]
-                        ).filter((r) => cleanFact(r.value));
-                        return rows.map((r) => (
-                          <FactTile
-                            key={r.label}
-                            icon={r.icon}
-                            label={r.label}
-                            value={r.value}
-                            wide={r.wide}
-                            accent={r.accent}
-                          />
-                        ));
-                      })()}
-                    </View>
+                      <View style={styles.factGrid}>
+                        {(() => {
+                          const rows = (
+                            [
+                              {
+                                icon: 'shield-half-outline',
+                                label: 'Alignment',
+                                value: stats.biography.alignment,
+                                accent: alignmentColor,
+                              },
+                              { icon: 'planet-outline', label: 'Origin', value: details.origin },
+                              {
+                                icon: genderIcon(stats.appearance.gender),
+                                label: 'Gender',
+                                value: stats.appearance.gender,
+                              },
+                              {
+                                icon: 'people-outline',
+                                label: 'Race',
+                                value: stats.appearance.race,
+                              },
+                              {
+                                icon: 'swap-vertical-outline',
+                                label: 'Height',
+                                value: stats.appearance.height.join(' / '),
+                              },
+                              {
+                                icon: 'barbell-outline',
+                                label: 'Weight',
+                                value: stats.appearance.weight.join(' / '),
+                              },
+                              {
+                                icon: 'id-card-outline',
+                                label: 'Full name',
+                                value: stats.biography['full-name'],
+                                wide: true,
+                              },
+                              {
+                                icon: 'location-outline',
+                                label: 'Place of birth',
+                                value: stats.biography['place-of-birth'],
+                                wide: true,
+                              },
+                              {
+                                icon: 'briefcase-outline',
+                                label: 'Occupation',
+                                value: stats.work.occupation,
+                                wide: true,
+                              },
+                              {
+                                icon: 'business-outline',
+                                label: 'Base',
+                                value: stats.work.base,
+                                wide: true,
+                              },
+                            ] as {
+                              icon: IoniconName;
+                              label: string;
+                              value: string | null | undefined;
+                              wide?: boolean;
+                              accent?: string;
+                            }[]
+                          ).filter((r) => cleanFact(r.value));
+                          return rows.map((r) => (
+                            <FactTile
+                              key={r.label}
+                              icon={r.icon}
+                              label={r.label}
+                              value={r.value}
+                              wide={r.wide}
+                              accent={r.accent}
+                            />
+                          ));
+                        })()}
+                      </View>
                     )}
                   </View>
 
@@ -2003,7 +2005,9 @@ export default function WebCharacterScreen() {
                         <Ionicons name="create-outline" size={16} color={COLORS.navy} />
                       </Pressable>
                     </View>
-                    <Pressable onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}>
+                    <Pressable
+                      onPress={() => setEditTarget({ field: SUMMARY_FIELD, current: null })}
+                    >
                       <Text style={s2.summaryEmpty as object}>
                         Add a short summary for this hero.
                       </Text>

--- a/src/components/admin/health/domains/ReviewDomain.tsx
+++ b/src/components/admin/health/domains/ReviewDomain.tsx
@@ -10,6 +10,9 @@ import { COLORS } from '../../../../constants/colors';
 import {
   getReviewQueue,
   reviewContribution,
+  fieldTypeOf,
+  fieldLabelOf,
+  diffListValues,
   type ReviewItem,
   type ContributionKind,
 } from '../../../../lib/db/contributions';
@@ -95,6 +98,65 @@ export function ReviewDomain() {
   );
 }
 
+// Field edits render differently by shape: lists as added/removed chips, stats
+// as old → new, plain text as a strike-through current + proposed. A reviewer
+// should be able to judge the change at a glance without parsing array literals.
+function FieldDiff({ item }: { item: ReviewItem }) {
+  const type = fieldTypeOf(item.target_field);
+
+  if (type === 'list') {
+    const { added, removed, next } = diffListValues(item.old_value, item.new_value);
+    return (
+      <View style={s.diff}>
+        <View style={s.chips}>
+          {next.map((v) => {
+            const isNew = added.some((a) => a.toLowerCase() === v.toLowerCase());
+            return (
+              <View key={`n-${v}`} style={[s.chip, isNew && (s.chipAdded as object)]}>
+                <Text style={[s.chipText, isNew && (s.chipAddedText as object)]}>{v}</Text>
+              </View>
+            );
+          })}
+          {removed.map((v) => (
+            <View key={`r-${v}`} style={[s.chip, s.chipRemoved as object]}>
+              <Text style={[s.chipText, s.chipRemovedText as object]}>{v}</Text>
+            </View>
+          ))}
+        </View>
+        {added.length + removed.length > 0 ? (
+          <Text style={s.diffMeta}>
+            {added.length} added · {removed.length} removed
+          </Text>
+        ) : (
+          <Text style={s.diffMeta}>No net change</Text>
+        )}
+      </View>
+    );
+  }
+
+  if (type === 'stat') {
+    return (
+      <View style={s.statDiff}>
+        <Text style={s.statOld}>{item.old_value || '—'}</Text>
+        <Text style={s.statArrow}>→</Text>
+        <Text style={s.statNew}>{item.new_value}</Text>
+      </View>
+    );
+  }
+
+  // Plain text (and any unknown field): current struck through, proposed below.
+  return (
+    <View style={s.diff}>
+      {!!item.old_value && (
+        <Text style={s.old} numberOfLines={4}>
+          {item.old_value}
+        </Text>
+      )}
+      <Text style={s.new}>{item.new_value}</Text>
+    </View>
+  );
+}
+
 function ReviewRow({
   item,
   busy,
@@ -122,7 +184,9 @@ function ReviewRow({
         <View style={[s.kindTag, { backgroundColor: KIND_COLOR[item.kind] + '1c' }]}>
           <Text style={[s.kindTagText, { color: KIND_COLOR[item.kind] }]}>
             {KIND_LABEL[item.kind]}
-            {item.kind === 'field' && item.target_field ? ` · ${item.target_field}` : ''}
+            {item.kind === 'field' && item.target_field
+              ? ` · ${fieldLabelOf(item.target_field)}`
+              : ''}
           </Text>
         </View>
         <Text style={s.hero} numberOfLines={1}>
@@ -134,14 +198,7 @@ function ReviewRow({
       </View>
 
       {item.kind === 'field' ? (
-        <View style={s.diff}>
-          {!!item.old_value && (
-            <Text style={s.old} numberOfLines={3}>
-              {item.old_value}
-            </Text>
-          )}
-          <Text style={s.new}>{item.new_value}</Text>
-        </View>
+        <FieldDiff item={item} />
       ) : item.kind === 'fact' ? (
         <Text style={s.new}>{item.new_value}</Text>
       ) : (
@@ -209,7 +266,14 @@ const s = StyleSheet.create({
   },
   hero: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.black, flex: 1 },
   meta: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: COLORS.grey },
-  diff: { gap: 3 },
+  diff: { gap: 4 },
+  diffMeta: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 10,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+  },
   old: {
     fontFamily: 'Nunito_400Regular',
     fontSize: 12,
@@ -217,6 +281,24 @@ const s = StyleSheet.create({
     textDecorationLine: 'line-through',
   },
   new: { fontFamily: 'Nunito_400Regular', fontSize: 14, color: COLORS.black, lineHeight: 20 },
+  // List diff — added/removed chips.
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  chip: {
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: '#eadfce',
+  },
+  chipText: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.navy },
+  chipAdded: { backgroundColor: COLORS.green + '22' } as object,
+  chipAddedText: { color: COLORS.green } as object,
+  chipRemoved: { backgroundColor: COLORS.red + '18' } as object,
+  chipRemovedText: { color: COLORS.red, textDecorationLine: 'line-through' } as object,
+  // Stat diff — old → new.
+  statDiff: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  statOld: { fontFamily: 'Flame-Regular', fontSize: 20, color: COLORS.grey },
+  statArrow: { fontFamily: 'Nunito_700Bold', fontSize: 16, color: COLORS.grey },
+  statNew: { fontFamily: 'Flame-Regular', fontSize: 22, color: COLORS.green },
   report: { fontFamily: 'Nunito_400Regular', fontSize: 14, color: COLORS.red, lineHeight: 20 },
   note: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey, fontStyle: 'italic' },
   input: {

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -84,8 +84,18 @@ export const EDITABLE_FIELDS: EditableFieldDef[] = [
     guideline: 'e.g. 200 lb',
     group: 'appearance',
   },
-  { field: 'eye_color', label: 'Eyes', question: 'What colour are their eyes?', group: 'appearance' },
-  { field: 'hair_color', label: 'Hair', question: 'What colour is their hair?', group: 'appearance' },
+  {
+    field: 'eye_color',
+    label: 'Eyes',
+    question: 'What colour are their eyes?',
+    group: 'appearance',
+  },
+  {
+    field: 'hair_color',
+    label: 'Hair',
+    question: 'What colour is their hair?',
+    group: 'appearance',
+  },
   // Connections
   { field: 'occupation', label: 'Occupation', question: 'What do they do?', group: 'connections' },
   {
@@ -135,7 +145,11 @@ export const STAT_FIELDS: EditableFieldDef[] = [
 
 /** Dossier edit list, grouped to read like the section it replaces. */
 export const DOSSIER_GROUPS: { key: string; label: string; fields: EditableFieldDef[] }[] = [
-  { key: 'profile', label: 'Profile', fields: EDITABLE_FIELDS.filter((f) => f.group === 'profile') },
+  {
+    key: 'profile',
+    label: 'Profile',
+    fields: EDITABLE_FIELDS.filter((f) => f.group === 'profile'),
+  },
   {
     key: 'appearance',
     label: 'Appearance',

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -152,6 +152,100 @@ const FIELD_LABEL: Record<string, string> = Object.fromEntries(
   [...EDITABLE_FIELDS, SUMMARY_FIELD, POWERS_FIELD, ...STAT_FIELDS].map((f) => [f.field, f.label]),
 );
 
+const FIELD_TYPE: Record<string, FieldType> = Object.fromEntries(
+  [...EDITABLE_FIELDS, SUMMARY_FIELD, POWERS_FIELD, ...STAT_FIELDS].map((f) => [
+    f.field,
+    f.type ?? 'text',
+  ]),
+);
+
+/** The shape of a field (text/list/stat), or null if it's not an editable field. */
+export function fieldTypeOf(targetField: string | null): FieldType | null {
+  return targetField ? (FIELD_TYPE[targetField] ?? null) : null;
+}
+
+/** Human label for an editable field column ('place_of_birth' → 'Place of birth'). */
+export function fieldLabelOf(targetField: string | null): string {
+  return FIELD_LABEL[targetField ?? ''] ?? targetField ?? '';
+}
+
+/** Parse a Postgres text[] literal ('{a,"b c",NULL}') into a string[]. Used to
+ *  read a list field's snapshot (old_value), which is stored as the array's
+ *  ::text form. Quoted elements are unescaped; NULL/empty are dropped. */
+export function parsePgArrayLiteral(literal: string | null | undefined): string[] {
+  if (!literal) return [];
+  const s = literal.trim();
+  if (!s.startsWith('{') || !s.endsWith('}')) {
+    // Not an array literal — fall back to the one-per-line/comma form.
+    return splitListInput(literal);
+  }
+  const inner = s.slice(1, -1);
+  if (inner.trim() === '') return [];
+  const out: string[] = [];
+  let i = 0;
+  while (i < inner.length) {
+    let val = '';
+    if (inner[i] === '"') {
+      i++;
+      while (i < inner.length && inner[i] !== '"') {
+        if (inner[i] === '\\') {
+          i++;
+          val += inner[i] ?? '';
+        } else {
+          val += inner[i];
+        }
+        i++;
+      }
+      i++; // closing quote
+    } else {
+      while (i < inner.length && inner[i] !== ',') {
+        val += inner[i];
+        i++;
+      }
+      val = val.trim();
+      if (val === 'NULL') val = '';
+    }
+    if (val !== '') out.push(val);
+    while (i < inner.length && inner[i] === ',') i++;
+  }
+  return out;
+}
+
+/** Split a "one per line" (or comma-separated) intake into a trimmed list,
+ *  dropping blanks — mirrors the server's _parse_str_list so the review diff
+ *  matches what will actually be written. */
+export function splitListInput(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[\n,]/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0);
+}
+
+export interface ListDiff {
+  added: string[];
+  removed: string[];
+  /** The resulting list (what the field becomes), in order. */
+  next: string[];
+}
+
+/** Diff a list field for review: what's added vs. removed between the stored
+ *  old value (array literal) and the proposed new value (one-per-line). */
+export function diffListValues(
+  oldLiteral: string | null | undefined,
+  newRaw: string | null | undefined,
+): ListDiff {
+  const prev = parsePgArrayLiteral(oldLiteral);
+  const next = splitListInput(newRaw);
+  const prevSet = new Set(prev.map((v) => v.toLowerCase()));
+  const nextSet = new Set(next.map((v) => v.toLowerCase()));
+  return {
+    added: next.filter((v) => !prevSet.has(v.toLowerCase())),
+    removed: prev.filter((v) => !nextSet.has(v.toLowerCase())),
+    next,
+  };
+}
+
 /** Human description of what a contribution changed, for the profile list. */
 export function describeContribution(c: {
   kind: ContributionKind;


### PR DESCRIPTION
## Summary

Makes the admin **Review queue** first-class for the widened inline-edit surface (#32). The queue was built for 6 plain-text fields; the widened work now funnels **lists** (`aliases`, `powers`) and **stats** through it too — where a moderator saw incomparable raw values:

> old `{Telepathy,"Time travel",Healing}` (Postgres array literal) vs new `Telepathy\nFlight` (newlines)

confirmed during the end-to-end verification of #32.

### What changed
The queue now renders each field edit **by shape**:
- **list** → added (green) / removed (struck-through red) chips + an "N added · M removed" summary, parsing the stored array literal and the one-per-line proposal into comparable lists
- **stat** → `old → new`
- **text** → current (struck) + proposed, as before

The kind tag now uses the **human field label** ("Affiliations") instead of the raw column name ("group_affiliation").

### New shared helpers (pure, tested)
`fieldTypeOf`, `fieldLabelOf`, `parsePgArrayLiteral`, `splitListInput`, `diffListValues` in `contributions.ts` — 12 unit tests covering array quoting/escaping/NULL edge cases and case-insensitive diffing.

## Verification
- `yarn typecheck` clean · lint 0 errors · **363/363 tests pass**
- Command center is web-only, so this touches only the web review UI + shared lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_