### PR TITLE
refactor(character): extract data layer into useHeroDetail hook (native)

### DIFF
--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -31,38 +31,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { SymbolView } from 'expo-symbols';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
-import {
-  fetchHeroStats,
-  fetchHeroDetails,
-  fetchHeroGallery,
-  HeroNotFoundError,
-} from '../../src/lib/api';
 import { NotFoundView, LoadErrorView } from '../../src/components/NotFoundView';
-import {
-  heroRowToCharacterData,
-  getHeroFamily,
-  type RelatedHeroCard,
-} from '../../src/lib/db/heroes';
-import type { FamilyMember } from '../../src/lib/family/types';
+import { heroRowToCharacterData } from '../../src/lib/db/heroes';
 import { FamilyCanvas } from '../../src/components/family/FamilyCanvas';
-import { useHeroRow, useHeroPercentile, useRelatedHeroes } from '../../src/lib/query/heroQueries';
-import { planHeroLoad } from '../../src/lib/query/heroLoadPlan';
-import {
-  isFavourited,
-  addFavourite,
-  removeFavourite,
-  getHeroFavouriteCount,
-} from '../../src/lib/db/favourites';
-import { getHeroTitles, groupTitlesByMedia, type HeroTitle } from '../../src/lib/db/titles';
-import {
-  getHeroPortrayals,
-  getHeroLinks,
-  type HeroPortrayals,
-  type HeroLinks,
-} from '../../src/lib/db/people';
+import { groupTitlesByMedia } from '../../src/lib/db/titles';
 import { PortrayedBySection } from '../../src/components/PortrayedBySection';
 import { HeroLinksRow, heroLinksHasContent } from '../../src/components/HeroLinksRow';
-import { useAuth } from '../../src/hooks/useAuth';
+import { useHeroDetail } from '../../src/hooks/useHeroDetail';
 import { ContributeSheet } from '../../src/components/contribute/ContributeSheet';
 import { isBlankValue } from '../../src/lib/contribute/missingFields';
 import {
@@ -72,8 +47,6 @@ import {
   STAT_FIELDS,
   type EditableFieldDef,
 } from '../../src/lib/db/contributions';
-import { getProfile } from '../../src/lib/db/profiles';
-import { useRecordView } from '../../src/hooks/useViewHistory';
 import { HeroImage } from '../../src/components/HeroImage';
 import { COLORS } from '../../src/constants/colors';
 import { CharacterSkeleton } from '../../src/components/skeletons/CharacterSkeleton';
@@ -82,7 +55,6 @@ import { SkeletonProvider } from '../../src/components/ui/SkeletonProvider';
 import { AbilitiesSection } from '../../src/components/AbilitiesSection';
 import { TraitBand } from '../../src/components/character/TraitBand';
 import { DidYouKnowDeck } from '../../src/components/character/DidYouKnowDeck';
-import { getHeroNarrative, type HeroNarrative } from '../../src/lib/db/heroFacts';
 import { MovieStrip } from '../../src/components/MovieStrip';
 import { FirstIssueModal } from '../../src/components/FirstIssueModal';
 import { GalleryStrip } from '../../src/components/GalleryStrip';
@@ -90,7 +62,7 @@ import { ImageLightbox } from '../../src/components/ImageLightbox';
 import { RelatedHeroStrip } from '../../src/components/RelatedHeroStrip';
 import { PublisherLogoChip } from '../../src/components/PublisherBadge';
 import { brandForPublisher } from '../../src/constants/publishers';
-import type { CharacterData, IssueCover } from '../../src/types';
+import type { CharacterData } from '../../src/types';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 const HERO_IMAGE_HEIGHT = Math.round(SCREEN_HEIGHT * 0.66);
@@ -605,55 +577,52 @@ export default function CharacterScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const compareStripStyle = [styles.compareStrip, { paddingBottom: insets.bottom || 16 }];
-  const { user } = useAuth();
-  useRecordView(user?.id, id);
-  const [data, setData] = useState<CharacterData | null>(null);
+  const {
+    user,
+    isAdmin,
+    data,
+    setData,
+    narrative,
+    family,
+    comicVineLoading,
+    notFound,
+    loadError,
+    favourited,
+    favLoading,
+    favCount,
+    titles,
+    portrayals,
+    links,
+    issueCovers,
+    galleryLoading,
+    heroRow,
+    heroRowQuery,
+    powerTotal,
+    percentile,
+    hasFirstVisual,
+    relatedHeroMap,
+    enemyNames,
+    allyNames,
+    teammateNames,
+    heroImageUrl,
+    heroPortraitUrl,
+    displayName,
+    retryLoad,
+    toggleFavourite,
+  } = useHeroDetail({ id, paramName, paramImageUri });
+
+  // View-only UI state (edit sheet, first-issue modal, image lightbox).
   const [editing, setEditing] = useState(false);
   const [editTarget, setEditTarget] = useState<{
     field: EditableFieldDef | null;
     current: string | null;
   } | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
   const [editingStats, setEditingStats] = useState(false);
-  const [narrative, setNarrative] = useState<HeroNarrative | null>(null);
-  const [family, setFamily] = useState<FamilyMember[]>([]);
-  const [comicVineLoading, setComicVineLoading] = useState(true);
   const [showIssueModal, setShowIssueModal] = useState(false);
-  // Two distinct failure modes: the hero genuinely doesn't exist (404 → poster),
-  // versus a transient load failure (network/server → retryable). `retryToken`
-  // re-runs the load effect when the user taps Retry.
-  const [notFound, setNotFound] = useState(false);
-  const [loadError, setLoadError] = useState(false);
-  const [retryToken, setRetryToken] = useState(0);
-  const [favourited, setFavourited] = useState(false);
-  const [favLoading, setFavLoading] = useState(false);
-  const [favCount, setFavCount] = useState<number>(0);
-  const [titles, setTitles] = useState<HeroTitle[] | null>(null);
-  const [portrayals, setPortrayals] = useState<HeroPortrayals | null>(null);
-  const [links, setLinks] = useState<HeroLinks | null>(null);
-  const [issueCovers, setIssueCovers] = useState<IssueCover[] | null>(null);
-  const [galleryLoading, setGalleryLoading] = useState(false);
   const [lightboxImages, setLightboxImages] = useState<{ url: string; caption?: string | null }[]>(
     [],
   );
   const [lightboxIndex, setLightboxIndex] = useState(0);
-
-  const heroRowQuery = useHeroRow(id);
-  const heroRow = heroRowQuery.data;
-
-  useEffect(() => {
-    if (!user) {
-      setIsAdmin(false);
-      return;
-    }
-    let active = true;
-    getProfile(user.id)
-      .then((p) => active && setIsAdmin(!!p?.is_admin))
-      .catch(() => {});
-    return () => {
-      active = false;
-    };
-  }, [user]);
 
   const scrollY = useRef(new Animated.Value(0)).current;
   const compareScale = useRef(new Animated.Value(1)).current;
@@ -760,44 +729,6 @@ export default function CharacterScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Total powerstats — drives both the vitals strip and the percentile hook.
-  const powerTotal = useMemo(() => {
-    if (!data) return 0;
-    return STAT_CONFIG.map(({ key }) =>
-      parseInt((data.stats.powerstats as Record<string, string>)[key] ?? '0', 10),
-    )
-      .filter((n) => !isNaN(n) && n > 0)
-      .reduce((sum, n) => sum + n, 0);
-  }, [data]);
-
-  const { data: percentile } = useHeroPercentile(powerTotal || null);
-
-  // A hero with a cover image gets the visual "First Appearance" section; without
-  // one, the same fact shows as a text row inside the Dossier (no duplication).
-  const hasFirstVisual = !!data?.firstIssue?.imageUrl;
-
-  // Enemies / allies / teammates from the relationship graph (same-universe,
-  // popularity-ranked), matching the web character page. The map drives the
-  // enemy/ally strips; teammates render straight from the graph (there's no
-  // ComicVine "teammates" name list).
-  const { data: related } = useRelatedHeroes(id);
-  const relatedHeroMap = useMemo(() => {
-    const m = new Map<string, RelatedHeroCard>();
-    for (const h of [
-      ...(related?.enemies ?? []),
-      ...(related?.allies ?? []),
-      ...(related?.teammates ?? []),
-    ]) {
-      m.set(h.name, h);
-    }
-    return m;
-  }, [related]);
-  // Names in the graph's popularity-ranked order so the strips lead with the
-  // recognisable foes/allies/teammates (every one resolves to a card).
-  const enemyNames = useMemo(() => (related?.enemies ?? []).map((h) => h.name), [related]);
-  const allyNames = useMemo(() => (related?.allies ?? []).map((h) => h.name), [related]);
-  const teammateNames = useMemo(() => (related?.teammates ?? []).map((h) => h.name), [related]);
-
   // The sections that actually render, in scroll order — drives the quick-nav
   // chips and active-section tracking. Mirrors the render conditions below.
   const presentSections = useMemo<{ key: string; label: string }[]>(() => {
@@ -840,253 +771,6 @@ export default function CharacterScreen() {
   ]);
   sectionOrder.current = presentSections.map((s) => s.key);
 
-  useEffect(() => {
-    setFamily([]);
-    if (!id) return;
-    getHeroFamily(id)
-      .then(setFamily)
-      .catch(() => setFamily([]));
-  }, [id]);
-
-  useEffect(() => {
-    setNarrative(null);
-    if (!id) return;
-    let active = true;
-    getHeroNarrative(id)
-      .then((n) => {
-        if (active) setNarrative(n);
-      })
-      .catch(() => {
-        if (active) setNarrative(null);
-      });
-    return () => {
-      active = false;
-    };
-  }, [id]);
-
-  useEffect(() => {
-    if (!data?.stats.id) return;
-    let active = true;
-    getHeroTitles(data.stats.id).then((f) => {
-      if (active) setTitles(f);
-    });
-    getHeroPortrayals(data.stats.id).then((pp) => {
-      if (active) setPortrayals(pp);
-    });
-    getHeroLinks(data.stats.id).then((l) => {
-      if (active) setLinks(l);
-    });
-    return () => {
-      active = false;
-    };
-  }, [data?.stats.id]);
-
-  useEffect(() => {
-    if (!id) return;
-
-    const loadFromApi = () => {
-      fetchHeroStats(id)
-        .then((stats) => {
-          setData({
-            stats,
-            details: {
-              summary: null,
-              publisher: null,
-              firstIssueId: null,
-              firstIssueData: null,
-              powers: null,
-              description: null,
-              origin: null,
-              issueCount: null,
-              creators: null,
-              enemies: null,
-              friends: null,
-              movies: null,
-              movieCount: null,
-              teams: null,
-            },
-            firstIssue: null,
-          });
-          fetchHeroDetails(stats.id, stats.name)
-            .then((details) => {
-              setData({ stats, details, firstIssue: details.firstIssueData });
-            })
-            .catch(() => {})
-            .finally(() => setComicVineLoading(false));
-        })
-        .catch((e: unknown) => {
-          if (e instanceof HeroNotFoundError) setNotFound(true);
-          else setLoadError(true);
-        });
-    };
-
-    const plan = planHeroLoad({
-      isPlaceholderData: heroRowQuery.isPlaceholderData,
-      isError: heroRowQuery.isError,
-      isSuccess: heroRowQuery.isSuccess,
-      row: heroRow,
-    });
-
-    // Still resolving (instant placeholder, or no row yet) — keep the skeleton.
-    if (plan === 'wait') return;
-
-    // No usable DB row → fetch base stats from the external SuperheroAPI by id.
-    // Reached only for genuine SuperheroAPI heroes (numeric ids not in our DB, or
-    // un-enriched numeric stubs); never for `cv-` ComicVine heroes, whose id
-    // can't resolve against SuperheroAPI.
-    if (plan === 'external-api') {
-      loadFromApi();
-      return;
-    }
-
-    // plan === 'render-row': a real DB row exists. Paint from it immediately, then
-    // layer ComicVine enrichment on top. This serves both base-enriched heroes and
-    // ComicVine-only `cv-` heroes (e.g. the franchise characters), which never get
-    // an `enriched_at` timestamp and previously fell through to a 404'ing
-    // SuperheroAPI fetch that wiped the screen.
-    if (heroRow) {
-      setData(heroRowToCharacterData(heroRow));
-
-      // Seed issue covers from DB if already populated
-      if (heroRow.issue_covers) {
-        setIssueCovers(heroRow.issue_covers as unknown as IssueCover[]);
-      }
-
-      // Lazy-fetch covers only if never enriched (sentinel null). Heroes with no
-      // covers keep a null column but a set timestamp, so they don't re-trigger
-      // the fetch on every visit.
-      const needsGallery = heroRow.comicvine_id != null && heroRow.gallery_enriched_at === null;
-      if (needsGallery) {
-        setGalleryLoading(true);
-        fetchHeroGallery(heroRow.id, heroRow.comicvine_id!)
-          .then(({ issueCovers: covers }) => {
-            if (covers) setIssueCovers(covers);
-          })
-          .catch(() => {})
-          .finally(() => setGalleryLoading(false));
-      }
-
-      // Refetch ComicVine only when this hero has never been successfully
-      // enriched. Gate on the terminal `comicvine_status` (written by the
-      // get-comicvine-hero edge fn) — NOT on individual fields being null.
-      // ComicVine legitimately returns no powers/movies for civilians, and the
-      // old field-nullness gate treated that as "unfetched", so ~97% of heroes
-      // re-fetched ~13 ComicVine calls on every single view, forever.
-      const cvStatus = heroRow.comicvine_status;
-      const needsComicVine = cvStatus == null || cvStatus === 'pending';
-      const moviesIncomplete =
-        !needsComicVine &&
-        heroRow.movie_count != null &&
-        heroRow.movies != null &&
-        heroRow.movie_count > (heroRow.movies as unknown[]).length;
-      const moviesLackDetail =
-        !needsComicVine &&
-        !moviesIncomplete &&
-        heroRow.movies != null &&
-        (heroRow.movies as unknown[]).length > 0 &&
-        (
-          heroRow.movies as {
-            deck?: string | null;
-            rating?: string | null;
-            runtime?: string | null;
-          }[]
-        )
-          .slice(0, 5)
-          .every((m) => m.deck === null && m.rating === null && m.runtime === null);
-      setComicVineLoading(needsComicVine);
-
-      if (needsComicVine || moviesIncomplete || moviesLackDetail) {
-        fetchHeroDetails(heroRow.id, heroRow.name)
-          .then((details) => {
-            setData((prev) => {
-              if (!prev) return prev;
-              const p = prev.details;
-              // Additive merge: the live ComicVine fetch FILLS gaps, it must never
-              // ERASE a good DB value. Every field ComicVine returns as null falls
-              // back to what the row already had — so a partial response (or an
-              // all-null NULL_RESPONSE when ComicVine is throttled/unmatched) keeps
-              // the DB data on screen instead of flashing it then blanking it.
-              // Listing fields explicitly makes tsc flag any HeroDetails addition.
-              return {
-                ...prev,
-                details: {
-                  summary: details.summary ?? p.summary,
-                  publisher: details.publisher ?? p.publisher,
-                  firstIssueId: details.firstIssueId ?? p.firstIssueId,
-                  firstIssueData: details.firstIssueData ?? p.firstIssueData,
-                  powers: details.powers ?? p.powers,
-                  description: details.description ?? p.description,
-                  origin: details.origin ?? p.origin,
-                  issueCount: details.issueCount ?? p.issueCount,
-                  creators: details.creators ?? p.creators,
-                  enemies: details.enemies ?? p.enemies,
-                  friends: details.friends ?? p.friends,
-                  movies: details.movies ?? p.movies,
-                  movieCount: details.movieCount ?? p.movieCount,
-                  teams: details.teams ?? p.teams,
-                },
-                firstIssue: details.firstIssueData ?? prev.firstIssue,
-              };
-            });
-          })
-          .catch(() => {})
-          .finally(() => {
-            if (needsComicVine) setComicVineLoading(false);
-          });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    id,
-    heroRow?.id,
-    heroRow?.enriched_at,
-    heroRowQuery.isPlaceholderData,
-    heroRowQuery.isError,
-    heroRowQuery.isSuccess,
-    retryToken,
-  ]);
-
-  const retryLoad = useCallback(() => {
-    setLoadError(false);
-    setRetryToken((t) => t + 1);
-    heroRowQuery.refetch();
-  }, [heroRowQuery]);
-
-  useEffect(() => {
-    if (!user || !id) return;
-    isFavourited(user.id, id)
-      .then(setFavourited)
-      .catch(() => {});
-  }, [user, id]);
-
-  useEffect(() => {
-    if (!id) return;
-    getHeroFavouriteCount(id)
-      .then(setFavCount)
-      .catch(() => {});
-  }, [id]);
-
-  const toggleFavourite = useCallback(async () => {
-    if (!user || !id || favLoading) return;
-    setFavLoading(true);
-    const next = !favourited;
-    setFavourited(next);
-    Haptics.impactAsync(
-      next ? Haptics.ImpactFeedbackStyle.Medium : Haptics.ImpactFeedbackStyle.Light,
-    );
-    try {
-      await (next ? addFavourite(user.id, id) : removeFavourite(user.id, id));
-      getHeroFavouriteCount(id)
-        .then(setFavCount)
-        .catch(() => {});
-    } catch {
-      setFavourited(!next);
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-    } finally {
-      setFavLoading(false);
-    }
-  }, [user, id, favourited, favLoading]);
-
   const handleShare = useCallback(async () => {
     const name = data?.stats.name ?? heroRow?.name ?? paramName;
     if (!name) return;
@@ -1097,14 +781,6 @@ export default function CharacterScreen() {
       // user dismissed the sheet or sharing is unavailable — nothing to do
     }
   }, [data, heroRow?.name, paramName]);
-
-  // Priority: Supabase portrait → param portrait (from card) → API image → CDN
-  const heroImageUrl = data?.stats.image.url ?? heroRow?.image_url ?? null;
-  const heroPortraitUrl =
-    data?.stats.image.portraitUrl ?? heroRow?.portrait_url ?? paramImageUri ?? null;
-
-  // Show name immediately from params while API loads
-  const displayName = data?.stats.name ?? heroRow?.name ?? paramName ?? '';
 
   // Header shared by both failure states: a back chevron over the beige canvas.
   const failureHeader = (

--- a/src/hooks/useHeroDetail.ts
+++ b/src/hooks/useHeroDetail.ts
@@ -1,0 +1,425 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import {
+  fetchHeroStats,
+  fetchHeroDetails,
+  fetchHeroGallery,
+  HeroNotFoundError,
+} from '../lib/api';
+import {
+  heroRowToCharacterData,
+  getHeroFamily,
+  type RelatedHeroCard,
+} from '../lib/db/heroes';
+import type { FamilyMember } from '../lib/family/types';
+import { useHeroRow, useHeroPercentile, useRelatedHeroes } from '../lib/query/heroQueries';
+import { planHeroLoad } from '../lib/query/heroLoadPlan';
+import {
+  isFavourited,
+  addFavourite,
+  removeFavourite,
+  getHeroFavouriteCount,
+} from '../lib/db/favourites';
+import { getHeroTitles, type HeroTitle } from '../lib/db/titles';
+import {
+  getHeroPortrayals,
+  getHeroLinks,
+  type HeroPortrayals,
+  type HeroLinks,
+} from '../lib/db/people';
+import { getProfile } from '../lib/db/profiles';
+import { getHeroNarrative, type HeroNarrative } from '../lib/db/heroFacts';
+import { useAuth } from './useAuth';
+import { useRecordView } from './useViewHistory';
+import type { CharacterData, IssueCover } from '../types';
+
+// Power-stat keys in dial order. The view keeps its own STAT_CONFIG (keys + tints
+// + labels) for rendering; the hook only needs the keys to total the stats.
+const STAT_KEYS = ['intelligence', 'strength', 'speed', 'durability', 'power', 'combat'];
+
+export interface UseHeroDetailParams {
+  id: string;
+  paramName?: string;
+  paramImageUri?: string;
+}
+
+/**
+ * Platform-neutral data layer for the character detail screen. Owns every fetch,
+ * piece of loaded state, and derived value the `app/character/[id].{tsx,web.tsx}`
+ * views render — so the views stay thin and the two platforms can't drift.
+ *
+ * The views keep their own UI-only state (edit sheet, lightbox, animations,
+ * scroll/quick-nav) and consume this hook's output by identical name.
+ */
+export function useHeroDetail({ id, paramName, paramImageUri }: UseHeroDetailParams) {
+  const { user } = useAuth();
+  useRecordView(user?.id, id);
+
+  const [data, setData] = useState<CharacterData | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [narrative, setNarrative] = useState<HeroNarrative | null>(null);
+  const [family, setFamily] = useState<FamilyMember[]>([]);
+  const [comicVineLoading, setComicVineLoading] = useState(true);
+  // Two distinct failure modes: the hero genuinely doesn't exist (404 → poster),
+  // versus a transient load failure (network/server → retryable). `retryToken`
+  // re-runs the load effect when the user taps Retry.
+  const [notFound, setNotFound] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+  const [retryToken, setRetryToken] = useState(0);
+  const [favourited, setFavourited] = useState(false);
+  const [favLoading, setFavLoading] = useState(false);
+  const [favCount, setFavCount] = useState<number>(0);
+  const [titles, setTitles] = useState<HeroTitle[] | null>(null);
+  const [portrayals, setPortrayals] = useState<HeroPortrayals | null>(null);
+  const [links, setLinks] = useState<HeroLinks | null>(null);
+  const [issueCovers, setIssueCovers] = useState<IssueCover[] | null>(null);
+  const [galleryLoading, setGalleryLoading] = useState(false);
+
+  const heroRowQuery = useHeroRow(id);
+  const heroRow = heroRowQuery.data;
+
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false);
+      return;
+    }
+    let active = true;
+    getProfile(user.id)
+      .then((p) => active && setIsAdmin(!!p?.is_admin))
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  // Total powerstats — drives both the vitals strip and the percentile hook.
+  const powerTotal = useMemo(() => {
+    if (!data) return 0;
+    return STAT_KEYS.map((key) =>
+      parseInt((data.stats.powerstats as Record<string, string>)[key] ?? '0', 10),
+    )
+      .filter((n) => !isNaN(n) && n > 0)
+      .reduce((sum, n) => sum + n, 0);
+  }, [data]);
+
+  const { data: percentile } = useHeroPercentile(powerTotal || null);
+
+  // A hero with a cover image gets the visual "First Appearance" section; without
+  // one, the same fact shows as a text row inside the Dossier (no duplication).
+  const hasFirstVisual = !!data?.firstIssue?.imageUrl;
+
+  // Enemies / allies / teammates from the relationship graph (same-universe,
+  // popularity-ranked). The map drives the enemy/ally strips; teammates render
+  // straight from the graph (there's no ComicVine "teammates" name list).
+  const { data: related } = useRelatedHeroes(id);
+  const relatedHeroMap = useMemo(() => {
+    const m = new Map<string, RelatedHeroCard>();
+    for (const h of [
+      ...(related?.enemies ?? []),
+      ...(related?.allies ?? []),
+      ...(related?.teammates ?? []),
+    ]) {
+      m.set(h.name, h);
+    }
+    return m;
+  }, [related]);
+  // Names in the graph's popularity-ranked order so the strips lead with the
+  // recognisable foes/allies/teammates (every one resolves to a card).
+  const enemyNames = useMemo(() => (related?.enemies ?? []).map((h) => h.name), [related]);
+  const allyNames = useMemo(() => (related?.allies ?? []).map((h) => h.name), [related]);
+  const teammateNames = useMemo(() => (related?.teammates ?? []).map((h) => h.name), [related]);
+
+  useEffect(() => {
+    setFamily([]);
+    if (!id) return;
+    getHeroFamily(id)
+      .then(setFamily)
+      .catch(() => setFamily([]));
+  }, [id]);
+
+  useEffect(() => {
+    setNarrative(null);
+    if (!id) return;
+    let active = true;
+    getHeroNarrative(id)
+      .then((n) => {
+        if (active) setNarrative(n);
+      })
+      .catch(() => {
+        if (active) setNarrative(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    if (!data?.stats.id) return;
+    let active = true;
+    getHeroTitles(data.stats.id).then((f) => {
+      if (active) setTitles(f);
+    });
+    getHeroPortrayals(data.stats.id).then((pp) => {
+      if (active) setPortrayals(pp);
+    });
+    getHeroLinks(data.stats.id).then((l) => {
+      if (active) setLinks(l);
+    });
+    return () => {
+      active = false;
+    };
+  }, [data?.stats.id]);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const loadFromApi = () => {
+      fetchHeroStats(id)
+        .then((stats) => {
+          setData({
+            stats,
+            details: {
+              summary: null,
+              publisher: null,
+              firstIssueId: null,
+              firstIssueData: null,
+              powers: null,
+              description: null,
+              origin: null,
+              issueCount: null,
+              creators: null,
+              enemies: null,
+              friends: null,
+              movies: null,
+              movieCount: null,
+              teams: null,
+            },
+            firstIssue: null,
+          });
+          fetchHeroDetails(stats.id, stats.name)
+            .then((details) => {
+              setData({ stats, details, firstIssue: details.firstIssueData });
+            })
+            .catch(() => {})
+            .finally(() => setComicVineLoading(false));
+        })
+        .catch((e: unknown) => {
+          if (e instanceof HeroNotFoundError) setNotFound(true);
+          else setLoadError(true);
+        });
+    };
+
+    const plan = planHeroLoad({
+      isPlaceholderData: heroRowQuery.isPlaceholderData,
+      isError: heroRowQuery.isError,
+      isSuccess: heroRowQuery.isSuccess,
+      row: heroRow,
+    });
+
+    // Still resolving (instant placeholder, or no row yet) — keep the skeleton.
+    if (plan === 'wait') return;
+
+    // No usable DB row → fetch base stats from the external SuperheroAPI by id.
+    // Reached only for genuine SuperheroAPI heroes (numeric ids not in our DB, or
+    // un-enriched numeric stubs); never for `cv-` ComicVine heroes, whose id
+    // can't resolve against SuperheroAPI.
+    if (plan === 'external-api') {
+      loadFromApi();
+      return;
+    }
+
+    // plan === 'render-row': a real DB row exists. Paint from it immediately, then
+    // layer ComicVine enrichment on top. This serves both base-enriched heroes and
+    // ComicVine-only `cv-` heroes (e.g. the franchise characters), which never get
+    // an `enriched_at` timestamp and previously fell through to a 404'ing
+    // SuperheroAPI fetch that wiped the screen.
+    if (heroRow) {
+      setData(heroRowToCharacterData(heroRow));
+
+      // Seed issue covers from DB if already populated
+      if (heroRow.issue_covers) {
+        setIssueCovers(heroRow.issue_covers as unknown as IssueCover[]);
+      }
+
+      // Lazy-fetch covers only if never enriched (sentinel null). Heroes with no
+      // covers keep a null column but a set timestamp, so they don't re-trigger
+      // the fetch on every visit.
+      const needsGallery = heroRow.comicvine_id != null && heroRow.gallery_enriched_at === null;
+      if (needsGallery) {
+        setGalleryLoading(true);
+        fetchHeroGallery(heroRow.id, heroRow.comicvine_id!)
+          .then(({ issueCovers: covers }) => {
+            if (covers) setIssueCovers(covers);
+          })
+          .catch(() => {})
+          .finally(() => setGalleryLoading(false));
+      }
+
+      // Refetch ComicVine only when this hero has never been successfully
+      // enriched. Gate on the terminal `comicvine_status` (written by the
+      // get-comicvine-hero edge fn) — NOT on individual fields being null.
+      // ComicVine legitimately returns no powers/movies for civilians, and the
+      // old field-nullness gate treated that as "unfetched", so ~97% of heroes
+      // re-fetched ~13 ComicVine calls on every single view, forever.
+      const cvStatus = heroRow.comicvine_status;
+      const needsComicVine = cvStatus == null || cvStatus === 'pending';
+      const moviesIncomplete =
+        !needsComicVine &&
+        heroRow.movie_count != null &&
+        heroRow.movies != null &&
+        heroRow.movie_count > (heroRow.movies as unknown[]).length;
+      const moviesLackDetail =
+        !needsComicVine &&
+        !moviesIncomplete &&
+        heroRow.movies != null &&
+        (heroRow.movies as unknown[]).length > 0 &&
+        (
+          heroRow.movies as {
+            deck?: string | null;
+            rating?: string | null;
+            runtime?: string | null;
+          }[]
+        )
+          .slice(0, 5)
+          .every((m) => m.deck === null && m.rating === null && m.runtime === null);
+      setComicVineLoading(needsComicVine);
+
+      if (needsComicVine || moviesIncomplete || moviesLackDetail) {
+        fetchHeroDetails(heroRow.id, heroRow.name)
+          .then((details) => {
+            setData((prev) => {
+              if (!prev) return prev;
+              const p = prev.details;
+              // Additive merge: the live ComicVine fetch FILLS gaps, it must never
+              // ERASE a good DB value. Every field ComicVine returns as null falls
+              // back to what the row already had — so a partial response (or an
+              // all-null NULL_RESPONSE when ComicVine is throttled/unmatched) keeps
+              // the DB data on screen instead of flashing it then blanking it.
+              // Listing fields explicitly makes tsc flag any HeroDetails addition.
+              return {
+                ...prev,
+                details: {
+                  summary: details.summary ?? p.summary,
+                  publisher: details.publisher ?? p.publisher,
+                  firstIssueId: details.firstIssueId ?? p.firstIssueId,
+                  firstIssueData: details.firstIssueData ?? p.firstIssueData,
+                  powers: details.powers ?? p.powers,
+                  description: details.description ?? p.description,
+                  origin: details.origin ?? p.origin,
+                  issueCount: details.issueCount ?? p.issueCount,
+                  creators: details.creators ?? p.creators,
+                  enemies: details.enemies ?? p.enemies,
+                  friends: details.friends ?? p.friends,
+                  movies: details.movies ?? p.movies,
+                  movieCount: details.movieCount ?? p.movieCount,
+                  teams: details.teams ?? p.teams,
+                },
+                firstIssue: details.firstIssueData ?? prev.firstIssue,
+              };
+            });
+          })
+          .catch(() => {})
+          .finally(() => {
+            if (needsComicVine) setComicVineLoading(false);
+          });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    id,
+    heroRow?.id,
+    heroRow?.enriched_at,
+    heroRowQuery.isPlaceholderData,
+    heroRowQuery.isError,
+    heroRowQuery.isSuccess,
+    retryToken,
+  ]);
+
+  const retryLoad = useCallback(() => {
+    setLoadError(false);
+    setRetryToken((t) => t + 1);
+    heroRowQuery.refetch();
+  }, [heroRowQuery]);
+
+  useEffect(() => {
+    if (!user || !id) return;
+    isFavourited(user.id, id)
+      .then(setFavourited)
+      .catch(() => {});
+  }, [user, id]);
+
+  useEffect(() => {
+    if (!id) return;
+    getHeroFavouriteCount(id)
+      .then(setFavCount)
+      .catch(() => {});
+  }, [id]);
+
+  const toggleFavourite = useCallback(async () => {
+    if (!user || !id || favLoading) return;
+    setFavLoading(true);
+    const next = !favourited;
+    setFavourited(next);
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(
+        next ? Haptics.ImpactFeedbackStyle.Medium : Haptics.ImpactFeedbackStyle.Light,
+      );
+    }
+    try {
+      await (next ? addFavourite(user.id, id) : removeFavourite(user.id, id));
+      getHeroFavouriteCount(id)
+        .then(setFavCount)
+        .catch(() => {});
+    } catch {
+      setFavourited(!next);
+      if (Platform.OS !== 'web') {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      }
+    } finally {
+      setFavLoading(false);
+    }
+  }, [user, id, favourited, favLoading]);
+
+  // Priority: Supabase portrait → param portrait (from card) → API image → CDN
+  const heroImageUrl = data?.stats.image.url ?? heroRow?.image_url ?? null;
+  const heroPortraitUrl =
+    data?.stats.image.portraitUrl ?? heroRow?.portrait_url ?? paramImageUri ?? null;
+
+  // Show name immediately from params while API loads
+  const displayName = data?.stats.name ?? heroRow?.name ?? paramName ?? '';
+
+  return {
+    user,
+    isAdmin,
+    data,
+    setData,
+    narrative,
+    family,
+    comicVineLoading,
+    notFound,
+    loadError,
+    favourited,
+    favLoading,
+    favCount,
+    titles,
+    portrayals,
+    links,
+    issueCovers,
+    galleryLoading,
+    heroRow,
+    heroRowQuery,
+    powerTotal,
+    percentile,
+    hasFirstVisual,
+    relatedHeroMap,
+    enemyNames,
+    allyNames,
+    teammateNames,
+    heroImageUrl,
+    heroPortraitUrl,
+    displayName,
+    retryLoad,
+    toggleFavourite,
+  };
+}


### PR DESCRIPTION
## PR 2 of the token-efficiency series

Extracts the **data layer** of the character detail screen into a new platform-neutral hook, `src/hooks/useHeroDetail.ts`, and wires the **native** view (`app/character/[id].tsx`) to it.

### Why
`character/[id].tsx` (2,469 lines) and `character/[id].web.tsx` (3,966 lines) each contained their **own copy** of the fetch/state logic (hero row, ComicVine enrichment, family, narrative, titles, portrayals, links, gallery, favourites, related heroes, percentile). Any change meant editing ~6,400 lines across two files that had drifted apart — the single biggest token sink in the repo.

### What this PR does
- **New `useHeroDetail({ id, paramName, paramImageUri })` hook** owns every fetch, loaded state value, and derived value (`powerTotal`, `percentile`, `relatedHeroMap`, `enemyNames`/`allyNames`/`teammateNames`, `heroImageUrl`, `displayName`, `toggleFavourite`, `retryLoad`, …) plus `setData` for the post-contribution refresh.
- **Native view** consumes the hook by **identical names**, so the ~1,400-line render body is untouched — the diff is purely the data layer moving out and the import list shrinking.
- View keeps its genuinely view-only state (edit sheet, first-issue modal, image lightbox, animations, scroll/quick-nav).
- Haptics calls in the hook are guarded with `Platform.OS !== 'web'` so the hook is safe to share with the web view next.

### Impact
- `app/character/[id].tsx`: **2,469 → 2,145 lines**.
- Data layer now lives once, in a documented 425-line hook.

### Next (PR 3)
Point `app/character/[id].web.tsx` at the same hook and delete its duplicated fetch/state logic — that's where the big web-side reduction lands.

### Verification
- `yarn typecheck` — clean.
- `yarn test:ci` — 363 tests pass (51 suites).
- `yarn lint` — 0 errors (remaining warnings are pre-existing repo patterns: ref-access-during-render in the animation code and `setState`-in-effect, which the moved effects warned about identically before).
- **No behavior change on native** — the hook reproduces the existing logic verbatim.

> Note: this PR branches off `main`; merge **after** #35. PR 4/5 (profile, explore) follow the same pattern and are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188VyZJxPqwnQ2ZJVTC2Cur

---
_Generated by [Claude Code](https://claude.ai/code/session_0188VyZJxPqwnQ2ZJVTC2Cur)_