### PR TITLE
refactor(explore): unify data layer into useExploreData hook

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -2,14 +2,7 @@
 // the daily battle and editorial "Beyond the Page" features (rivalries, most
 // feared, era timeline, first-appearance covers). Brought to parity with the web
 // explore so native shows the full catalogue's depth, not a thin slice.
-import {
-  useEffect,
-  useState,
-  useCallback,
-  useMemo,
-  type ReactNode,
-  type ComponentType,
-} from 'react';
+import { useState, useCallback, useMemo, type ReactNode, type ComponentType } from 'react';
 import {
   View,
   Text,
@@ -36,52 +29,28 @@ import { SpotlightCarousel } from '../../src/components/home/SpotlightCarousel';
 import { rowStyle } from '../../src/lib/home/rowStyle';
 import { HomeHeroRow, type RowHero } from '../../src/components/home/HomeHeroRow';
 import {
-  getSpotlightHeroes,
-  getIconicHeroes,
-  getTrendingSpotlightHeroes,
-  getBrowseCovers,
-  getVillains,
-  getAntiHeroes,
-  getXMen,
-  getNewlyAddedCV,
-  getFranchiseIcons,
-  getHeroesByPublisher,
-  getHeroesByMediaTag,
-  getHeroesByStatRanking,
-  getTopRivalries,
-  getMostFeared,
-  getEraTimeline,
-  getFirstAppearanceCovers,
-  getHeroCount,
   type Hero,
-  type BrowseCover,
-  type CategorySlug,
   type Rivalry,
   type FearedVillain,
   type EraBucket,
   type FirstAppearanceCover,
 } from '../../src/lib/db/heroes';
-import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
 import {
-  getTrendingTitles,
-  getActiveCampaigns,
-  getTrendingForUser,
   type TrendingTitle,
   type Campaign,
   type TrendingTitleCharacter,
 } from '../../src/lib/db/trending';
-import { getTodaysMatchup, type TodaysMatchup as Matchup } from '../../src/lib/matchup';
+import { type TodaysMatchup as Matchup } from '../../src/lib/matchup';
 import { RightNowBand } from '../../src/components/home/RightNowBand';
 import { TodaysMatchup } from '../../src/components/home/TodaysMatchup';
 import { GreatestRivalries } from '../../src/components/home/GreatestRivalries';
 import { HallOfInfamy } from '../../src/components/home/HallOfInfamy';
 import { EraTimeline } from '../../src/components/home/EraTimeline';
 import { CoverGallery } from '../../src/components/home/CoverGallery';
-import { CategoryPodGrid, BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
+import { CategoryPodGrid } from '../../src/components/home/CategoryPodGrid';
 import { PublisherGrid } from '../../src/components/home/PublisherGrid';
 import { PulseTicker } from '../../src/components/home/PulseTicker';
-import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
-import { useAuth } from '../../src/hooks/useAuth';
+import { useExploreData } from '../../src/hooks/useExploreData';
 import type { FavouriteHero } from '../../src/types';
 
 const SPOTLIGHT_POOL = 5;
@@ -133,44 +102,43 @@ const FeedList = Animated.FlatList as unknown as ComponentType<
 export default function HomeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { user } = useAuth();
 
-  // Above-fold data — skeleton shows until this arrives
-  const [spotlight, setSpotlight] = useState<Hero[]>([]);
-  const [initialLoaded, setInitialLoaded] = useState(false);
-
-  const [iconic, setIconic] = useState<Hero[]>([]);
-  const [browseCovers, setBrowseCovers] = useState<Record<string, BrowseCover>>({});
-  const [onScreen, setOnScreen] = useState<TrendingTitle[]>([]);
-  const [comingSoon, setComingSoon] = useState<TrendingTitle[]>([]);
-  const [streaming, setStreaming] = useState<TrendingTitle[]>([]);
-  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
-  const [trendingForUser, setTrendingForUser] = useState<TrendingTitleCharacter[]>([]);
-  const [matchup, setMatchup] = useState<Matchup | null>(null);
-  const [heroCount, setHeroCount] = useState(0);
-
-  // Curated catalogue rows (the dormant depth, now surfaced on native).
-  const [villains, setVillains] = useState<Hero[]>([]);
-  const [horror, setHorror] = useState<Hero[]>([]);
-  const [antiHeroes, setAntiHeroes] = useState<Hero[]>([]);
-  const [marvel, setMarvel] = useState<Hero[]>([]);
-  const [dc, setDc] = useState<Hero[]>([]);
-  const [strongest, setStrongest] = useState<Hero[]>([]);
-  const [mostIntelligent, setMostIntelligent] = useState<Hero[]>([]);
-  const [xmen, setXmen] = useState<Hero[]>([]);
-  const [anime, setAnime] = useState<Hero[]>([]);
-  const [videoGames, setVideoGames] = useState<Hero[]>([]);
-  const [franchise, setFranchise] = useState<Hero[]>([]);
-  const [newlyAdded, setNewlyAdded] = useState<Hero[]>([]);
-
-  // Editorial "Beyond the Page" features.
-  const [rivalries, setRivalries] = useState<Rivalry[]>([]);
-  const [mostFeared, setMostFeared] = useState<FearedVillain[]>([]);
-  const [eras, setEras] = useState<EraBucket[]>([]);
-  const [covers, setCovers] = useState<FirstAppearanceCover[]>([]);
-
-  const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
-  const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
+  // Shared, platform-neutral data layer (see useExploreData). Aliased to the
+  // names this view already renders with; spotlight is sliced to the native
+  // billboard size and heroCount coerced to a number for the pulse ticker.
+  const {
+    started: initialLoaded,
+    spotlight: spotlightAll,
+    iconic,
+    browseCovers,
+    onScreen,
+    comingSoon,
+    streaming,
+    campaigns,
+    trendingForUser,
+    matchup,
+    heroCount: heroCountRaw,
+    villains,
+    horror,
+    antiHeroes,
+    marvel,
+    dc,
+    strongest,
+    mostIntelligent,
+    xmen,
+    anime,
+    videoGames,
+    franchiseIcons: franchise,
+    newlyAdded,
+    rivalries,
+    mostFeared,
+    eras,
+    covers,
+    recentlyViewed,
+    favourites,
+  } = useExploreData();
+  const spotlight = spotlightAll.slice(0, SPOTLIGHT_POOL);
+  const heroCount = heroCountRaw ?? 0;
   const [navigating, setNavigating] = useState(false);
 
   const scrollY = useSharedValue(0);
@@ -183,120 +151,6 @@ export default function HomeScreen() {
     transform: [{ translateY: scrollY.value < 0 ? scrollY.value : 0 }],
   }));
   const spotlightPool = spotlight;
-
-  // Spotlight fires first — once it resolves the skeleton is replaced with real
-  // content. All other queries fire in parallel and their rows appear as they
-  // arrive. getSpotlightHeroes gates on portraits + enrichment and rotates a
-  // mostly-marquee, partly-discovery lineup, so the billboard always looks right.
-  useEffect(() => {
-    // Lead the billboard with up to 2 characters who are on screen right now,
-    // then fill with the curated spotlight pool (deduped).
-    Promise.all([getSpotlightHeroes(SPOTLIGHT_POOL), getTrendingSpotlightHeroes(2)])
-      .then(([base, trend]) => {
-        const seen = new Set<string>();
-        const merged: Hero[] = [];
-        for (const h of [...trend, ...base]) {
-          if (!seen.has(h.id)) {
-            seen.add(h.id);
-            merged.push(h);
-          }
-        }
-        setSpotlight(merged.slice(0, SPOTLIGHT_POOL));
-        setInitialLoaded(true);
-      })
-      .catch(() => setInitialLoaded(true));
-
-    getActiveCampaigns()
-      .then(setCampaigns)
-      .catch(() => {});
-    getTodaysMatchup()
-      .then(setMatchup)
-      .catch(() => {});
-    getHeroCount()
-      .then(setHeroCount)
-      .catch(() => {});
-
-    getIconicHeroes(20)
-      .then(setIconic)
-      .catch(() => {});
-    getBrowseCovers(BROWSE_PODS.map((p) => p.slug as CategorySlug))
-      .then(setBrowseCovers)
-      .catch(() => {});
-    getTrendingTitles('on_screen', 6)
-      .then(setOnScreen)
-      .catch(() => {});
-    getTrendingTitles('coming_soon', 6)
-      .then(setComingSoon)
-      .catch(() => {});
-    getTrendingTitles('streaming', 6)
-      .then(setStreaming)
-      .catch(() => {});
-
-    // Curated catalogue rows.
-    getVillains(25)
-      .then(setVillains)
-      .catch(() => {});
-    getHeroesByMediaTag('horror-icon', 20)
-      .then(setHorror)
-      .catch(() => {});
-    getAntiHeroes(20)
-      .then(setAntiHeroes)
-      .catch(() => {});
-    getHeroesByPublisher('marvel', 25)
-      .then(setMarvel)
-      .catch(() => {});
-    getHeroesByPublisher('dc', 25)
-      .then(setDc)
-      .catch(() => {});
-    getHeroesByStatRanking('strength', 20)
-      .then(setStrongest)
-      .catch(() => {});
-    getHeroesByStatRanking('intelligence', 20)
-      .then(setMostIntelligent)
-      .catch(() => {});
-    getXMen(25)
-      .then(setXmen)
-      .catch(() => {});
-    getHeroesByMediaTag('anime', 25)
-      .then(setAnime)
-      .catch(() => {});
-    getHeroesByMediaTag('video-game', 25)
-      .then(setVideoGames)
-      .catch(() => {});
-    getFranchiseIcons(25)
-      .then(setFranchise)
-      .catch(() => {});
-    getNewlyAddedCV(25)
-      .then(setNewlyAdded)
-      .catch(() => {});
-
-    // Editorial features.
-    getTopRivalries(12)
-      .then(setRivalries)
-      .catch(() => {});
-    getMostFeared(12)
-      .then(setMostFeared)
-      .catch(() => {});
-    getEraTimeline(7)
-      .then(setEras)
-      .catch(() => {});
-    getFirstAppearanceCovers(14)
-      .then(setCovers)
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    if (!user?.id) return;
-    getRecentlyViewed(user.id)
-      .then(setRecentlyViewed)
-      .catch(() => {});
-    getUserFavouriteHeroes(user.id)
-      .then(setFavourites)
-      .catch(() => {});
-    getTrendingForUser(user.id)
-      .then(setTrendingForUser)
-      .catch(() => {});
-  }, [user?.id]);
 
   const handlePress = useCallback(
     (item: { id: string; portrait_url?: string | null; image_url?: string | null }) => {

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -7,49 +7,10 @@ import { useRouter } from 'expo-router';
 import { COLORS } from '../../src/constants/colors';
 import { HeroImage } from '../../src/components/HeroImage';
 import { WebHomeSkeleton } from '../../src/components/web/HomeSkeleton';
-import {
-  getHeroCount,
-  getXMen,
-  getAntiHeroes,
-  getVillains,
-  getIconicHeroes,
-  getSpotlightHeroes,
-  getNewlyAddedCV,
-  getHeroesByPublisher,
-  getHeroesByStatRanking,
-  getFranchiseIcons,
-  getHeroesByMediaTag,
-  getTrendingSpotlightHeroes,
-  getBrowseCovers,
-  type Hero,
-  type BrowseCover,
-  type CategorySlug,
-  getTopHeroByStat,
-  getPublisherCounts,
-  getFirstAppearanceCovers,
-  getEraTimeline,
-  getTopRivalries,
-  getMostFeared,
-  type PublisherCounts,
-  type FirstAppearanceCover,
-  type EraBucket,
-  type Rivalry,
-  type FearedVillain,
-} from '../../src/lib/db/heroes';
-import { getUserFavouriteHeroes } from '../../src/lib/db/favourites';
-import {
-  getTrendingTitles,
-  getActiveCampaigns,
-  getTrendingForUser,
-  type TrendingTitle,
-  type Campaign,
-  type TrendingTitleCharacter,
-} from '../../src/lib/db/trending';
+import { type Hero } from '../../src/lib/db/heroes';
 import { RightNowBand } from '../../src/components/web/home/RightNowBand';
 import { CategoryPodGrid } from '../../src/components/web/home/CategoryPodGrid';
-import { BROWSE_PODS } from '../../src/components/home/CategoryPodGrid';
-import { getRecentlyViewed } from '../../src/lib/db/viewHistory';
-import { useAuth } from '../../src/hooks/useAuth';
+import { useExploreData } from '../../src/hooks/useExploreData';
 import type { FavouriteHero } from '../../src/types';
 import { RankingCard } from '../../src/components/web/home/RankingCard';
 import { HomeFooter } from '../../src/components/web/home/HomeFooter';
@@ -59,7 +20,6 @@ import {
   TodaysMatchup as TodaysMatchupCard,
   TodaysMatchupSkeleton,
 } from '../../src/components/web/home/TodaysMatchup';
-import { getTodaysMatchup, type TodaysMatchup } from '../../src/lib/matchup';
 import { TOPBAR_HEIGHT } from '../../src/components/web/TopBar';
 import { useWebCanvas } from '../../src/hooks/useWebCanvas';
 import { useChromeColor } from '../../src/contexts/WebChromeContext';
@@ -1171,172 +1131,12 @@ export default function WebHomeScreen() {
   // 1. MATCH THE ACCORDION_SCALES EXACTLY
   const optimalPoolSize = width >= 1280 ? 8 : width >= 900 ? 6 : 3;
 
-  const { user } = useAuth();
-
-  // Home data — partial so rows render as each query resolves
-  interface HomeData {
-    spotlight: Hero[];
-    iconic: Hero[];
-    xmen: Hero[];
-    villains: Hero[];
-    antiHeroes: Hero[];
-    marvel: Hero[];
-    dc: Hero[];
-    strongest: Hero[];
-    mostIntelligent: Hero[];
-    newlyAdded: Hero[];
-    franchiseIcons: Hero[];
-    anime: Hero[];
-    videoGames: Hero[];
-    horror: Hero[];
-    onScreen: TrendingTitle[];
-    comingSoon: TrendingTitle[];
-    streaming: TrendingTitle[];
-    campaigns: Campaign[];
-    trendingForUser: TrendingTitleCharacter[];
-    browseCovers: Record<string, BrowseCover>;
-    strongestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
-    smartestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
-    fastestHero: Pick<Hero, 'id' | 'name' | 'strength' | 'intelligence' | 'speed'> | null;
-    publisherCounts: PublisherCounts | null;
-    covers: FirstAppearanceCover[];
-    eras: EraBucket[];
-    matchup: TodaysMatchup | null;
-    rivalries: Rivalry[];
-    mostFeared: FearedVillain[];
-  }
-  const [homeData, setHomeData] = useState<Partial<HomeData>>({});
-  const [homeStarted, setHomeStarted] = useState(false); // true once spotlight arrives
-  const [recentlyViewed, setRecentlyViewed] = useState<FavouriteHero[]>([]);
-  const [favourites, setFavourites] = useState<FavouriteHero[]>([]);
-  const [totalHeroCount, setTotalHeroCount] = useState<number | null>(null);
-
-  // Fire every query independently — rows appear as each resolves.
-  // Spotlight fires first since it's above the fold.
-  useEffect(() => {
-    getHeroCount()
-      .then(setTotalHeroCount)
-      .catch(() => {});
-
-    const set =
-      <K extends keyof HomeData>(key: K) =>
-      (val: HomeData[K]) =>
-        setHomeData((d) => ({ ...d, [key]: val }));
-
-    // Lead the billboard with characters on screen right now, then the pool.
-    Promise.all([getSpotlightHeroes(10), getTrendingSpotlightHeroes(2)])
-      .then(([base, trend]) => {
-        const seen = new Set<string>();
-        const merged: Hero[] = [];
-        for (const h of [...trend, ...base]) {
-          if (!seen.has(h.id)) {
-            seen.add(h.id);
-            merged.push(h);
-          }
-        }
-        set('spotlight')(merged);
-        setHomeStarted(true);
-      })
-      .catch(() => setHomeStarted(true));
-
-    getActiveCampaigns()
-      .then(set('campaigns'))
-      .catch(() => {});
-
-    getIconicHeroes(25)
-      .then(set('iconic'))
-      .catch(() => {});
-    getXMen(25)
-      .then(set('xmen'))
-      .catch(() => {});
-    getAntiHeroes(20)
-      .then(set('antiHeroes'))
-      .catch(() => {});
-    getVillains(25)
-      .then(set('villains'))
-      .catch(() => {});
-    getHeroesByPublisher('marvel', 25)
-      .then(set('marvel'))
-      .catch(() => {});
-    getHeroesByPublisher('dc', 25)
-      .then(set('dc'))
-      .catch(() => {});
-    getHeroesByStatRanking('strength', 20)
-      .then(set('strongest'))
-      .catch(() => {});
-    getHeroesByStatRanking('intelligence', 20)
-      .then(set('mostIntelligent'))
-      .catch(() => {});
-    getNewlyAddedCV(25)
-      .then(set('newlyAdded'))
-      .catch(() => {});
-    getFranchiseIcons(25)
-      .then(set('franchiseIcons'))
-      .catch(() => {});
-    getHeroesByMediaTag('anime', 25)
-      .then(set('anime'))
-      .catch(() => {});
-    getHeroesByMediaTag('video-game', 25)
-      .then(set('videoGames'))
-      .catch(() => {});
-    getHeroesByMediaTag('horror-icon', 25)
-      .then(set('horror'))
-      .catch(() => {});
-    getTrendingTitles('on_screen', 6)
-      .then(set('onScreen'))
-      .catch(() => {});
-    getTrendingTitles('coming_soon', 6)
-      .then(set('comingSoon'))
-      .catch(() => {});
-    getTrendingTitles('streaming', 6)
-      .then(set('streaming'))
-      .catch(() => {});
-    getBrowseCovers(BROWSE_PODS.map((p) => p.slug as CategorySlug))
-      .then(set('browseCovers'))
-      .catch(() => {});
-    getFirstAppearanceCovers(14)
-      .then(set('covers'))
-      .catch(() => {});
-    getEraTimeline(8)
-      .then(set('eras'))
-      .catch(() => {});
-    getTopRivalries(12)
-      .then(set('rivalries'))
-      .catch(() => {});
-    getMostFeared(12)
-      .then(set('mostFeared'))
-      .catch(() => {});
-    getTodaysMatchup()
-      .then(set('matchup'))
-      .catch(() => set('matchup')(null));
-    getTopHeroByStat('strength')
-      .then(set('strongestHero'))
-      .catch(() => {});
-    getTopHeroByStat('intelligence')
-      .then(set('smartestHero'))
-      .catch(() => {});
-    getTopHeroByStat('speed')
-      .then(set('fastestHero'))
-      .catch(() => {});
-    getPublisherCounts()
-      .then(set('publisherCounts'))
-      .catch(() => {});
-  }, []);
-
-  // Personal rows
-  useEffect(() => {
-    if (!user?.id) return;
-    getRecentlyViewed(user.id)
-      .then(setRecentlyViewed)
-      .catch(() => {});
-    getUserFavouriteHeroes(user.id)
-      .then(setFavourites)
-      .catch(() => {});
-    getTrendingForUser(user.id)
-      .then((v) => setHomeData((d) => ({ ...d, trendingForUser: v })))
-      .catch(() => {});
-  }, [user?.id]);
-
+  // Shared, platform-neutral data layer (see useExploreData). Web keeps reading
+  // rows via `homeData.*`; these aliases preserve the existing render references.
+  const homeData = useExploreData();
+  const { recentlyViewed, favourites } = homeData;
+  const homeStarted = homeData.started;
+  const totalHeroCount = homeData.heroCount;
   const handlePress = useCallback(
     (id: string) => {
       router.push(`/character/${id}`);

--- a/src/hooks/useExploreData.ts
+++ b/src/hooks/useExploreData.ts
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getSpotlightHeroes,
+  getIconicHeroes,
+  getTrendingSpotlightHeroes,
+  getBrowseCovers,
+  getVillains,
+  getAntiHeroes,
+  getXMen,
+  getNewlyAddedCV,
+  getFranchiseIcons,
+  getHeroesByPublisher,
+  getHeroesByMediaTag,
+  getHeroesByStatRanking,
+  getTopRivalries,
+  getMostFeared,
+  getEraTimeline,
+  getFirstAppearanceCovers,
+  getHeroCount,
+  type Hero,
+  type BrowseCover,
+  type CategorySlug,
+  type Rivalry,
+  type FearedVillain,
+  type EraBucket,
+  type FirstAppearanceCover,
+} from '../lib/db/heroes';
+import { getUserFavouriteHeroes } from '../lib/db/favourites';
+import {
+  getTrendingTitles,
+  getActiveCampaigns,
+  getTrendingForUser,
+  type TrendingTitle,
+  type Campaign,
+  type TrendingTitleCharacter,
+} from '../lib/db/trending';
+import { getTodaysMatchup, type TodaysMatchup } from '../lib/matchup';
+import { getRecentlyViewed } from '../lib/db/viewHistory';
+import { BROWSE_PODS } from '../components/home/CategoryPodGrid';
+import { useAuth } from './useAuth';
+import type { FavouriteHero } from '../types';
+
+// Fetch a generous spotlight pool; each view slices to its own size (native 5,
+// web sizes responsively). Keeping the larger pool here preserves web's
+// rotation/variety without re-fetching.
+const SPOTLIGHT_POOL = 10;
+
+export interface ExploreData {
+  /** True once the spotlight billboard has resolved — both views gate their
+   *  skeleton on this. */
+  started: boolean;
+  // Billboard + curated catalogue rows.
+  spotlight: Hero[];
+  iconic: Hero[];
+  villains: Hero[];
+  horror: Hero[];
+  antiHeroes: Hero[];
+  marvel: Hero[];
+  dc: Hero[];
+  strongest: Hero[];
+  mostIntelligent: Hero[];
+  xmen: Hero[];
+  anime: Hero[];
+  videoGames: Hero[];
+  franchiseIcons: Hero[];
+  newlyAdded: Hero[];
+  // Editorial features.
+  rivalries: Rivalry[];
+  mostFeared: FearedVillain[];
+  eras: EraBucket[];
+  covers: FirstAppearanceCover[];
+  browseCovers: Record<string, BrowseCover>;
+  // Right-now / trending.
+  onScreen: TrendingTitle[];
+  comingSoon: TrendingTitle[];
+  streaming: TrendingTitle[];
+  campaigns: Campaign[];
+  /** `undefined` while loading, `null` when there's no matchup today. */
+  matchup: TodaysMatchup | null | undefined;
+  /** `null` while loading; a count once resolved. */
+  heroCount: number | null;
+  // Personalised (re-fetched when the signed-in user changes).
+  trendingForUser: TrendingTitleCharacter[];
+  recentlyViewed: FavouriteHero[];
+  favourites: FavouriteHero[];
+}
+
+const INITIAL: ExploreData = {
+  started: false,
+  spotlight: [],
+  iconic: [],
+  villains: [],
+  horror: [],
+  antiHeroes: [],
+  marvel: [],
+  dc: [],
+  strongest: [],
+  mostIntelligent: [],
+  xmen: [],
+  anime: [],
+  videoGames: [],
+  franchiseIcons: [],
+  newlyAdded: [],
+  rivalries: [],
+  mostFeared: [],
+  eras: [],
+  covers: [],
+  browseCovers: {},
+  onScreen: [],
+  comingSoon: [],
+  streaming: [],
+  campaigns: [],
+  matchup: undefined,
+  heroCount: null,
+  trendingForUser: [],
+  recentlyViewed: [],
+  favourites: [],
+};
+
+/**
+ * Platform-neutral data layer for the Explore/Home screen. Owns every catalogue,
+ * editorial, trending, and personalised fetch and returns one flat snapshot.
+ * Both `app/(tabs)/explore.tsx` (native, virtualised FlatList) and
+ * `explore.web.tsx` (web grid) consume it; each keeps its own presentation.
+ *
+ * Loaders use the more mature limits from the two prior implementations. The
+ * previously web-only stat-pod / publisher-count fetches were dropped — they were
+ * fetched but never rendered.
+ */
+export function useExploreData(): ExploreData {
+  const { user } = useAuth();
+  const [data, setData] = useState<ExploreData>(INITIAL);
+
+  const set = useCallback(
+    <K extends keyof ExploreData>(key: K) =>
+      (val: ExploreData[K]) =>
+        setData((d) => ({ ...d, [key]: val })),
+    [],
+  );
+
+  // Mount: billboard + catalogue + editorial + trending. Each query is
+  // independent and fills its row as it resolves; only the spotlight (which gates
+  // the skeleton) is awaited as a group.
+  useEffect(() => {
+    // Lead the billboard with up to 2 characters on screen right now, then fill
+    // with the curated spotlight pool (deduped). Views slice to their own size.
+    Promise.all([getSpotlightHeroes(SPOTLIGHT_POOL), getTrendingSpotlightHeroes(2)])
+      .then(([base, trend]) => {
+        const seen = new Set<string>();
+        const merged: Hero[] = [];
+        for (const h of [...trend, ...base]) {
+          if (!seen.has(h.id)) {
+            seen.add(h.id);
+            merged.push(h);
+          }
+        }
+        setData((d) => ({ ...d, spotlight: merged, started: true }));
+      })
+      .catch(() => setData((d) => ({ ...d, started: true })));
+
+    getActiveCampaigns()
+      .then(set('campaigns'))
+      .catch(() => {});
+    getTodaysMatchup()
+      .then(set('matchup'))
+      .catch(() => set('matchup')(null));
+    getHeroCount()
+      .then(set('heroCount'))
+      .catch(() => {});
+
+    getIconicHeroes(25)
+      .then(set('iconic'))
+      .catch(() => {});
+    getBrowseCovers(BROWSE_PODS.map((p) => p.slug as CategorySlug))
+      .then(set('browseCovers'))
+      .catch(() => {});
+    getTrendingTitles('on_screen', 6)
+      .then(set('onScreen'))
+      .catch(() => {});
+    getTrendingTitles('coming_soon', 6)
+      .then(set('comingSoon'))
+      .catch(() => {});
+    getTrendingTitles('streaming', 6)
+      .then(set('streaming'))
+      .catch(() => {});
+
+    // Curated catalogue rows.
+    getVillains(25)
+      .then(set('villains'))
+      .catch(() => {});
+    getHeroesByMediaTag('horror-icon', 25)
+      .then(set('horror'))
+      .catch(() => {});
+    getAntiHeroes(20)
+      .then(set('antiHeroes'))
+      .catch(() => {});
+    getHeroesByPublisher('marvel', 25)
+      .then(set('marvel'))
+      .catch(() => {});
+    getHeroesByPublisher('dc', 25)
+      .then(set('dc'))
+      .catch(() => {});
+    getHeroesByStatRanking('strength', 20)
+      .then(set('strongest'))
+      .catch(() => {});
+    getHeroesByStatRanking('intelligence', 20)
+      .then(set('mostIntelligent'))
+      .catch(() => {});
+    getXMen(25)
+      .then(set('xmen'))
+      .catch(() => {});
+    getHeroesByMediaTag('anime', 25)
+      .then(set('anime'))
+      .catch(() => {});
+    getHeroesByMediaTag('video-game', 25)
+      .then(set('videoGames'))
+      .catch(() => {});
+    getFranchiseIcons(25)
+      .then(set('franchiseIcons'))
+      .catch(() => {});
+    getNewlyAddedCV(25)
+      .then(set('newlyAdded'))
+      .catch(() => {});
+
+    // Editorial features.
+    getTopRivalries(12)
+      .then(set('rivalries'))
+      .catch(() => {});
+    getMostFeared(12)
+      .then(set('mostFeared'))
+      .catch(() => {});
+    getEraTimeline(8)
+      .then(set('eras'))
+      .catch(() => {});
+    getFirstAppearanceCovers(14)
+      .then(set('covers'))
+      .catch(() => {});
+  }, [set]);
+
+  // Personalised rows — refetch when the signed-in user changes.
+  useEffect(() => {
+    if (!user?.id) return;
+    getRecentlyViewed(user.id)
+      .then(set('recentlyViewed'))
+      .catch(() => {});
+    getUserFavouriteHeroes(user.id)
+      .then(set('favourites'))
+      .catch(() => {});
+    getTrendingForUser(user.id)
+      .then(set('trendingForUser'))
+      .catch(() => {});
+  }, [user?.id, set]);
+
+  return data;
+}


### PR DESCRIPTION
## Explore screen-pair unification (the deferred deep-dive)

Extracts the duplicated Home/Explore data layer into a new platform-neutral hook, `src/hooks/useExploreData.ts`. `explore.tsx` (native) and `explore.web.tsx` (web) each carried their own copy of ~28 fetches across a mount effect + a per-user effect — drifted in limits, field names, and one screen's dead code. Now there's one source of truth; **each view keeps its own presentation** (native's virtualised `FlatList` + `rows` memo; web's grid).

### Deep-dive findings → decisions ("more mature, each to its strengths")
A full data-layer comparison of both screens drove these reconciliations:

| Concern | Native was | Web was | Unified to |
|---|---|---|---|
| `iconic` / `horror` / `eras` limits | 20 / 20 / 7 | 25 / 25 / 8 | **25 / 25 / 8** (web) |
| spotlight | `getSpotlightHeroes(5)` + slice | `(10)`, responsive slice | **fetch 10 un-sliced in hook**; native slices to 5, web sizes responsively |
| `heroCount` | `number` (0) | `number \| null` | **`number \| null`** (null = loading); native coerces `?? 0` |
| `matchup` | `… \| null` | `… \| null` (Partial → undefined) | **tri-state `… \| null \| undefined`** so web keeps its loading skeleton; native's `if (matchup)` unchanged |
| gate flag | `initialLoaded` | `homeStarted` | **`started`** (views alias on destructure) |
| `franchise` / `franchiseIcons` | `franchise` | `franchiseIcons` | one key; views alias |

**Dead code removed:** web fetched `strongestHero`/`smartestHero`/`fastestHero`/`publisherCounts` (via `getTopHeroByStat`×3 + `getPublisherCounts`) but **never rendered them** — confirmed they're not accessed anywhere in the render tree. Dropped → **4 fewer queries per web load**.

Both views' render trees are essentially untouched: native destructures the hook with aliases (`started: initialLoaded`, `franchiseIcons: franchise`) and web keeps reading via `homeData.*` (the hook return is assigned to a local `homeData`).

### Impact
- `explore.tsx`: **678 → 532** · `explore.web.tsx`: **1,656 → 1,456**.
- The ~28-field data layer now lives once in a 255-line hook.

### ⚠️ Behavior changes to verify in-app (web + native)
This intentionally changes behavior (the deep-dive unification you asked for):
1. Native's `iconic`/`horror` rows show up to 25 (was 20) and `eras` up to 8 (was 7) — a few more items.
2. Web no longer issues the 4 dead stat/count queries.
3. `matchup`/`heroCount` are now tri-state/nullable (loading states preserved on web; native behavior unchanged via guards).

Automated coverage is green (`typecheck`, `lint` 0 errors, `format:check`, 363 tests), but there are **no screen-render tests** — please smoke-test Explore on **web and native** (spotlight billboard, the catalogue rows, matchup skeleton). The Vercel preview covers web.

### Verification
- `yarn typecheck` — clean.
- `yarn test:ci` — 363 pass.
- `yarn lint` + `format:check` — 0 errors, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188VyZJxPqwnQ2ZJVTC2Cur

---
_Generated by [Claude Code](https://claude.ai/code/session_0188VyZJxPqwnQ2ZJVTC2Cur)_