### PR TITLE
Silence the accepted expo-doctor app-config check so it passes green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,9 @@ jobs:
     name: Expo Doctor (informational)
     runs-on: ubuntu-latest
     # Non-blocking: surfaces dependency drift / config issues without gating.
-    # (The repo intentionally commits android/ alongside app.config.ts, which
-    # doctor flags — see the prebuild-properties warning.)
+    # The repo intentionally commits android/ alongside app.config.ts; that one
+    # accepted warning is disabled via expo.doctor.appConfigFieldsNotSyncedCheck
+    # in package.json, so doctor otherwise stays green and still catches drift.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -93,6 +93,13 @@
     "typescript": "~6.0.3"
   },
   "private": true,
+  "expo": {
+    "doctor": {
+      "appConfigFieldsNotSyncedCheck": {
+        "enabled": false
+      }
+    }
+  },
   "packageManager": "yarn@4.15.0",
   "resolutions": {
     "uuid": "^11.1.1",


### PR DESCRIPTION
## Summary

Fixes the **Expo Doctor (informational)** check that shows a red ✗ on every PR.

The repo intentionally commits `android/` alongside native props in `app.config.ts`. expo-doctor flags this ("app config fields that may not be synced in a non-CNG project" — `scheme`, `icon`, `plugins`, `ios`, `android`, …), so `npx expo-doctor` exits 1 every run. The job is already `continue-on-error: true` (non-blocking), but it still surfaces as a red check.

This disables **only that one accepted check** via `expo.doctor.appConfigFieldsNotSyncedCheck` in `package.json`, so doctor passes green while still running every other check to catch real dependency/config drift. Also updates the CI comment to explain it.

## Verification

```
$ npx expo-doctor
The appConfigFieldsNotSyncedCheck is disabled. …
Running 20 checks on your project...
20/20 checks passed. No issues detected!   (exit 0)
```

Config-only change (no app code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV4wLsWBCnVp4eRufo5LpD)_