### PR TITLE
chore(admin): web observability — apply migrations, regen types, drop temp casts

### DIFF
--- a/__tests__/components/admin/health/format.test.ts
+++ b/__tests__/components/admin/health/format.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../src/components/admin/health/format';
 
 describe('DOMAINS', () => {
-  it('lists the primary domains in rail order, then placeholders', () => {
+  it('lists every domain in rail order', () => {
     expect(DOMAINS.map((d) => d.key)).toEqual([
       'command',
       'catalog',
@@ -18,9 +18,9 @@ describe('DOMAINS', () => {
     ]);
   });
 
-  it('flags exactly the remaining future domain as a placeholder', () => {
+  it('has no remaining placeholder domains (all are live)', () => {
     const placeholders = DOMAINS.filter((d) => d.placeholder).map((d) => d.key);
-    expect(placeholders).toEqual(['traffic']);
+    expect(placeholders).toEqual([]);
   });
 
   it('every domain has a label and an Ionicons name', () => {
@@ -40,6 +40,7 @@ describe('DOMAINS', () => {
       'campaigns',
       'spend',
       'community',
+      'traffic',
     ]);
   });
 });

--- a/__tests__/components/admin/health/format.test.ts
+++ b/__tests__/components/admin/health/format.test.ts
@@ -13,14 +13,14 @@ describe('DOMAINS', () => {
       'pipelines',
       'campaigns',
       'spend',
-      'users',
+      'community',
       'traffic',
     ]);
   });
 
-  it('flags exactly the two future domains as placeholders', () => {
+  it('flags exactly the remaining future domain as a placeholder', () => {
     const placeholders = DOMAINS.filter((d) => d.placeholder).map((d) => d.key);
-    expect(placeholders).toEqual(['users', 'traffic']);
+    expect(placeholders).toEqual(['traffic']);
   });
 
   it('every domain has a label and an Ionicons name', () => {
@@ -39,6 +39,7 @@ describe('DOMAINS', () => {
       'pipelines',
       'campaigns',
       'spend',
+      'community',
     ]);
   });
 });

--- a/__tests__/lib/db/community.test.ts
+++ b/__tests__/lib/db/community.test.ts
@@ -8,6 +8,11 @@ import { fetchCommunityOverview } from '../../../src/lib/db/community';
 const fullOverview = {
   authorized: true,
   totals: { members: 2, favourites: 5, views: 30, compares: 82, votes: 12, contributions: 3 },
+  online: {
+    onlineNow: 1,
+    activeToday: 2,
+    recent: [{ userId: 'u1', displayName: 'Gino', lastSeenAt: '2026-06-23T00:00:00Z', live: true }],
+  },
   topViewed: [{ id: 'h1', name: 'Spawn', image_url: null, publisher: 'Image', count: 9 }],
   topFavourited: [],
   topBacked: [
@@ -29,6 +34,7 @@ describe('fetchCommunityOverview', () => {
     expect(mockRpc).toHaveBeenCalledWith('admin_community_overview');
     expect(r).not.toBeNull();
     expect(r!.totals.views).toBe(30);
+    expect(r!.online.onlineNow).toBe(1);
     expect(r!.topBacked[0].winRate).toBe(67);
     // The `authorized` flag must not leak into the returned object.
     expect((r as unknown as Record<string, unknown>).authorized).toBeUndefined();

--- a/__tests__/lib/db/community.test.ts
+++ b/__tests__/lib/db/community.test.ts
@@ -1,0 +1,46 @@
+const mockRpc = jest.fn();
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: { rpc: (...a: unknown[]) => mockRpc(...a) },
+}));
+
+import { fetchCommunityOverview } from '../../../src/lib/db/community';
+
+const fullOverview = {
+  authorized: true,
+  totals: { members: 2, favourites: 5, views: 30, compares: 82, votes: 12, contributions: 3 },
+  topViewed: [{ id: 'h1', name: 'Spawn', image_url: null, publisher: 'Image', count: 9 }],
+  topFavourited: [],
+  topBacked: [
+    { id: 'h1', name: 'Spawn', image_url: null, publisher: 'Image', count: 4, winRate: 67 },
+  ],
+  topContributors: [{ userId: 'u1', displayName: 'Gino', approved: 3, level: 'curator' }],
+  contributionsByStatus: { pending: 1, approved: 2, rejected: 0 },
+  recent: [
+    { kind: 'view', at: '2026-06-23T00:00:00Z', heroId: 'h1', heroName: 'Spawn', text: null },
+  ],
+};
+
+describe('fetchCommunityOverview', () => {
+  beforeEach(() => mockRpc.mockReset());
+
+  it('strips the authorized flag and returns the typed overview', async () => {
+    mockRpc.mockResolvedValue({ data: fullOverview, error: null });
+    const r = await fetchCommunityOverview();
+    expect(mockRpc).toHaveBeenCalledWith('admin_community_overview');
+    expect(r).not.toBeNull();
+    expect(r!.totals.views).toBe(30);
+    expect(r!.topBacked[0].winRate).toBe(67);
+    // The `authorized` flag must not leak into the returned object.
+    expect((r as unknown as Record<string, unknown>).authorized).toBeUndefined();
+  });
+
+  it('returns null for a non-admin caller', async () => {
+    mockRpc.mockResolvedValue({ data: { authorized: false }, error: null });
+    expect(await fetchCommunityOverview()).toBeNull();
+  });
+
+  it('returns null on RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    expect(await fetchCommunityOverview()).toBeNull();
+  });
+});

--- a/__tests__/lib/db/community.test.ts
+++ b/__tests__/lib/db/community.test.ts
@@ -11,6 +11,7 @@ const fullOverview = {
   online: {
     onlineNow: 1,
     activeToday: 2,
+    activeVisitors: 3,
     recent: [{ userId: 'u1', displayName: 'Gino', lastSeenAt: '2026-06-23T00:00:00Z', live: true }],
   },
   topViewed: [{ id: 'h1', name: 'Spawn', image_url: null, publisher: 'Image', count: 9 }],

--- a/__tests__/lib/db/traffic.test.ts
+++ b/__tests__/lib/db/traffic.test.ts
@@ -1,0 +1,42 @@
+const mockRpc = jest.fn();
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: { rpc: (...a: unknown[]) => mockRpc(...a) },
+}));
+
+import { fetchTrafficOverview } from '../../../src/lib/db/traffic';
+
+const overview = {
+  authorized: true,
+  rangeDays: 28,
+  totals: { pageViews: 120, visitors: 40 },
+  activeNow: 3,
+  series: [{ day: '2026-06-23', views: 10, visitors: 5 }],
+  topPages: [{ route: '/character/[id]', views: 60 }],
+  topReferrers: [{ source: 'google.com', views: 12 }],
+  devices: [{ label: 'desktop', views: 80 }],
+};
+
+describe('fetchTrafficOverview', () => {
+  beforeEach(() => mockRpc.mockReset());
+
+  it('passes the day window and returns the typed overview', async () => {
+    mockRpc.mockResolvedValue({ data: overview, error: null });
+    const r = await fetchTrafficOverview(28);
+    expect(mockRpc).toHaveBeenCalledWith('admin_traffic_overview', { p_days: 28 });
+    expect(r).not.toBeNull();
+    expect(r!.totals.pageViews).toBe(120);
+    expect(r!.activeNow).toBe(3);
+    expect(r!.topPages[0].route).toBe('/character/[id]');
+    expect((r as unknown as Record<string, unknown>).authorized).toBeUndefined();
+  });
+
+  it('returns null for a non-admin caller', async () => {
+    mockRpc.mockResolvedValue({ data: { authorized: false }, error: null });
+    expect(await fetchTrafficOverview()).toBeNull();
+  });
+
+  it('returns null on RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    expect(await fetchTrafficOverview()).toBeNull();
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import {
 } from '@expo-google-fonts/nunito';
 import { Righteous_400Regular } from '@expo-google-fonts/righteous';
 import { useAuth } from '../src/hooks/useAuth';
+import { usePresenceHeartbeat } from '../src/hooks/usePresenceHeartbeat';
 import { LogoLoader } from '../src/components/ui/LogoLoader';
 import AnalyticsProvider from '../src/components/Analytics';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -36,6 +37,13 @@ if (Platform.OS !== 'web') {
 }
 
 SplashScreen.preventAutoHideAsync();
+
+// Drives the presence heartbeat app-wide (no-op when logged out). Rendered as a
+// sibling of the router so it lives for the whole session without re-mounting.
+function PresenceHeartbeat() {
+  usePresenceHeartbeat();
+  return null;
+}
 
 function AuthGate() {
   const { user, loading } = useAuth();
@@ -90,6 +98,7 @@ export default function RootLayout() {
       <QueryClientProvider client={queryClient}>
         <StatusBar style="dark" />
         <AnalyticsProvider />
+        <PresenceHeartbeat />
         <AuthGate />
       </QueryClientProvider>
     </GestureHandlerRootView>

--- a/app/admin/health.web.tsx
+++ b/app/admin/health.web.tsx
@@ -32,7 +32,7 @@ import { fetchSourceCoverage } from '../../src/lib/db/catalogHealth';
 import { CampaignsDomain } from '../../src/components/admin/health/domains/CampaignsDomain';
 import { ReviewDomain } from '../../src/components/admin/health/domains/ReviewDomain';
 import { CommunityDomain } from '../../src/components/admin/health/domains/CommunityDomain';
-import { PlaceholderDomain } from '../../src/components/admin/health/domains/PlaceholderDomain';
+import { TrafficDomain } from '../../src/components/admin/health/domains/TrafficDomain';
 import {
   useActivityLog,
   useCatalogActions,
@@ -96,6 +96,7 @@ export default function AdminHealthScreen() {
     portraitsPendingQ,
     recentEnrichedQ,
     communityQ,
+    trafficQ,
   } = useCatalogQueries({
     enabled: gateResolved && isAdmin,
     domain,
@@ -452,10 +453,10 @@ export default function AdminHealthScreen() {
           />
         )}
         {domain === 'traffic' && (
-          <PlaceholderDomain
-            label="Traffic"
-            icon="trending-up-outline"
-            blurb="Page views, search, and traffic analytics will live here."
+          <TrafficDomain
+            data={trafficQ.data ?? null}
+            loading={trafficQ.isLoading}
+            narrow={narrow}
           />
         )}
       </CommandShell>

--- a/app/admin/health.web.tsx
+++ b/app/admin/health.web.tsx
@@ -31,6 +31,7 @@ import { SourcesDomain } from '../../src/components/admin/health/domains/Sources
 import { fetchSourceCoverage } from '../../src/lib/db/catalogHealth';
 import { CampaignsDomain } from '../../src/components/admin/health/domains/CampaignsDomain';
 import { ReviewDomain } from '../../src/components/admin/health/domains/ReviewDomain';
+import { CommunityDomain } from '../../src/components/admin/health/domains/CommunityDomain';
 import { PlaceholderDomain } from '../../src/components/admin/health/domains/PlaceholderDomain';
 import {
   useActivityLog,
@@ -94,6 +95,7 @@ export default function AdminHealthScreen() {
     statsPendingQ,
     portraitsPendingQ,
     recentEnrichedQ,
+    communityQ,
   } = useCatalogQueries({
     enabled: gateResolved && isAdmin,
     domain,
@@ -438,11 +440,15 @@ export default function AdminHealthScreen() {
         )}
         {domain === 'campaigns' && <CampaignsDomain />}
         {domain === 'spend' && <SpendDomain spend={spendQ.data} loading={spendQ.isLoading} />}
-        {domain === 'users' && (
-          <PlaceholderDomain
-            label="Users"
-            icon="people-outline"
-            blurb="User accounts, sessions, and engagement signals will live here."
+        {domain === 'community' && (
+          <CommunityDomain
+            data={communityQ.data ?? null}
+            loading={communityQ.isLoading}
+            narrow={narrow}
+            onOpenReview={() => {
+              setCatSub('review');
+              setDomain('catalog');
+            }}
           />
         )}
         {domain === 'traffic' && (

--- a/docs/superpowers/plans/2026-06-23-command-center-web-observability.md
+++ b/docs/superpowers/plans/2026-06-23-command-center-web-observability.md
@@ -1,0 +1,356 @@
+# Command Center — Web Observability Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. Implement
+> task-by-task; commit after each task; run `yarn test:ci` and `yarn tsc --noEmit` before
+> committing source changes.
+
+**Date:** 2026-06-23
+**Status:** Planned (ready to build)
+**Goal:** Fill the two dimmed rail slots in the Mythique Command Center so that — ahead of the
+web launch — we can see **who's online**, **who viewed which page / hero**, and **what to
+focus on**. Three workstreams, built in order: **Community** → **Presence** → **Traffic**.
+
+**Source specs (already in repo):**
+- `docs/superpowers/specs/2026-06-14-command-center-engagement-domain-design.md` (Approved) — Community/engagement domain.
+- `docs/superpowers/specs/2026-06-17-command-center-traffic-domain-design.md` (Draft) — Traffic domain. **Decision since spec:** we go with **Approach 2 (self-hosted `page_views`)**, not the Vercel API, so the domain is plan-independent and gives per-user attribution.
+
+**Decisions baked in (confirmed with product owner 2026-06-23):**
+1. Build all three; **Community first**.
+2. Traffic data is **self-hosted** in a `page_views` table (no Vercel-plan dependency).
+3. **Presence** ("who's online") is **new** (not in either spec) and is folded into the
+   Community domain rather than its own rail item.
+
+## Global constraints (from CLAUDE.md / repo conventions)
+
+- **yarn** only. Tests: `yarn test:ci`. Typecheck: `yarn tsc --noEmit`.
+- Screens **never** import `supabase` directly — all DB access via `src/lib/db/`.
+- Migrations: new file `supabase/migrations/YYYYMMDDHHMMSS_description.sql`, applied via
+  `mcp__supabase__apply_migration` (not the dashboard). Regenerate
+  `src/types/database.generated.ts` via `mcp__supabase__generate_typescript_types` after each.
+- New tables auto-enable RLS. **Always add an explicit policy** or the table returns 0 rows /
+  RPCs return `[]` silently.
+- Cross-user aggregation runs through **admin-guarded `SECURITY DEFINER` RPCs**, mirroring the
+  established pattern: guard with
+  `exists (select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin)`,
+  `set search_path = public`, `revoke all ... from public, anon`, then explicit grants.
+- PostgREST caps at 1000 rows — always `.limit()`.
+- Styles: `StyleSheet.create`; fonts `Flame-Regular` (display) / `FlameSans-Regular` (body) /
+  `Nunito_*` (UI). Domain files reuse `Panel` / `Bento` / `HeroThumb` and stay < ~400 lines.
+- Domain UI is **web-only** chrome but the command center already ships `health.tsx` +
+  `health.web.tsx`; new domain components live under `src/components/admin/health/domains/`
+  and are imported by `health.web.tsx` (the native `health.tsx` is a thin stub — follow
+  whatever the existing domains do).
+
+---
+
+# Phase 1 — Community domain (engagement & "who viewed what")
+
+Highest value, zero external dependencies, spec already approved. Reads existing tables
+(`user_view_history`, `user_favourites`, `matchup_votes`, `contributions`,
+`contributor_stats`, `verdicts`, `user_profiles`) through one admin RPC.
+
+## Task 1.1 — `admin_community_overview()` RPC
+
+**File:** `supabase/migrations/<ts>_admin_community_overview.sql`
+
+Single round trip, admin-guarded, returns one JSON object. Lists capped (8 leaderboard / 12
+activity) for one cheap query. Returns empty/zero shape for non-admins (never raises to the
+client UI — but revoke from anon).
+
+```sql
+-- Read-only community/engagement analytics for the command center.
+-- Admin-guarded; aggregates per-user tables that individually carry RLS.
+create or replace function public.admin_community_overview()
+returns json language plpgsql security definer set search_path = public stable
+as $$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'totals', (select json_build_object(
+      'members',       (select count(*) from public.user_profiles),
+      'favourites',    (select count(*) from public.user_favourites),
+      'views',         (select count(*) from public.user_view_history),
+      'compares',      (select count(*) from public.verdicts),
+      'votes',         (select count(*) from public.matchup_votes),
+      'contributions', (select count(*) from public.contributions)
+    )),
+    'topViewed', (select coalesce(json_agg(r), '[]') from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_view_history v join public.heroes h on h.id = v.hero_id
+      group by h.id order by count(*) desc limit 8
+    ) r),
+    'topFavourited', (select coalesce(json_agg(r), '[]') from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_favourites f join public.heroes h on h.id = f.hero_id
+      group by h.id order by count(*) desc limit 8
+    ) r),
+    'topBacked', (select coalesce(json_agg(r), '[]') from (
+      select h.id, h.name, h.image_url, h.publisher,
+             count(*)::int as count
+      from public.matchup_votes mv join public.heroes h on h.id = mv.picked_id
+      group by h.id order by count(*) desc limit 8
+    ) r),
+    'topContributors', (select coalesce(json_agg(r), '[]') from (
+      select cs.user_id as "userId", p.display_name as "displayName",
+             cs.approved, cs.level
+      from public.contributor_stats cs
+      left join public.user_profiles p on p.id = cs.user_id
+      order by cs.approved desc limit 8
+    ) r),
+    'contributionsByStatus', (select json_build_object(
+      'pending',  count(*) filter (where status = 'pending'),
+      'approved', count(*) filter (where status = 'approved'),
+      'rejected', count(*) filter (where status = 'rejected')
+    ) from public.contributions),
+    'recent', (select coalesce(json_agg(r), '[]') from (
+      select * from (
+        select 'view'::text as kind, v.viewed_at as at, h.id as "heroId", h.name as "heroName", null::text as text
+          from public.user_view_history v join public.heroes h on h.id = v.hero_id
+        union all
+        select 'favourite', f.created_at, h.id, h.name, null
+          from public.user_favourites f join public.heroes h on h.id = f.hero_id
+        union all
+        select 'vote', mv.created_at, h.id, h.name, null
+          from public.matchup_votes mv join public.heroes h on h.id = mv.picked_id
+        union all
+        select 'contribution', c.created_at, h.id, h.name,
+               coalesce('edited ' || c.target_field, c.kind)
+          from public.contributions c join public.heroes h on h.id = c.hero_id
+      ) u order by at desc limit 12
+    ) r)
+  );
+end;
+$$;
+
+revoke all on function public.admin_community_overview() from public, anon;
+grant execute on function public.admin_community_overview() to authenticated, service_role;
+```
+
+> **Note on `topBacked` win-rate:** the spec wants an optional `winRate` per backed hero. A
+> hero appears in many matchups; a true win rate needs (times picked) / (times in a matchup as
+> either side). Add as a follow-up `select` if cheap; ship count-only first.
+
+- [ ] Write the migration. Confirm column names against the live schema first with
+  `mcp__supabase__execute_sql` (`user_favourites`/`verdicts`/`matchup_votes` column names —
+  e.g. does `user_favourites` have `created_at`? if not, drop it from `recent`).
+- [ ] Apply via `mcp__supabase__apply_migration` (name `admin_community_overview`).
+- [ ] Verify: `select public.admin_community_overview();` as an admin → `authorized:true` with
+  totals matching the spec's known volumes (~30 views, 82 verdicts, etc.).
+- [ ] Regenerate types; commit.
+
+## Task 1.2 — DB wrapper `src/lib/db/community.ts`
+
+```ts
+export interface HeroStat { id: string; name: string; image_url: string | null; publisher: string | null; count: number; winRate?: number; }
+export interface Contributor { userId: string; displayName: string | null; approved: number; level: string | null; }
+export interface ActivityItem { kind: 'favourite' | 'view' | 'compare' | 'vote' | 'contribution'; at: string; heroId: string; heroName: string; text?: string; }
+export interface CommunityOverview {
+  totals: { members: number; favourites: number; views: number; compares: number; votes: number; contributions: number };
+  topViewed: HeroStat[]; topFavourited: HeroStat[]; topBacked: HeroStat[];
+  topContributors: Contributor[];
+  contributionsByStatus: { pending: number; approved: number; rejected: number };
+  recent: ActivityItem[];
+}
+export async function fetchCommunityOverview(): Promise<CommunityOverview | null>;
+```
+
+- [ ] `fetchCommunityOverview` calls `supabase.rpc('admin_community_overview')`; returns `null`
+  when `authorized:false` or on error (so the UI shows an empty/locked state, never crashes).
+
+## Task 1.3 — `CommunityDomain.tsx` + wire-up
+
+- [ ] Create `src/components/admin/health/domains/CommunityDomain.tsx` — bento of `Panel`s,
+  reusing `HeroThumb`, `relTime`, the existing bar/stat patterns:
+  1. Headline stats (Members · Favourites · Views · Compares · Votes · Contributions)
+  2. Most-viewed heroes (top 8, deep-link `/character/:id`)
+  3. Most-favourited heroes (top 8)
+  4. Most-backed heroes (top 8, matchup votes)
+  5. Top contributors (name + approved + level chip; header action **"Open review"** →
+     switches `domain` to `catalog`/Review sub-tab; badge = `contributionsByStatus.pending`)
+  6. Recent activity (unified, icon-coded, `relTime`)
+  Each panel has a calm empty state (expected pre-launch).
+- [ ] **Rename rail slot** in `src/components/admin/health/format.ts`: `DomainKey` `'users'`
+  → `'community'`; `DOMAINS` entry `{ key:'community', label:'Community', icon:'people-outline' }`
+  and **remove `placeholder:true`** (it becomes a real domain).
+- [ ] Add the query in `src/components/admin/health/hooks.ts` (or domain-local):
+  `useCommunity` — React Query, `enabled: gateResolved && isAdmin && domain==='community'`,
+  `staleTime: 60_000`.
+- [ ] Route it in `app/admin/health.web.tsx`: replace the `domain === 'users'` placeholder
+  block with `domain === 'community' && <CommunityDomain data={communityQ.data} ... />`.
+- [ ] Update `__tests__/components/admin/health/format.test.ts` domain-key assertions
+  (`users` → `community`).
+- [ ] `yarn tsc --noEmit && yarn test:ci`; commit.
+
+---
+
+# Phase 2 — Presence ("who's online")
+
+Not covered by either spec. Two layers, because the app is **not** auth-gated (logged-out users
+browse freely):
+
+- **Named-user presence** — `user_profiles.last_seen_at`, updated by a throttled heartbeat.
+  Tells us *which* signed-in users are online now / active today. **Self-contained — ships in
+  this phase.**
+- **Anonymous "active now" count** — derived from `page_views` recency (distinct `session_id`
+  in the last 5 min). **Depends on Phase 3's `page_views` table**; wire it into the panel once
+  Phase 3 lands.
+
+## Task 2.1 — `last_seen_at` + heartbeat RPC
+
+**File:** `supabase/migrations/<ts>_user_presence.sql`
+
+```sql
+alter table public.user_profiles add column if not exists last_seen_at timestamptz;
+create index if not exists user_profiles_last_seen_idx on public.user_profiles (last_seen_at desc);
+
+-- Throttled heartbeat: stamps the caller's last_seen_at. Cheap; called ~once/min.
+create or replace function public.touch_last_seen()
+returns void language sql security definer set search_path = public as $$
+  update public.user_profiles set last_seen_at = now() where id = auth.uid();
+$$;
+revoke all on function public.touch_last_seen() from public, anon;
+grant execute on function public.touch_last_seen() to authenticated, service_role;
+```
+
+- [ ] Apply; regenerate types; commit.
+
+## Task 2.2 — Heartbeat hook + mount
+
+- [ ] `src/hooks/usePresenceHeartbeat.ts` — when `useAuth().user` exists, call
+  `supabase.rpc('touch_last_seen')` on mount, on app-focus/visibility regain, and on a ~60s
+  interval; no-op for anon. (DB access via a tiny `src/lib/db/presence.ts` wrapper, not direct
+  `supabase` in the hook — keep with the repo rule.)
+- [ ] Mount it once near `AnalyticsProvider` in `app/_layout.tsx` (it already renders for all
+  platforms; the RPC is a no-op when logged out).
+
+## Task 2.3 — Surface presence in Community
+
+- [ ] Extend `admin_community_overview()` (new migration or fold into 1.1 before it ships) with
+  an `online` block: `online_now` = `count(*) where last_seen_at > now() - interval '5 min'`,
+  `active_today` = `count(*) where last_seen_at > now() - interval '1 day'`, plus a small list
+  of the most-recently-seen members (display_name + `last_seen_at`).
+- [ ] Add an **"Online now"** panel to `CommunityDomain` (online count + active-today + recent
+  members list). Leave a labelled slot for the anonymous "active visitors" number that Phase 3
+  fills.
+
+---
+
+# Phase 3 — Traffic domain (self-hosted page views)
+
+Self-hosted `page_views` (Approach 2). Collection reuses the existing `Analytics.web.tsx`,
+which already computes `route` (matched pattern, e.g. `/character/[id]`) and `path` (concrete
+URL) on every navigation — so route grouping is free and there's almost no new client plumbing.
+
+## Task 3.1 — `page_views` table
+
+**File:** `supabase/migrations/<ts>_page_views.sql`
+
+```sql
+-- Self-hosted web page-view events. Privacy: rows are insert-only from clients;
+-- NO public select (reads go through admin_traffic_overview only). user_id is set
+-- for signed-in views, null for anon; session_id is a random client id.
+create table if not exists public.page_views (
+  id         bigint generated always as identity primary key,
+  route      text not null,         -- matched pattern e.g. /character/[id]
+  path       text not null,         -- concrete url e.g. /character/123
+  user_id    uuid references auth.users(id) on delete set null,
+  session_id text,                  -- anon client id (random, persisted client-side)
+  referrer   text,                  -- document.referrer host, if any
+  device     text,                  -- 'desktop' | 'mobile' | 'tablet'
+  created_at timestamptz not null default now()
+);
+create index if not exists page_views_created_idx on public.page_views (created_at desc);
+create index if not exists page_views_route_idx    on public.page_views (route);
+create index if not exists page_views_session_idx  on public.page_views (session_id);
+
+alter table public.page_views enable row level security;
+-- Anyone (anon or signed-in) may insert their own view; nobody may read directly.
+drop policy if exists page_views_insert on public.page_views;
+create policy page_views_insert on public.page_views
+  for insert to anon, authenticated with check (true);
+-- (No select policy → table is unreadable except via the SECURITY DEFINER RPC below.)
+```
+
+> **Abuse note:** `with check (true)` lets anyone insert arbitrary rows. Acceptable pre-launch;
+> before scaling, consider a rate-limit (e.g. a Postgres trigger capping inserts per session/
+> minute) or routing writes through an edge function. Flag in the success criteria.
+
+- [ ] Apply; regenerate types; commit.
+
+## Task 3.2 — Write path
+
+- [ ] `src/lib/db/pageViews.ts` — `recordPageView({ route, path })`: derive `device` from
+  `navigator.userAgent`, `referrer` from `document.referrer` host, read/create a persistent
+  anon `session_id` in `localStorage`, attach `user_id` if a session exists, fire-and-forget
+  insert (swallow errors, like `recordView`).
+- [ ] Call it from `src/components/Analytics.web.tsx` in an effect keyed on `path` (it already
+  has `route` + `path`). Dedupe rapid repeats. **Web only** — the native `Analytics.tsx`
+  returns null, so no native writes.
+
+## Task 3.3 — `admin_traffic_overview(p_days int)` RPC
+
+**File:** `supabase/migrations/<ts>_admin_traffic_overview.sql`. Admin-guarded, mirrors 1.1.
+
+Returns JSON: `totals { pageViews, visitors }` (visitors = distinct
+`coalesce(user_id::text, session_id)`), `series [{ day, views, visitors }]` (daily, last
+`p_days`), `topPages [{ route, views }]` (top 8, already grouped by route), `topReferrers`,
+`devices [{ label, views }]`. Default window 28 days (matches Spend).
+
+- [ ] Write + apply; verify `select public.admin_traffic_overview(28);` as admin.
+- [ ] Regenerate types; commit.
+
+## Task 3.4 — `TrafficDomain.tsx` + wire-up
+
+- [ ] `src/lib/db/traffic.ts` — `fetchTrafficOverview(days)` wrapper + `TrafficOverview` type.
+- [ ] `src/components/admin/health/domains/TrafficDomain.tsx` — bento: headline (page views ·
+  visitors), traffic-over-time trend (reuse the completeness/spend chart treatment), top pages,
+  top referrers, devices split. Calm empty state pre-traffic.
+- [ ] `format.ts`: `traffic` domain → drop `placeholder:true`.
+- [ ] `useTraffic` query (`enabled: ... && domain==='traffic'`, `staleTime: 5min`); route
+  `domain === 'traffic'` in `health.web.tsx`.
+- [ ] **Back-fill Phase 2's anon presence:** add an `active_now` field to `admin_traffic_overview`
+  (or a tiny shared read) = distinct `session_id` in `page_views` over the last 5 min, and feed
+  the Community "Online now" panel's anonymous slot.
+- [ ] `yarn tsc --noEmit && yarn test:ci`; commit.
+
+---
+
+## Cross-cutting: privacy & pre-launch reality
+
+- The two source specs both stress this is **~2-user, forward-looking scaffolding** — the
+  panels will read near-empty until launch. Build for correctness + graceful empty states, not
+  for volume.
+- `page_views` and `last_seen_at` are **per-user behavioural data**. Keep all reads behind
+  admin RPCs (no public select), and make sure the privacy policy (`app/privacy*.tsx`) covers
+  first-party analytics before launch — **confirm with product owner**.
+- Native (iOS/Android) usage analytics is explicitly **out of scope** (different SDK).
+
+## Suggested sequencing
+
+1. **Phase 1** (Community) — ship first; pure win, no deps.
+2. **Phase 2.1–2.2** (presence heartbeat + named-user online panel) — small, self-contained.
+3. **Phase 3** (page_views + Traffic domain) — then back-fill the anon "active now" count into
+   the Community presence panel (Task 3.4 last checkbox).
+
+## Success criteria
+
+- `community` and `traffic` rail items open populated bentos (or calm empty states); no crashes.
+- All cross-user aggregates come from admin-guarded `SECURITY DEFINER` RPCs; non-admins get
+  nothing; `page_views` is never directly selectable.
+- "Who's online" shows named signed-in users (last_seen) and, post-Phase-3, an anonymous
+  active-visitor count.
+- Hero rows deep-link to `/character/:id`; thumbnails use `HeroThumb` fallback.
+- Page-view collection reuses the existing `Analytics.web.tsx` route grouping (no raw ids as
+  distinct pages).
+- Fully responsive < 760px; matches the dark-chrome/light-panel command-center system.
+- Data layers isolated in `community.ts` / `presence.ts` / `pageViews.ts` / `traffic.ts`;
+  each domain file < ~400 lines.
+```

--- a/docs/superpowers/plans/2026-06-23-web-observability-APPLY-STEPS.md
+++ b/docs/superpowers/plans/2026-06-23-web-observability-APPLY-STEPS.md
@@ -1,0 +1,111 @@
+# Web Observability — Apply & Finish (handoff for a Supabase-MCP session)
+
+**Branch:** `claude/web-observability-tools-625r23`
+**Why this exists:** Phases 1–3 (Community, Presence, Traffic) are code-complete and
+pushed, but the session that built them had **no Supabase MCP connected**, so the
+migrations were never applied and `database.generated.ts` was never regenerated. The
+client code compiles via a few temporary `as never` / `page_views` casts that must be
+dropped once types are regenerated.
+
+Run this in a Claude Code chat **with the Supabase MCP connected (write enabled)** and the
+branch checked out. Paste the prompt at the bottom, or follow the steps directly.
+
+---
+
+## Step 1 — Apply the 4 migrations, in this order
+
+Use `mcp__supabase__apply_migration` once per file. Pass the file's full contents as the
+query and the listed name. Order matters (later ones `create or replace` earlier objects and
+reference earlier tables):
+
+| # | Migration file | `name` arg |
+|---|---|---|
+| 1 | `supabase/migrations/20260623120000_admin_community_overview.sql` | `admin_community_overview` |
+| 2 | `supabase/migrations/20260623130000_user_presence.sql` | `user_presence` |
+| 3 | `supabase/migrations/20260623140000_page_views.sql` | `page_views` |
+| 4 | `supabase/migrations/20260623150000_admin_traffic_overview.sql` | `admin_traffic_overview` |
+
+Sanity check after applying (via `mcp__supabase__execute_sql`):
+
+```sql
+-- objects exist
+select to_regclass('public.page_views') is not null as page_views_ok,
+       (select count(*) from pg_proc where proname in
+         ('admin_community_overview','admin_traffic_overview','touch_last_seen')) as fns,
+       (select count(*) from information_schema.columns
+         where table_name='user_profiles' and column_name='last_seen_at') as last_seen_col;
+```
+
+> NOTE on verifying the RPCs directly: `admin_community_overview()` / `admin_traffic_overview()`
+> self-guard on `auth.uid()` + `is_admin`. Called through the MCP (no auth context) they return
+> `{"authorized": false}` — that's expected, not a bug. To see real data, call them from the app
+> while signed in as an admin (ensure `user_profiles.is_admin = true` for your account), or test
+> the inner `select`s directly.
+
+## Step 2 — Regenerate types
+
+Run `mcp__supabase__generate_typescript_types` and **overwrite** `src/types/database.generated.ts`
+with the result. Do not hand-edit it.
+
+## Step 3 — Drop the temporary casts (now that the RPCs/table are typed)
+
+- **`src/lib/db/community.ts:85`**
+  `supabase.rpc('admin_community_overview' as never)` → `supabase.rpc('admin_community_overview')`
+  (keep the `data as unknown as OverviewJson` line — the RPC returns `Json`.)
+
+- **`src/lib/db/presence.ts:10`**
+  `supabase.rpc('touch_last_seen' as never)` → `supabase.rpc('touch_last_seen')`
+
+- **`src/lib/db/traffic.ts:47-52`**
+  ```ts
+  const { data, error } = await supabase.rpc('admin_traffic_overview', { p_days: days });
+  ```
+  (remove both `as never`.)
+
+- **`src/lib/db/pageViews.ts`** — remove the `InsertOnly` interface (line ~52) and the cast at
+  line ~63; insert directly:
+  ```ts
+  await supabase.from('page_views').insert({
+    route, path,
+    user_id: session?.user?.id ?? null,
+    session_id: getSessionId(),
+    referrer: getReferrerHost(),
+    device: getDevice(),
+  });
+  ```
+
+## Step 4 — Verify
+
+```sh
+yarn tsc --noEmit          # must be clean
+yarn test:ci               # 431 tests should pass
+yarn lint                  # 0 errors (pre-existing ref warnings in health.web.tsx are fine)
+```
+
+## Step 5 — Commit & push (stay on the branch)
+
+```sh
+git add -A
+git commit -m "chore(admin): apply web-observability migrations; regen types; drop temp casts"
+git push -u origin claude/web-observability-tools-625r23
+```
+
+## Optional — confirm the feature end to end
+- Sign in as an admin and open `/admin/health` (web). The **Community** and **Traffic** rail
+  items should populate (or show calm empty states pre-traffic).
+- Navigate a few pages, then check **Traffic** → rows should appear in `page_views`
+  (`select count(*) from public.page_views;`).
+- **Before launch:** make sure `app/privacy.tsx` / `app/privacy.web.tsx` mention first-party
+  page-view + presence analytics.
+
+---
+
+## Copy-paste prompt for the other chat
+
+> On branch `claude/web-observability-tools-625r23`, finish the web-observability work using the
+> Supabase MCP. Open `docs/superpowers/plans/2026-06-23-web-observability-APPLY-STEPS.md` and do
+> exactly that: apply the 4 migrations in order (`apply_migration`), regenerate
+> `src/types/database.generated.ts` (`generate_typescript_types`), drop the temporary `as never`
+> / `page_views` casts in `community.ts`, `presence.ts`, `traffic.ts`, `pageViews.ts`, then run
+> `yarn tsc --noEmit && yarn test:ci`, and commit + push to the same branch. Don't open a PR
+> unless I ask.

--- a/src/components/Analytics.web.tsx
+++ b/src/components/Analytics.web.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 import { usePathname, useSegments } from 'expo-router';
+import { recordPageView } from '../lib/db/pageViews';
 
 export default function AnalyticsProvider() {
   // path is the concrete URL (e.g. /character/123); route is the matched
@@ -9,6 +11,15 @@ export default function AnalyticsProvider() {
   const path = usePathname();
   const segments = useSegments();
   const route = '/' + segments.filter((segment) => !segment.startsWith('(')).join('/');
+
+  // Mirror the same view into our self-hosted page_views table (command-center
+  // Traffic domain). Keyed on path + deduped so a re-render doesn't double-count.
+  const lastPath = useRef<string | null>(null);
+  useEffect(() => {
+    if (!path || lastPath.current === path) return;
+    lastPath.current = path;
+    void recordPageView(route, path);
+  }, [path, route]);
 
   return <Analytics route={route} path={path} />;
 }

--- a/src/components/admin/health/domains/CommunityDomain.tsx
+++ b/src/components/admin/health/domains/CommunityDomain.tsx
@@ -122,6 +122,10 @@ function OnlineNow({ online }: { online: PresenceSummary }) {
           <Text style={s.onlineSub}>{online.activeToday.toLocaleString()}</Text>
           <Text style={s.onlineSubLabel}>active today</Text>
         </View>
+        <View>
+          <Text style={s.onlineSub}>{online.activeVisitors.toLocaleString()}</Text>
+          <Text style={s.onlineSubLabel}>visitors now</Text>
+        </View>
       </View>
       {online.recent.length === 0 ? (
         <EmptyState text="No members seen yet." />
@@ -136,7 +140,9 @@ function OnlineNow({ online }: { online: PresenceSummary }) {
           </View>
         ))
       )}
-      <Text style={s.anonNote}>Anonymous visitor counts arrive with Traffic (Phase 3).</Text>
+      <Text style={s.anonNote}>
+        “Visitors now” counts anonymous + signed-in sessions — see Traffic for detail.
+      </Text>
     </Panel>
   );
 }

--- a/src/components/admin/health/domains/CommunityDomain.tsx
+++ b/src/components/admin/health/domains/CommunityDomain.tsx
@@ -16,6 +16,7 @@ import type {
   Contributor,
   ActivityItem,
   ActivityKind,
+  PresenceSummary,
 } from '../../../../lib/db/community';
 
 const KIND_META: Record<
@@ -106,6 +107,40 @@ function ActivityRow({ item, onPress }: { item: ActivityItem; onPress: () => voi
   );
 }
 
+// Named-user presence: who's signed in and active right now. The anonymous
+// "active visitors" line is a deliberate placeholder until Phase 3's page_views
+// table lands (anon traffic isn't tracked yet).
+function OnlineNow({ online }: { online: PresenceSummary }) {
+  return (
+    <Panel title="Online now" hint="Signed-in members · last 5 min" style={s.flex1}>
+      <View style={s.onlineHead}>
+        <View style={s.onlineBig}>
+          <View style={s.dot} />
+          <Text style={s.onlineCount}>{online.onlineNow.toLocaleString()}</Text>
+        </View>
+        <View>
+          <Text style={s.onlineSub}>{online.activeToday.toLocaleString()}</Text>
+          <Text style={s.onlineSubLabel}>active today</Text>
+        </View>
+      </View>
+      {online.recent.length === 0 ? (
+        <EmptyState text="No members seen yet." />
+      ) : (
+        online.recent.map((m) => (
+          <View key={m.userId} style={s.row}>
+            <View style={[s.statusDot, { backgroundColor: m.live ? COLORS.green : COLORS.grey }]} />
+            <Text style={[s.rowName, s.flex1]} numberOfLines={1}>
+              {m.displayName ?? 'Anonymous'}
+            </Text>
+            <Text style={s.actTime}>{relTime(m.lastSeenAt)}</Text>
+          </View>
+        ))
+      )}
+      <Text style={s.anonNote}>Anonymous visitor counts arrive with Traffic (Phase 3).</Text>
+    </Panel>
+  );
+}
+
 export function CommunityDomain({
   data,
   loading,
@@ -145,21 +180,26 @@ export function CommunityDomain({
 
   return (
     <Bento>
-      {/* Headline stats */}
-      <Panel title="Community" hint="Engagement across the catalogue">
-        <View style={s.tiles}>
-          <StatTile label="Members" value={t.members.toLocaleString()} tint={COLORS.navy} />
-          <StatTile label="Favourites" value={t.favourites.toLocaleString()} tint={COLORS.red} />
-          <StatTile label="Views" value={t.views.toLocaleString()} tint={COLORS.blue} />
-          <StatTile label="Compares" value={t.compares.toLocaleString()} tint={COLORS.orange} />
-          <StatTile label="Votes" value={t.votes.toLocaleString()} tint={COLORS.gold} />
-          <StatTile
-            label="Contributions"
-            value={t.contributions.toLocaleString()}
-            tint={COLORS.green}
-          />
-        </View>
-      </Panel>
+      <Bento.Row narrow={narrow}>
+        {/* Headline stats */}
+        <Panel title="Community" hint="Engagement across the catalogue" style={s.flex15}>
+          <View style={s.tiles}>
+            <StatTile label="Members" value={t.members.toLocaleString()} tint={COLORS.navy} />
+            <StatTile label="Favourites" value={t.favourites.toLocaleString()} tint={COLORS.red} />
+            <StatTile label="Views" value={t.views.toLocaleString()} tint={COLORS.blue} />
+            <StatTile label="Compares" value={t.compares.toLocaleString()} tint={COLORS.orange} />
+            <StatTile label="Votes" value={t.votes.toLocaleString()} tint={COLORS.gold} />
+            <StatTile
+              label="Contributions"
+              value={t.contributions.toLocaleString()}
+              tint={COLORS.green}
+            />
+          </View>
+        </Panel>
+
+        {/* Online now */}
+        <OnlineNow online={data.online} />
+      </Bento.Row>
 
       <Bento.Row narrow={narrow}>
         {/* Most viewed */}
@@ -243,7 +283,23 @@ export function CommunityDomain({
 
 const s = StyleSheet.create({
   flex1: { flex: 1 },
+  flex15: { flex: 1.5 },
   tiles: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  // Online-now panel
+  onlineHead: { flexDirection: 'row', alignItems: 'flex-end', gap: 28, marginBottom: 10 },
+  onlineBig: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  dot: { width: 10, height: 10, borderRadius: 999, backgroundColor: COLORS.green },
+  onlineCount: { fontFamily: 'Flame-Regular', fontSize: 38, color: COLORS.green, lineHeight: 40 },
+  onlineSub: { fontFamily: 'Flame-Regular', fontSize: 22, color: COLORS.navy, lineHeight: 24 },
+  onlineSubLabel: { fontFamily: 'Nunito_700Bold', fontSize: 10, color: COLORS.grey },
+  statusDot: { width: 8, height: 8, borderRadius: 999 },
+  anonNote: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 11,
+    color: COLORS.grey,
+    fontStyle: 'italic',
+    marginTop: 10,
+  },
   row: { flexDirection: 'row', alignItems: 'center', gap: 9, paddingVertical: 5 },
   rowInfo: { flex: 1, gap: 1, minWidth: 0 },
   rowName: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.black },

--- a/src/components/admin/health/domains/CommunityDomain.tsx
+++ b/src/components/admin/health/domains/CommunityDomain.tsx
@@ -1,0 +1,301 @@
+// Community / engagement domain — the read-only "who's doing what" glance.
+// Aggregates come from one admin-guarded RPC (see src/lib/db/community.ts); this
+// is a pure view of that data. No mutations: moderation lives in ReviewDomain
+// (the "Open review" action just deep-links there).
+import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { COLORS } from '../../../../constants/colors';
+import { Panel } from '../Panel';
+import { Bento } from '../Bento';
+import { HeroThumb, StatTile, EmptyState, Chip } from '../ui';
+import { relTime } from '../format';
+import type {
+  CommunityOverview,
+  HeroStat,
+  Contributor,
+  ActivityItem,
+  ActivityKind,
+} from '../../../../lib/db/community';
+
+const KIND_META: Record<
+  ActivityKind,
+  { icon: keyof typeof Ionicons.glyphMap; tint: string; verb: string }
+> = {
+  view: { icon: 'eye-outline', tint: COLORS.blue, verb: 'viewed' },
+  favourite: { icon: 'heart', tint: COLORS.red, verb: 'favourited' },
+  vote: { icon: 'trophy-outline', tint: COLORS.gold, verb: 'backed' },
+  compare: { icon: 'git-compare-outline', tint: COLORS.orange, verb: 'compared' },
+  contribution: { icon: 'create-outline', tint: COLORS.green, verb: 'edited' },
+};
+
+const LEVEL_TINT: Record<string, string> = {
+  steward: COLORS.green,
+  curator: COLORS.blue,
+  new: COLORS.grey,
+};
+
+// One leaderboard row: thumb + name/publisher, a right-aligned count, and an
+// optional win-rate chip (most-backed only). Taps through to the character.
+function HeroRow({ hero, unit, onPress }: { hero: HeroStat; unit: string; onPress: () => void }) {
+  return (
+    <Pressable onPress={onPress} style={s.row}>
+      <HeroThumb uri={hero.image_url} size={30} radius={8} />
+      <View style={s.rowInfo}>
+        <Text style={s.rowName} numberOfLines={1}>
+          {hero.name}
+        </Text>
+        <Text style={s.rowSub} numberOfLines={1}>
+          {hero.publisher ?? '—'}
+        </Text>
+      </View>
+      {hero.winRate != null ? (
+        <Chip bg={COLORS.green + '1a'} fg={COLORS.green} text={`${hero.winRate}%`} />
+      ) : null}
+      <Text style={s.rowCount}>
+        {hero.count.toLocaleString()}
+        <Text style={s.rowUnit}> {unit}</Text>
+      </Text>
+    </Pressable>
+  );
+}
+
+function ContributorRow({ c }: { c: Contributor }) {
+  const tint = LEVEL_TINT[c.level ?? 'new'] ?? COLORS.grey;
+  return (
+    <View style={s.row}>
+      <View style={[s.avatar, { backgroundColor: tint + '22' }]}>
+        <Ionicons name="person" size={15} color={tint} />
+      </View>
+      <View style={s.rowInfo}>
+        <Text style={s.rowName} numberOfLines={1}>
+          {c.displayName ?? 'Anonymous'}
+        </Text>
+        {c.level ? (
+          <Text style={[s.rowSub, { color: tint, textTransform: 'capitalize' }]}>{c.level}</Text>
+        ) : null}
+      </View>
+      <Text style={s.rowCount}>
+        {c.approved.toLocaleString()}
+        <Text style={s.rowUnit}> approved</Text>
+      </Text>
+    </View>
+  );
+}
+
+function ActivityRow({ item, onPress }: { item: ActivityItem; onPress: () => void }) {
+  const meta = KIND_META[item.kind];
+  return (
+    <Pressable onPress={onPress} style={s.actRow}>
+      <View style={[s.actIcon, { backgroundColor: meta.tint + '1a' }]}>
+        <Ionicons name={meta.icon} size={14} color={meta.tint} />
+      </View>
+      <View style={s.rowInfo}>
+        <Text style={s.actText} numberOfLines={1}>
+          <Text style={s.actVerb}>{meta.verb} </Text>
+          {item.heroName}
+        </Text>
+        {item.text ? (
+          <Text style={s.rowSub} numberOfLines={1}>
+            {item.text}
+          </Text>
+        ) : null}
+      </View>
+      <Text style={s.actTime}>{relTime(item.at)}</Text>
+    </Pressable>
+  );
+}
+
+export function CommunityDomain({
+  data,
+  loading,
+  narrow,
+  onOpenReview,
+}: {
+  data: CommunityOverview | null;
+  loading: boolean;
+  narrow: boolean;
+  onOpenReview: () => void;
+}) {
+  const router = useRouter();
+  const goHero = (id: string) => router.push(`/character/${id}`);
+
+  if (loading && !data) {
+    return (
+      <Panel title="Community">
+        <ActivityIndicator color={COLORS.orange} style={{ marginTop: 16 }} />
+      </Panel>
+    );
+  }
+  if (!data) {
+    return (
+      <Panel title="Community">
+        <View style={s.locked}>
+          <Ionicons name="lock-closed-outline" size={26} color={COLORS.grey} />
+          <Text style={s.lockedText}>
+            Community analytics are admin-only, or no engagement data is available yet.
+          </Text>
+        </View>
+      </Panel>
+    );
+  }
+
+  const t = data.totals;
+  const pending = data.contributionsByStatus.pending;
+
+  return (
+    <Bento>
+      {/* Headline stats */}
+      <Panel title="Community" hint="Engagement across the catalogue">
+        <View style={s.tiles}>
+          <StatTile label="Members" value={t.members.toLocaleString()} tint={COLORS.navy} />
+          <StatTile label="Favourites" value={t.favourites.toLocaleString()} tint={COLORS.red} />
+          <StatTile label="Views" value={t.views.toLocaleString()} tint={COLORS.blue} />
+          <StatTile label="Compares" value={t.compares.toLocaleString()} tint={COLORS.orange} />
+          <StatTile label="Votes" value={t.votes.toLocaleString()} tint={COLORS.gold} />
+          <StatTile
+            label="Contributions"
+            value={t.contributions.toLocaleString()}
+            tint={COLORS.green}
+          />
+        </View>
+      </Panel>
+
+      <Bento.Row narrow={narrow}>
+        {/* Most viewed */}
+        <Panel title="Most viewed" hint="Top heroes by page view" style={s.flex1}>
+          {data.topViewed.length === 0 ? (
+            <EmptyState text="No views recorded yet." />
+          ) : (
+            data.topViewed.map((h) => (
+              <HeroRow key={h.id} hero={h} unit="views" onPress={() => goHero(h.id)} />
+            ))
+          )}
+        </Panel>
+
+        {/* Most favourited */}
+        <Panel title="Most favourited" hint="Top heroes by favourite" style={s.flex1}>
+          {data.topFavourited.length === 0 ? (
+            <EmptyState text="No favourites yet." />
+          ) : (
+            data.topFavourited.map((h) => (
+              <HeroRow key={h.id} hero={h} unit="favs" onPress={() => goHero(h.id)} />
+            ))
+          )}
+        </Panel>
+      </Bento.Row>
+
+      <Bento.Row narrow={narrow}>
+        {/* Most backed */}
+        <Panel title="Most backed" hint="Matchup-vote winners · win rate" style={s.flex1}>
+          {data.topBacked.length === 0 ? (
+            <EmptyState text="No votes cast yet." />
+          ) : (
+            data.topBacked.map((h) => (
+              <HeroRow key={h.id} hero={h} unit="votes" onPress={() => goHero(h.id)} />
+            ))
+          )}
+        </Panel>
+
+        {/* Top contributors */}
+        <Panel
+          title="Top contributors"
+          hint="By approved edits"
+          style={s.flex1}
+          action={
+            <Pressable onPress={onOpenReview} style={s.mini}>
+              <Text style={s.miniText}>Open review</Text>
+              {pending > 0 ? (
+                <View style={s.pendBadge}>
+                  <Text style={s.pendText}>{pending > 99 ? '99+' : pending}</Text>
+                </View>
+              ) : (
+                <Ionicons name="chevron-forward" size={13} color={COLORS.navy} />
+              )}
+            </Pressable>
+          }
+        >
+          {data.topContributors.length === 0 ? (
+            <EmptyState text="No contributors yet." />
+          ) : (
+            data.topContributors.map((c) => <ContributorRow key={c.userId} c={c} />)
+          )}
+        </Panel>
+      </Bento.Row>
+
+      {/* Recent activity */}
+      <Panel title="Recent activity" hint="Newest first across all signals">
+        {data.recent.length === 0 ? (
+          <EmptyState text="No activity yet — it fills in as people use the app." />
+        ) : (
+          data.recent.map((item, i) => (
+            <ActivityRow
+              key={`${item.kind}-${item.at}-${i}`}
+              item={item}
+              onPress={() => goHero(item.heroId)}
+            />
+          ))
+        )}
+      </Panel>
+    </Bento>
+  );
+}
+
+const s = StyleSheet.create({
+  flex1: { flex: 1 },
+  tiles: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 9, paddingVertical: 5 },
+  rowInfo: { flex: 1, gap: 1, minWidth: 0 },
+  rowName: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.black },
+  rowSub: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: COLORS.grey },
+  rowCount: { fontFamily: 'Flame-Regular', fontSize: 15, color: COLORS.navy },
+  rowUnit: { fontFamily: 'Nunito_700Bold', fontSize: 10, color: COLORS.grey },
+  avatar: {
+    width: 30,
+    height: 30,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Activity feed
+  actRow: { flexDirection: 'row', alignItems: 'center', gap: 9, paddingVertical: 5 },
+  actIcon: {
+    width: 26,
+    height: 26,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.black },
+  actVerb: { fontFamily: 'Nunito_400Regular', color: COLORS.grey },
+  actTime: { fontFamily: 'Nunito_700Bold', fontSize: 10.5, color: COLORS.grey },
+  // "Open review" action + pending badge
+  mini: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: '#efe6d6',
+    borderRadius: 8,
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+  },
+  miniText: { fontFamily: 'Nunito_700Bold', fontSize: 12, color: COLORS.navy },
+  pendBadge: {
+    minWidth: 16,
+    height: 16,
+    borderRadius: 999,
+    paddingHorizontal: 4,
+    backgroundColor: COLORS.orange,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pendText: { fontFamily: 'Nunito_700Bold', fontSize: 9.5, color: '#fff' },
+  locked: { alignItems: 'center', gap: 8, paddingVertical: 24 },
+  lockedText: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.grey,
+    textAlign: 'center',
+    maxWidth: 360,
+  },
+});

--- a/src/components/admin/health/domains/TrafficDomain.tsx
+++ b/src/components/admin/health/domains/TrafficDomain.tsx
@@ -1,0 +1,193 @@
+// Traffic domain — self-hosted web analytics (page_views) for the command
+// center. Read-only view of the admin_traffic_overview() RPC: headline totals +
+// live "active now", a daily trend, and top pages / referrers / device split.
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../../../constants/colors';
+import { Panel } from '../Panel';
+import { Bento } from '../Bento';
+import { StatTile, EmptyState } from '../ui';
+import type {
+  TrafficOverview,
+  RouteViews,
+  ReferrerViews,
+  DeviceViews,
+} from '../../../../lib/db/traffic';
+
+// Horizontal bar-list row: label on the left, a proportional fill, value right.
+function BarRow({ label, value, max }: { label: string; value: number; max: number }) {
+  const pct = max > 0 ? Math.max(4, Math.round((value / max) * 100)) : 0;
+  return (
+    <View style={s.barRow}>
+      <View style={s.barLabelWrap}>
+        <Text style={s.barLabel} numberOfLines={1}>
+          {label}
+        </Text>
+        <Text style={s.barVal}>{value.toLocaleString()}</Text>
+      </View>
+      <View style={s.barTrack}>
+        <View style={[s.barFill, { width: `${pct}%` }]} />
+      </View>
+    </View>
+  );
+}
+
+function BarList<T>({
+  rows,
+  empty,
+  label,
+  value,
+}: {
+  rows: T[];
+  empty: string;
+  label: (r: T) => string;
+  value: (r: T) => number;
+}) {
+  if (rows.length === 0) return <EmptyState text={empty} />;
+  const max = Math.max(1, ...rows.map(value));
+  return (
+    <View style={s.barList}>
+      {rows.map((r, i) => (
+        <BarRow key={i} label={label(r)} value={value(r)} max={max} />
+      ))}
+    </View>
+  );
+}
+
+export function TrafficDomain({
+  data,
+  loading,
+  narrow,
+}: {
+  data: TrafficOverview | null;
+  loading: boolean;
+  narrow: boolean;
+}) {
+  if (loading && !data) {
+    return (
+      <Panel title="Traffic">
+        <ActivityIndicator color={COLORS.orange} style={{ marginTop: 16 }} />
+      </Panel>
+    );
+  }
+  if (!data) {
+    return (
+      <Panel title="Traffic">
+        <View style={s.locked}>
+          <Ionicons name="lock-closed-outline" size={26} color={COLORS.grey} />
+          <Text style={s.lockedText}>
+            Traffic analytics are admin-only, or no page views have been recorded yet.
+          </Text>
+        </View>
+      </Panel>
+    );
+  }
+
+  const days = data.series;
+  const maxViews = Math.max(1, ...days.map((d) => d.views));
+
+  return (
+    <Bento>
+      <Bento.Row narrow={narrow}>
+        {/* Headline */}
+        <Panel title="Traffic" hint={`Last ${data.rangeDays} days`} style={s.flex15}>
+          <View style={s.tiles}>
+            <StatTile
+              label="Page views"
+              value={data.totals.pageViews.toLocaleString()}
+              tint={COLORS.navy}
+            />
+            <StatTile
+              label="Visitors"
+              value={data.totals.visitors.toLocaleString()}
+              tint={COLORS.blue}
+            />
+            <StatTile
+              label="Active now"
+              value={data.activeNow.toLocaleString()}
+              tint={COLORS.green}
+            />
+          </View>
+        </Panel>
+
+        {/* Devices */}
+        <Panel title="Devices" hint="Views by device" style={s.flex1}>
+          <BarList<DeviceViews>
+            rows={data.devices}
+            empty="No device data yet."
+            label={(d) => d.label}
+            value={(d) => d.views}
+          />
+        </Panel>
+      </Bento.Row>
+
+      {/* Traffic over time */}
+      <Panel title="Traffic over time" hint="Page views per day">
+        {days.length === 0 || maxViews === 1 ? (
+          <EmptyState text="No views recorded yet — the trend fills in daily." />
+        ) : (
+          <View style={s.bars}>
+            {days.map((d) => (
+              <View key={d.day} style={s.barCol}>
+                <View style={s.barColTrack}>
+                  <View
+                    style={[s.barColFill, { height: `${Math.round((d.views / maxViews) * 100)}%` }]}
+                  />
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+      </Panel>
+
+      <Bento.Row narrow={narrow}>
+        {/* Top pages */}
+        <Panel title="Top pages" hint="Grouped routes" style={s.flex1}>
+          <BarList<RouteViews>
+            rows={data.topPages}
+            empty="No page views yet."
+            label={(r) => r.route}
+            value={(r) => r.views}
+          />
+        </Panel>
+
+        {/* Top referrers */}
+        <Panel title="Top referrers" hint="Where visitors arrive from" style={s.flex1}>
+          <BarList<ReferrerViews>
+            rows={data.topReferrers}
+            empty="No external referrers yet."
+            label={(r) => r.source}
+            value={(r) => r.views}
+          />
+        </Panel>
+      </Bento.Row>
+    </Bento>
+  );
+}
+
+const s = StyleSheet.create({
+  flex1: { flex: 1 },
+  flex15: { flex: 1.5 },
+  tiles: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  // Daily trend (vertical bars)
+  bars: { flexDirection: 'row', alignItems: 'flex-end', gap: 2, height: 90, marginTop: 4 },
+  barCol: { flex: 1, height: '100%', justifyContent: 'flex-end' },
+  barColTrack: { width: '100%', height: '100%', justifyContent: 'flex-end' },
+  barColFill: { width: '100%', backgroundColor: COLORS.blue, borderRadius: 2, minHeight: 2 },
+  // Horizontal bar lists
+  barList: { gap: 8 },
+  barRow: { gap: 4 },
+  barLabelWrap: { flexDirection: 'row', justifyContent: 'space-between', gap: 8 },
+  barLabel: { flex: 1, fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.black },
+  barVal: { fontFamily: 'Flame-Regular', fontSize: 13, color: COLORS.navy },
+  barTrack: { height: 6, borderRadius: 999, backgroundColor: '#efe6d6', overflow: 'hidden' },
+  barFill: { height: '100%', borderRadius: 999, backgroundColor: COLORS.orange },
+  locked: { alignItems: 'center', gap: 8, paddingVertical: 24 },
+  lockedText: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.grey,
+    textAlign: 'center',
+    maxWidth: 360,
+  },
+});

--- a/src/components/admin/health/format.ts
+++ b/src/components/admin/health/format.ts
@@ -158,7 +158,7 @@ export type DomainKey =
   | 'pipelines'
   | 'campaigns'
   | 'spend'
-  | 'users'
+  | 'community'
   | 'traffic';
 
 export interface DomainDef {
@@ -178,7 +178,7 @@ export const DOMAINS: DomainDef[] = [
   { key: 'pipelines', label: 'Build', icon: 'construct-outline' },
   { key: 'campaigns', label: 'Campaigns', icon: 'megaphone-outline' },
   { key: 'spend', label: 'Spend', icon: 'cash-outline' },
-  { key: 'users', label: 'Users', icon: 'people-outline', placeholder: true },
+  { key: 'community', label: 'Community', icon: 'people-outline' },
   { key: 'traffic', label: 'Traffic', icon: 'trending-up-outline', placeholder: true },
 ];
 

--- a/src/components/admin/health/format.ts
+++ b/src/components/admin/health/format.ts
@@ -179,7 +179,7 @@ export const DOMAINS: DomainDef[] = [
   { key: 'campaigns', label: 'Campaigns', icon: 'megaphone-outline' },
   { key: 'spend', label: 'Spend', icon: 'cash-outline' },
   { key: 'community', label: 'Community', icon: 'people-outline' },
-  { key: 'traffic', label: 'Traffic', icon: 'trending-up-outline', placeholder: true },
+  { key: 'traffic', label: 'Traffic', icon: 'trending-up-outline' },
 ];
 
 /** Primary (non-placeholder) domain keys — the mobile bottom-bar set. */

--- a/src/components/admin/health/hooks.ts
+++ b/src/components/admin/health/hooks.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../lib/db/catalogHealth';
 import { getPendingStatsCount } from '../../../lib/db/stats';
 import { getPendingPortraitCount } from '../../../lib/db/portraits';
+import { fetchCommunityOverview } from '../../../lib/db/community';
 import type { LogTone, LogEntry, DomainKey } from './format';
 
 type Flash = (msg: string, tone?: LogTone) => void;
@@ -70,6 +71,7 @@ export function useCatalogQueries({
   const onCatalog = domain === 'catalog';
   const onBuild = domain === 'pipelines';
   const onSpend = domain === 'spend';
+  const onCommunity = domain === 'community';
 
   const healthQ = useQuery({
     queryKey: ['catalogHealth'],
@@ -166,6 +168,12 @@ export function useCatalogQueries({
     enabled: enabled && onBuild,
     staleTime: 15_000,
   });
+  const communityQ = useQuery({
+    queryKey: ['communityOverview'],
+    queryFn: fetchCommunityOverview,
+    enabled: enabled && onCommunity,
+    staleTime: 60_000,
+  });
 
   // While a run is in flight, poll backlog + usage so the live numbers tick down.
   const runsData = runsQ.data;
@@ -212,6 +220,7 @@ export function useCatalogQueries({
     statsPendingQ,
     portraitsPendingQ,
     recentEnrichedQ,
+    communityQ,
   };
 }
 

--- a/src/components/admin/health/hooks.ts
+++ b/src/components/admin/health/hooks.ts
@@ -35,6 +35,7 @@ import {
 import { getPendingStatsCount } from '../../../lib/db/stats';
 import { getPendingPortraitCount } from '../../../lib/db/portraits';
 import { fetchCommunityOverview } from '../../../lib/db/community';
+import { fetchTrafficOverview } from '../../../lib/db/traffic';
 import type { LogTone, LogEntry, DomainKey } from './format';
 
 type Flash = (msg: string, tone?: LogTone) => void;
@@ -72,6 +73,7 @@ export function useCatalogQueries({
   const onBuild = domain === 'pipelines';
   const onSpend = domain === 'spend';
   const onCommunity = domain === 'community';
+  const onTraffic = domain === 'traffic';
 
   const healthQ = useQuery({
     queryKey: ['catalogHealth'],
@@ -174,6 +176,12 @@ export function useCatalogQueries({
     enabled: enabled && onCommunity,
     staleTime: 60_000,
   });
+  const trafficQ = useQuery({
+    queryKey: ['trafficOverview'],
+    queryFn: () => fetchTrafficOverview(28),
+    enabled: enabled && onTraffic,
+    staleTime: 5 * 60_000,
+  });
 
   // While a run is in flight, poll backlog + usage so the live numbers tick down.
   const runsData = runsQ.data;
@@ -221,6 +229,7 @@ export function useCatalogQueries({
     portraitsPendingQ,
     recentEnrichedQ,
     communityQ,
+    trafficQ,
   };
 }
 

--- a/src/hooks/usePresenceHeartbeat.ts
+++ b/src/hooks/usePresenceHeartbeat.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useAuth } from './useAuth';
+import { touchLastSeen } from '../lib/db/presence';
+
+// How often to re-stamp last_seen_at while the app is foregrounded. 60s keeps
+// the "online now" window (5 min, server-side) comfortably fresh without chatty
+// writes.
+const HEARTBEAT_MS = 60_000;
+
+/**
+ * Keeps the signed-in user's presence fresh: an immediate beat on sign-in, then
+ * every 60s, plus one whenever the app/tab returns to the foreground. No-op when
+ * logged out (the RPC is anon-rejected anyway). Mount once, app-wide.
+ */
+export function usePresenceHeartbeat(): void {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user) return;
+    let active = true;
+    const beat = () => {
+      if (active) void touchLastSeen();
+    };
+
+    beat(); // stamp immediately on mount / sign-in
+    const interval = setInterval(beat, HEARTBEAT_MS);
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') beat();
+    });
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+      sub.remove();
+    };
+  }, [user]);
+}

--- a/src/lib/db/community.ts
+++ b/src/lib/db/community.ts
@@ -45,6 +45,8 @@ export interface PresenceSummary {
   onlineNow: number;
   /** Signed-in members seen in the last 24 hours. */
   activeToday: number;
+  /** Visitors (anon + signed-in) active in page_views in the last 5 min. */
+  activeVisitors: number;
   /** Most-recently-seen members (up to 8). */
   recent: OnlineMember[];
 }

--- a/src/lib/db/community.ts
+++ b/src/lib/db/community.ts
@@ -79,10 +79,7 @@ type OverviewJson = ({ authorized: false } | ({ authorized: true } & CommunityOv
  * instead of crashing.
  */
 export async function fetchCommunityOverview(): Promise<CommunityOverview | null> {
-  // NOTE: `admin_community_overview` is absent from database.generated.ts until
-  // the migration is applied and types are regenerated (Supabase MCP). The name
-  // cast keeps this compiling in the meantime; drop it after regeneration.
-  const { data, error } = await supabase.rpc('admin_community_overview' as never);
+  const { data, error } = await supabase.rpc('admin_community_overview');
   if (error) {
     console.warn('[fetchCommunityOverview] error:', error.message);
     return null;

--- a/src/lib/db/community.ts
+++ b/src/lib/db/community.ts
@@ -1,0 +1,82 @@
+import { supabase } from '../supabase';
+
+// Read layer for the command-center "Community" domain. All aggregation happens
+// server-side in the admin-guarded admin_community_overview() RPC (the per-user
+// tables carry RLS); this wrapper just invokes it and shapes the loose JSON.
+
+export interface HeroStat {
+  id: string;
+  name: string;
+  image_url: string | null;
+  publisher: string | null;
+  count: number;
+  /** Only present on the "most-backed" leaderboard (picked / appearances). */
+  winRate?: number | null;
+}
+
+export interface Contributor {
+  userId: string;
+  displayName: string | null;
+  approved: number;
+  level: string | null;
+}
+
+export type ActivityKind = 'favourite' | 'view' | 'compare' | 'vote' | 'contribution';
+
+export interface ActivityItem {
+  kind: ActivityKind;
+  at: string;
+  heroId: string;
+  heroName: string;
+  /** Verdict text (compare) or "edited <field>" (contribution); else null. */
+  text?: string | null;
+}
+
+export interface CommunityOverview {
+  totals: {
+    members: number;
+    favourites: number;
+    views: number;
+    compares: number;
+    votes: number;
+    contributions: number;
+  };
+  topViewed: HeroStat[];
+  topFavourited: HeroStat[];
+  topBacked: HeroStat[];
+  topContributors: Contributor[];
+  contributionsByStatus: { pending: number; approved: number; rejected: number };
+  recent: ActivityItem[];
+}
+
+// Shape returned by the RPC. `authorized:false` for non-admins; otherwise the
+// full overview is spread alongside it.
+type OverviewJson = ({ authorized: false } | ({ authorized: true } & CommunityOverview)) | null;
+
+/**
+ * Fetch the whole community overview in one round trip. Returns `null` when the
+ * caller isn't an admin or on error, so the UI shows a calm empty/locked state
+ * instead of crashing.
+ */
+export async function fetchCommunityOverview(): Promise<CommunityOverview | null> {
+  // NOTE: `admin_community_overview` is absent from database.generated.ts until
+  // the migration is applied and types are regenerated (Supabase MCP). The name
+  // cast keeps this compiling in the meantime; drop it after regeneration.
+  const { data, error } = await supabase.rpc('admin_community_overview' as never);
+  if (error) {
+    console.warn('[fetchCommunityOverview] error:', error.message);
+    return null;
+  }
+  const json = data as unknown as OverviewJson;
+  if (!json || json.authorized !== true) return null;
+  // Re-pick the fields explicitly so the `authorized` flag never leaks out.
+  return {
+    totals: json.totals,
+    topViewed: json.topViewed,
+    topFavourited: json.topFavourited,
+    topBacked: json.topBacked,
+    topContributors: json.topContributors,
+    contributionsByStatus: json.contributionsByStatus,
+    recent: json.recent,
+  };
+}

--- a/src/lib/db/community.ts
+++ b/src/lib/db/community.ts
@@ -32,6 +32,23 @@ export interface ActivityItem {
   text?: string | null;
 }
 
+export interface OnlineMember {
+  userId: string;
+  displayName: string | null;
+  lastSeenAt: string;
+  /** Seen within the last 5 minutes (computed server-side). */
+  live: boolean;
+}
+
+export interface PresenceSummary {
+  /** Signed-in members seen in the last 5 minutes. */
+  onlineNow: number;
+  /** Signed-in members seen in the last 24 hours. */
+  activeToday: number;
+  /** Most-recently-seen members (up to 8). */
+  recent: OnlineMember[];
+}
+
 export interface CommunityOverview {
   totals: {
     members: number;
@@ -41,6 +58,7 @@ export interface CommunityOverview {
     votes: number;
     contributions: number;
   };
+  online: PresenceSummary;
   topViewed: HeroStat[];
   topFavourited: HeroStat[];
   topBacked: HeroStat[];
@@ -72,6 +90,7 @@ export async function fetchCommunityOverview(): Promise<CommunityOverview | null
   // Re-pick the fields explicitly so the `authorized` flag never leaks out.
   return {
     totals: json.totals,
+    online: json.online,
     topViewed: json.topViewed,
     topFavourited: json.topFavourited,
     topBacked: json.topBacked,

--- a/src/lib/db/pageViews.ts
+++ b/src/lib/db/pageViews.ts
@@ -46,13 +46,6 @@ function getReferrerHost(): string | null {
   }
 }
 
-// Minimal insert surface so we can target page_views before it lands in
-// database.generated.ts (regenerate types after applying the migration to drop
-// the cast). Keeps us off `any`.
-interface InsertOnly {
-  insert: (row: Record<string, unknown>) => Promise<{ error: unknown }>;
-}
-
 /** Record one page view. Web only; no-ops cleanly off-web or on failure. */
 export async function recordPageView(route: string, path: string): Promise<void> {
   if (typeof window === 'undefined') return;
@@ -60,8 +53,7 @@ export async function recordPageView(route: string, path: string): Promise<void>
     const {
       data: { session },
     } = await supabase.auth.getSession();
-    const table = supabase.from('page_views' as never) as unknown as InsertOnly;
-    await table.insert({
+    await supabase.from('page_views').insert({
       route,
       path,
       user_id: session?.user?.id ?? null,

--- a/src/lib/db/pageViews.ts
+++ b/src/lib/db/pageViews.ts
@@ -1,0 +1,75 @@
+import { supabase } from '../supabase';
+
+// Self-hosted page-view collection (web only). Called from Analytics.web.tsx on
+// every navigation; fire-and-forget so it never blocks or surfaces errors.
+// page_views is insert-only + RLS-locked (reads go through admin_traffic_overview).
+
+const SESSION_KEY = 'mythique_sid';
+
+// Stable per-browser id so we can count unique visitors without identifying them.
+function getSessionId(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    let sid = localStorage.getItem(SESSION_KEY);
+    if (!sid) {
+      sid =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2) + Date.now().toString(36);
+      localStorage.setItem(SESSION_KEY, sid);
+    }
+    return sid;
+  } catch {
+    return null; // private mode / storage disabled
+  }
+}
+
+function getDevice(): string {
+  if (typeof navigator === 'undefined') return 'unknown';
+  const ua = navigator.userAgent || '';
+  if (/iPad|Tablet|PlayBook|Silk/i.test(ua) || (/Android/i.test(ua) && !/Mobile/i.test(ua))) {
+    return 'tablet';
+  }
+  if (/Mobi|iPhone|iPod|Android.*Mobile|Windows Phone/i.test(ua)) return 'mobile';
+  return 'desktop';
+}
+
+// Referring host, only when it's a different origin (skip internal navigation).
+function getReferrerHost(): string | null {
+  if (typeof document === 'undefined' || !document.referrer) return null;
+  try {
+    const ref = new URL(document.referrer);
+    if (typeof location !== 'undefined' && ref.host === location.host) return null;
+    return ref.host;
+  } catch {
+    return null;
+  }
+}
+
+// Minimal insert surface so we can target page_views before it lands in
+// database.generated.ts (regenerate types after applying the migration to drop
+// the cast). Keeps us off `any`.
+interface InsertOnly {
+  insert: (row: Record<string, unknown>) => Promise<{ error: unknown }>;
+}
+
+/** Record one page view. Web only; no-ops cleanly off-web or on failure. */
+export async function recordPageView(route: string, path: string): Promise<void> {
+  if (typeof window === 'undefined') return;
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    const table = supabase.from('page_views' as never) as unknown as InsertOnly;
+    await table.insert({
+      route,
+      path,
+      user_id: session?.user?.id ?? null,
+      session_id: getSessionId(),
+      referrer: getReferrerHost(),
+      device: getDevice(),
+    });
+  } catch {
+    // fire-and-forget — analytics writes must never break navigation
+  }
+}

--- a/src/lib/db/presence.ts
+++ b/src/lib/db/presence.ts
@@ -4,10 +4,7 @@ import { supabase } from '../supabase';
 // the touch_last_seen() RPC (no-op for anon). Fire-and-forget: presence is a
 // nice-to-have signal, never worth surfacing an error or blocking the UI.
 export async function touchLastSeen(): Promise<void> {
-  // NOTE: `touch_last_seen` is absent from database.generated.ts until the
-  // migration is applied and types are regenerated (Supabase MCP). The name cast
-  // keeps this compiling in the meantime; drop it after regeneration.
-  const { error } = await supabase.rpc('touch_last_seen' as never);
+  const { error } = await supabase.rpc('touch_last_seen');
   if (error) {
     // Swallow — heartbeat failures are non-fatal.
   }

--- a/src/lib/db/presence.ts
+++ b/src/lib/db/presence.ts
@@ -1,0 +1,14 @@
+import { supabase } from '../supabase';
+
+// Presence heartbeat. Stamps the signed-in user's last_seen_at server-side via
+// the touch_last_seen() RPC (no-op for anon). Fire-and-forget: presence is a
+// nice-to-have signal, never worth surfacing an error or blocking the UI.
+export async function touchLastSeen(): Promise<void> {
+  // NOTE: `touch_last_seen` is absent from database.generated.ts until the
+  // migration is applied and types are regenerated (Supabase MCP). The name cast
+  // keeps this compiling in the meantime; drop it after regeneration.
+  const { error } = await supabase.rpc('touch_last_seen' as never);
+  if (error) {
+    // Swallow — heartbeat failures are non-fatal.
+  }
+}

--- a/src/lib/db/traffic.ts
+++ b/src/lib/db/traffic.ts
@@ -41,15 +41,7 @@ type OverviewJson = ({ authorized: false } | ({ authorized: true } & TrafficOver
  * state rather than crashing.
  */
 export async function fetchTrafficOverview(days = 28): Promise<TrafficOverview | null> {
-  // NOTE: `admin_traffic_overview` is absent from database.generated.ts until
-  // the migration is applied and types are regenerated (Supabase MCP). The name
-  // cast keeps this compiling in the meantime; drop it after regeneration.
-  const { data, error } = await supabase.rpc(
-    'admin_traffic_overview' as never,
-    {
-      p_days: days,
-    } as never,
-  );
+  const { data, error } = await supabase.rpc('admin_traffic_overview', { p_days: days });
   if (error) {
     console.warn('[fetchTrafficOverview] error:', error.message);
     return null;

--- a/src/lib/db/traffic.ts
+++ b/src/lib/db/traffic.ts
@@ -1,0 +1,68 @@
+import { supabase } from '../supabase';
+
+// Read layer for the command-center "Traffic" domain. Aggregation happens
+// server-side in the admin-guarded admin_traffic_overview() RPC (page_views is
+// RLS-locked to inserts); this wrapper invokes it and shapes the loose JSON.
+
+export interface TrafficSeriesPoint {
+  day: string;
+  views: number;
+  visitors: number;
+}
+export interface RouteViews {
+  route: string;
+  views: number;
+}
+export interface ReferrerViews {
+  source: string;
+  views: number;
+}
+export interface DeviceViews {
+  label: string;
+  views: number;
+}
+
+export interface TrafficOverview {
+  rangeDays: number;
+  totals: { pageViews: number; visitors: number };
+  /** Unique visitors seen in the last 5 minutes. */
+  activeNow: number;
+  series: TrafficSeriesPoint[];
+  topPages: RouteViews[];
+  topReferrers: ReferrerViews[];
+  devices: DeviceViews[];
+}
+
+type OverviewJson = ({ authorized: false } | ({ authorized: true } & TrafficOverview)) | null;
+
+/**
+ * Fetch the traffic overview for the last `days` calendar days. Returns `null`
+ * when the caller isn't an admin or on error, so the UI shows an empty/locked
+ * state rather than crashing.
+ */
+export async function fetchTrafficOverview(days = 28): Promise<TrafficOverview | null> {
+  // NOTE: `admin_traffic_overview` is absent from database.generated.ts until
+  // the migration is applied and types are regenerated (Supabase MCP). The name
+  // cast keeps this compiling in the meantime; drop it after regeneration.
+  const { data, error } = await supabase.rpc(
+    'admin_traffic_overview' as never,
+    {
+      p_days: days,
+    } as never,
+  );
+  if (error) {
+    console.warn('[fetchTrafficOverview] error:', error.message);
+    return null;
+  }
+  const json = data as unknown as OverviewJson;
+  if (!json || json.authorized !== true) return null;
+  return {
+    rangeDays: json.rangeDays,
+    totals: json.totals,
+    activeNow: json.activeNow,
+    series: json.series,
+    topPages: json.topPages,
+    topReferrers: json.topReferrers,
+    devices: json.devices,
+  };
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -908,6 +908,39 @@ export type Database = {
         }
         Relationships: []
       }
+      page_views: {
+        Row: {
+          created_at: string
+          device: string | null
+          id: number
+          path: string
+          referrer: string | null
+          route: string
+          session_id: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          device?: string | null
+          id?: never
+          path: string
+          referrer?: string | null
+          route: string
+          session_id?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          device?: string | null
+          id?: never
+          path?: string
+          referrer?: string | null
+          route?: string
+          session_id?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       team_battle_votes: {
         Row: {
           created_at: string
@@ -1155,6 +1188,7 @@ export type Database = {
           display_name: string | null
           id: string
           is_admin: boolean
+          last_seen_at: string | null
         }
         Insert: {
           avatar_url?: string | null
@@ -1163,6 +1197,7 @@ export type Database = {
           display_name?: string | null
           id: string
           is_admin?: boolean
+          last_seen_at?: string | null
         }
         Update: {
           avatar_url?: string | null
@@ -1171,6 +1206,7 @@ export type Database = {
           display_name?: string | null
           id?: string
           is_admin?: boolean
+          last_seen_at?: string | null
         }
         Relationships: []
       }
@@ -1234,6 +1270,7 @@ export type Database = {
           id: string
         }[]
       }
+      admin_community_overview: { Args: never; Returns: Json }
       admin_cron_status: { Args: never; Returns: Json }
       admin_delete_campaign: { Args: { p_id: string }; Returns: number }
       admin_delete_hero: { Args: { p_hero_id: string }; Returns: number }
@@ -1277,6 +1314,7 @@ export type Database = {
         Args: { p_enabled: boolean; p_jobname: string }
         Returns: string
       }
+      admin_traffic_overview: { Args: { p_days?: number }; Returns: Json }
       admin_upsert_campaign: {
         Args: {
           p_accent?: string
@@ -1566,6 +1604,7 @@ export type Database = {
         }
         Returns: Json
       }
+      touch_last_seen: { Args: never; Returns: undefined }
     }
     Enums: {
       relation_kind:

--- a/supabase/migrations/20260623120000_admin_community_overview.sql
+++ b/supabase/migrations/20260623120000_admin_community_overview.sql
@@ -1,0 +1,116 @@
+-- Read-only community / engagement analytics for the Mythique Command Center's
+-- "Community" domain. One admin-guarded SECURITY DEFINER round trip that
+-- aggregates the per-user tables (each of which individually carries RLS) into a
+-- single JSON object. Mirrors the established admin_* pattern: self-guards on
+-- user_profiles.is_admin, returns { authorized:false } for everyone else, and is
+-- revoked from anon. Leaderboards capped at 8, the activity feed at 12, so the
+-- whole thing stays one cheap query.
+
+create or replace function public.admin_community_overview()
+returns json language plpgsql security definer set search_path = public stable
+as $$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'totals', json_build_object(
+      'members',       (select count(*) from public.user_profiles),
+      'favourites',    (select count(*) from public.user_favourites),
+      'views',         (select count(*) from public.user_view_history),
+      'compares',      (select count(*) from public.verdicts),
+      'votes',         (select count(*) from public.matchup_votes),
+      'contributions', (select count(*) from public.contributions)
+    ),
+    -- Most-viewed heroes (top 8 by distinct-or-not view rows).
+    'topViewed', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_view_history v
+      join public.heroes h on h.id = v.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    -- Most-favourited heroes (top 8).
+    'topFavourited', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_favourites f
+      join public.heroes h on h.id = f.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    -- Most-backed heroes: matchup_votes.picked_id tally + win rate
+    -- (times picked / times appearing in any matchup as either side).
+    'topBacked', (select coalesce(json_agg(r), '[]'::json) from (
+      with picks as (
+        select picked_id as hero_id, count(*)::int as picked
+        from public.matchup_votes
+        group by picked_id
+      ),
+      appearances as (
+        select hero_id, count(*)::int as total from (
+          select hero_a_id as hero_id from public.matchup_votes
+          union all
+          select hero_b_id from public.matchup_votes
+        ) a
+        group by hero_id
+      )
+      select h.id, h.name, h.image_url, h.publisher,
+             p.picked as count,
+             case when ap.total > 0 then round(100.0 * p.picked / ap.total)::int else null end as "winRate"
+      from picks p
+      join public.heroes h on h.id = p.hero_id
+      left join appearances ap on ap.hero_id = p.hero_id
+      order by p.picked desc
+      limit 8
+    ) r),
+    -- Top contributors (pre-aggregated; read-only, no moderation here).
+    'topContributors', (select coalesce(json_agg(r), '[]'::json) from (
+      select cs.user_id as "userId", p.display_name as "displayName",
+             cs.approved, cs.level
+      from public.contributor_stats cs
+      left join public.user_profiles p on p.id = cs.user_id
+      order by cs.approved desc, cs.updated_at desc
+      limit 8
+    ) r),
+    'contributionsByStatus', (select json_build_object(
+      'pending',  count(*) filter (where status = 'pending'),
+      'approved', count(*) filter (where status = 'approved'),
+      'rejected', count(*) filter (where status = 'rejected')
+    ) from public.contributions),
+    -- Unified newest-first activity feed across the five engagement signals.
+    'recent', (select coalesce(json_agg(r), '[]'::json) from (
+      select kind, at, "heroId", "heroName", text from (
+        select 'view'::text as kind, v.viewed_at as at,
+               h.id as "heroId", h.name as "heroName", null::text as text
+          from public.user_view_history v join public.heroes h on h.id = v.hero_id
+        union all
+        select 'favourite', f.created_at, h.id, h.name, null
+          from public.user_favourites f join public.heroes h on h.id = f.hero_id
+        union all
+        select 'vote', mv.created_at, h.id, h.name, null
+          from public.matchup_votes mv join public.heroes h on h.id = mv.picked_id
+        union all
+        select 'compare', vd.created_at, h.id, h.name, vd.verdict
+          from public.verdicts vd join public.heroes h on h.id = vd.hero_a_id
+        union all
+        select 'contribution', c.created_at, h.id, h.name,
+               coalesce('edited ' || c.target_field, c.kind)
+          from public.contributions c join public.heroes h on h.id = c.hero_id
+      ) u
+      order by at desc nulls last
+      limit 12
+    ) r)
+  );
+end;
+$$;
+
+revoke all on function public.admin_community_overview() from public, anon;
+grant execute on function public.admin_community_overview() to authenticated, service_role;

--- a/supabase/migrations/20260623130000_user_presence.sql
+++ b/supabase/migrations/20260623130000_user_presence.sql
@@ -1,0 +1,141 @@
+-- Presence backbone for the command-center "who's online" view.
+-- Two parts:
+--   1. user_profiles.last_seen_at + a throttled heartbeat RPC (touch_last_seen),
+--      called ~once/min by signed-in clients.
+--   2. admin_community_overview() gains an `online` block (online now / active
+--      today / most-recently-seen members), so the Community domain can show
+--      named-user presence. Anonymous "active visitors" arrives with Phase 3's
+--      page_views table.
+-- The function is re-stated in full (CREATE OR REPLACE) because migrations are
+-- append-only; the only change vs 20260623120000 is the added `online` key.
+
+alter table public.user_profiles add column if not exists last_seen_at timestamptz;
+create index if not exists user_profiles_last_seen_idx on public.user_profiles (last_seen_at desc);
+
+-- Throttled heartbeat: stamps the caller's last_seen_at. Cheap; clients call it
+-- on focus + on a ~60s interval. No-op (0 rows) for anon, which can't execute it.
+create or replace function public.touch_last_seen()
+returns void language sql security definer set search_path = public as $$
+  update public.user_profiles set last_seen_at = now() where id = auth.uid();
+$$;
+revoke all on function public.touch_last_seen() from public, anon;
+grant execute on function public.touch_last_seen() to authenticated, service_role;
+
+create or replace function public.admin_community_overview()
+returns json language plpgsql security definer set search_path = public stable
+as $$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'totals', json_build_object(
+      'members',       (select count(*) from public.user_profiles),
+      'favourites',    (select count(*) from public.user_favourites),
+      'views',         (select count(*) from public.user_view_history),
+      'compares',      (select count(*) from public.verdicts),
+      'votes',         (select count(*) from public.matchup_votes),
+      'contributions', (select count(*) from public.contributions)
+    ),
+    -- Named-user presence. onlineNow = seen in the last 5 min; activeToday = 24h.
+    'online', json_build_object(
+      'onlineNow',   (select count(*) from public.user_profiles
+                        where last_seen_at > now() - interval '5 minutes'),
+      'activeToday', (select count(*) from public.user_profiles
+                        where last_seen_at > now() - interval '1 day'),
+      'recent', (select coalesce(json_agg(r), '[]'::json) from (
+        select id as "userId", display_name as "displayName",
+               last_seen_at as "lastSeenAt",
+               (last_seen_at > now() - interval '5 minutes') as "live"
+        from public.user_profiles
+        where last_seen_at is not null
+        order by last_seen_at desc
+        limit 8
+      ) r)
+    ),
+    'topViewed', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_view_history v
+      join public.heroes h on h.id = v.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topFavourited', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_favourites f
+      join public.heroes h on h.id = f.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topBacked', (select coalesce(json_agg(r), '[]'::json) from (
+      with picks as (
+        select picked_id as hero_id, count(*)::int as picked
+        from public.matchup_votes
+        group by picked_id
+      ),
+      appearances as (
+        select hero_id, count(*)::int as total from (
+          select hero_a_id as hero_id from public.matchup_votes
+          union all
+          select hero_b_id from public.matchup_votes
+        ) a
+        group by hero_id
+      )
+      select h.id, h.name, h.image_url, h.publisher,
+             p.picked as count,
+             case when ap.total > 0 then round(100.0 * p.picked / ap.total)::int else null end as "winRate"
+      from picks p
+      join public.heroes h on h.id = p.hero_id
+      left join appearances ap on ap.hero_id = p.hero_id
+      order by p.picked desc
+      limit 8
+    ) r),
+    'topContributors', (select coalesce(json_agg(r), '[]'::json) from (
+      select cs.user_id as "userId", p.display_name as "displayName",
+             cs.approved, cs.level
+      from public.contributor_stats cs
+      left join public.user_profiles p on p.id = cs.user_id
+      order by cs.approved desc, cs.updated_at desc
+      limit 8
+    ) r),
+    'contributionsByStatus', (select json_build_object(
+      'pending',  count(*) filter (where status = 'pending'),
+      'approved', count(*) filter (where status = 'approved'),
+      'rejected', count(*) filter (where status = 'rejected')
+    ) from public.contributions),
+    'recent', (select coalesce(json_agg(r), '[]'::json) from (
+      select kind, at, "heroId", "heroName", text from (
+        select 'view'::text as kind, v.viewed_at as at,
+               h.id as "heroId", h.name as "heroName", null::text as text
+          from public.user_view_history v join public.heroes h on h.id = v.hero_id
+        union all
+        select 'favourite', f.created_at, h.id, h.name, null
+          from public.user_favourites f join public.heroes h on h.id = f.hero_id
+        union all
+        select 'vote', mv.created_at, h.id, h.name, null
+          from public.matchup_votes mv join public.heroes h on h.id = mv.picked_id
+        union all
+        select 'compare', vd.created_at, h.id, h.name, vd.verdict
+          from public.verdicts vd join public.heroes h on h.id = vd.hero_a_id
+        union all
+        select 'contribution', c.created_at, h.id, h.name,
+               coalesce('edited ' || c.target_field, c.kind)
+          from public.contributions c join public.heroes h on h.id = c.hero_id
+      ) u
+      order by at desc nulls last
+      limit 12
+    ) r)
+  );
+end;
+$$;
+
+revoke all on function public.admin_community_overview() from public, anon;
+grant execute on function public.admin_community_overview() to authenticated, service_role;

--- a/supabase/migrations/20260623140000_page_views.sql
+++ b/supabase/migrations/20260623140000_page_views.sql
@@ -1,0 +1,36 @@
+-- Self-hosted web page-view events — the collection side of the command-center
+-- "Traffic" domain (we self-host rather than depend on the plan-gated Vercel
+-- Analytics read API). Written client-side from Analytics.web.tsx, which already
+-- computes the matched `route` (e.g. /character/[id]) and concrete `path`, so
+-- dynamic routes stay grouped.
+--
+-- Privacy: rows are insert-only from clients; there is NO public select policy,
+-- so the table is unreadable except through the admin-guarded
+-- admin_traffic_overview() RPC. user_id is set for signed-in views (FK set null
+-- if the account is later deleted), null for anon; session_id is a random,
+-- client-persisted id used to count unique visitors without identifying anyone.
+create table if not exists public.page_views (
+  id         bigint generated always as identity primary key,
+  route      text not null,          -- matched pattern, e.g. /character/[id]
+  path       text not null,          -- concrete url, e.g. /character/123
+  user_id    uuid references auth.users(id) on delete set null,
+  session_id text,                   -- anon client id (random, persisted client-side)
+  referrer   text,                   -- referring host, when cross-origin
+  device     text,                   -- 'desktop' | 'mobile' | 'tablet'
+  created_at timestamptz not null default now()
+);
+create index if not exists page_views_created_idx on public.page_views (created_at desc);
+create index if not exists page_views_route_idx    on public.page_views (route);
+create index if not exists page_views_session_idx  on public.page_views (session_id);
+
+alter table public.page_views enable row level security;
+
+-- Anyone (anon or signed-in) may record their own view; nobody may read directly.
+drop policy if exists page_views_insert on public.page_views;
+create policy page_views_insert on public.page_views
+  for insert to anon, authenticated with check (true);
+-- (Intentionally no select policy → reads only via admin_traffic_overview.)
+
+-- ABUSE NOTE: `with check (true)` lets anyone insert arbitrary rows. Acceptable
+-- pre-launch; before scaling, add a per-session/minute rate limit (trigger) or
+-- route writes through an edge function.

--- a/supabase/migrations/20260623150000_admin_traffic_overview.sql
+++ b/supabase/migrations/20260623150000_admin_traffic_overview.sql
@@ -1,0 +1,198 @@
+-- Traffic analytics read layer for the command-center "Traffic" domain, plus a
+-- small extension to the Community domain's presence block.
+--
+-- 1. admin_traffic_overview(p_days) — one admin-guarded SECURITY DEFINER round
+--    trip aggregating public.page_views into totals / daily series / top pages /
+--    top referrers / device split, plus a live "active now" count. Mirrors the
+--    admin_community_overview pattern (authorized:false for non-admins).
+-- 2. admin_community_overview() re-stated to add online.activeVisitors (distinct
+--    visitors seen in page_views in the last 5 min) so the "Online now" panel can
+--    show anonymous traffic alongside named-user presence.
+
+create or replace function public.admin_traffic_overview(p_days int default 28)
+returns json language plpgsql security definer set search_path = public stable
+as $$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+  v_since timestamptz := (current_date - make_interval(days => greatest(p_days, 1) - 1));
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'rangeDays', greatest(p_days, 1),
+    'totals', (select json_build_object(
+      'pageViews', count(*),
+      'visitors',  count(distinct coalesce(user_id::text, session_id))
+    ) from public.page_views where created_at >= v_since),
+    -- Live: unique visitors (signed-in or anon) seen in the last 5 minutes.
+    'activeNow', (select count(distinct coalesce(user_id::text, session_id))::int
+                    from public.page_views where created_at > now() - interval '5 minutes'),
+    -- Daily trend, gap-filled across the window so the chart has one point/day.
+    'series', (select coalesce(json_agg(r), '[]'::json) from (
+      select to_char(d.day, 'YYYY-MM-DD') as day,
+             count(pv.id)::int as views,
+             count(distinct coalesce(pv.user_id::text, pv.session_id))::int as visitors
+      from generate_series(v_since, current_date, interval '1 day') as d(day)
+      left join public.page_views pv
+        on pv.created_at >= d.day and pv.created_at < d.day + interval '1 day'
+      group by d.day
+      order by d.day
+    ) r),
+    'topPages', (select coalesce(json_agg(r), '[]'::json) from (
+      select route, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since
+      group by route
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topReferrers', (select coalesce(json_agg(r), '[]'::json) from (
+      select referrer as source, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since and referrer is not null and referrer <> ''
+      group by referrer
+      order by count(*) desc
+      limit 8
+    ) r),
+    'devices', (select coalesce(json_agg(r), '[]'::json) from (
+      select coalesce(nullif(device, ''), 'unknown') as label, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since
+      group by coalesce(nullif(device, ''), 'unknown')
+      order by count(*) desc
+    ) r)
+  );
+end;
+$$;
+
+revoke all on function public.admin_traffic_overview(int) from public, anon;
+grant execute on function public.admin_traffic_overview(int) to authenticated, service_role;
+
+-- ── Community overview: add online.activeVisitors (page_views, last 5 min) ──────
+-- Re-stated in full (migrations are append-only); only the online block changes
+-- vs 20260623130000.
+create or replace function public.admin_community_overview()
+returns json language plpgsql security definer set search_path = public stable
+as $$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'totals', json_build_object(
+      'members',       (select count(*) from public.user_profiles),
+      'favourites',    (select count(*) from public.user_favourites),
+      'views',         (select count(*) from public.user_view_history),
+      'compares',      (select count(*) from public.verdicts),
+      'votes',         (select count(*) from public.matchup_votes),
+      'contributions', (select count(*) from public.contributions)
+    ),
+    'online', json_build_object(
+      'onlineNow',   (select count(*) from public.user_profiles
+                        where last_seen_at > now() - interval '5 minutes'),
+      'activeToday', (select count(*) from public.user_profiles
+                        where last_seen_at > now() - interval '1 day'),
+      -- Anonymous + signed-in visitors active in the last 5 min (from page_views).
+      'activeVisitors', (select count(distinct coalesce(user_id::text, session_id))::int
+                           from public.page_views where created_at > now() - interval '5 minutes'),
+      'recent', (select coalesce(json_agg(r), '[]'::json) from (
+        select id as "userId", display_name as "displayName",
+               last_seen_at as "lastSeenAt",
+               (last_seen_at > now() - interval '5 minutes') as "live"
+        from public.user_profiles
+        where last_seen_at is not null
+        order by last_seen_at desc
+        limit 8
+      ) r)
+    ),
+    'topViewed', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_view_history v
+      join public.heroes h on h.id = v.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topFavourited', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, h.image_url, h.publisher, count(*)::int as count
+      from public.user_favourites f
+      join public.heroes h on h.id = f.hero_id
+      group by h.id, h.name, h.image_url, h.publisher
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topBacked', (select coalesce(json_agg(r), '[]'::json) from (
+      with picks as (
+        select picked_id as hero_id, count(*)::int as picked
+        from public.matchup_votes
+        group by picked_id
+      ),
+      appearances as (
+        select hero_id, count(*)::int as total from (
+          select hero_a_id as hero_id from public.matchup_votes
+          union all
+          select hero_b_id from public.matchup_votes
+        ) a
+        group by hero_id
+      )
+      select h.id, h.name, h.image_url, h.publisher,
+             p.picked as count,
+             case when ap.total > 0 then round(100.0 * p.picked / ap.total)::int else null end as "winRate"
+      from picks p
+      join public.heroes h on h.id = p.hero_id
+      left join appearances ap on ap.hero_id = p.hero_id
+      order by p.picked desc
+      limit 8
+    ) r),
+    'topContributors', (select coalesce(json_agg(r), '[]'::json) from (
+      select cs.user_id as "userId", p.display_name as "displayName",
+             cs.approved, cs.level
+      from public.contributor_stats cs
+      left join public.user_profiles p on p.id = cs.user_id
+      order by cs.approved desc, cs.updated_at desc
+      limit 8
+    ) r),
+    'contributionsByStatus', (select json_build_object(
+      'pending',  count(*) filter (where status = 'pending'),
+      'approved', count(*) filter (where status = 'approved'),
+      'rejected', count(*) filter (where status = 'rejected')
+    ) from public.contributions),
+    'recent', (select coalesce(json_agg(r), '[]'::json) from (
+      select kind, at, "heroId", "heroName", text from (
+        select 'view'::text as kind, v.viewed_at as at,
+               h.id as "heroId", h.name as "heroName", null::text as text
+          from public.user_view_history v join public.heroes h on h.id = v.hero_id
+        union all
+        select 'favourite', f.created_at, h.id, h.name, null
+          from public.user_favourites f join public.heroes h on h.id = f.hero_id
+        union all
+        select 'vote', mv.created_at, h.id, h.name, null
+          from public.matchup_votes mv join public.heroes h on h.id = mv.picked_id
+        union all
+        select 'compare', vd.created_at, h.id, h.name, vd.verdict
+          from public.verdicts vd join public.heroes h on h.id = vd.hero_a_id
+        union all
+        select 'contribution', c.created_at, h.id, h.name,
+               coalesce('edited ' || c.target_field, c.kind)
+          from public.contributions c join public.heroes h on h.id = c.hero_id
+      ) u
+      order by at desc nulls last
+      limit 12
+    ) r)
+  );
+end;
+$$;
+
+revoke all on function public.admin_community_overview() from public, anon;
+grant execute on function public.admin_community_overview() to authenticated, service_role;


### PR DESCRIPTION
Finishes the web-observability work (Community / Presence / Traffic command-center domains) per `docs/superpowers/plans/2026-06-23-web-observability-APPLY-STEPS.md`.

## What changed
- Applied the 4 migrations (in order) via Supabase MCP:
  1. `admin_community_overview`
  2. `user_presence` (`last_seen_at` + `touch_last_seen()`)
  3. `page_views` (insert-only, RLS-locked)
  4. `admin_traffic_overview`
- Regenerated `src/types/database.generated.ts`.
- Dropped the temporary `as never` / `page_views` casts in `community.ts`, `presence.ts`, `traffic.ts`, and `pageViews.ts` (removed the `InsertOnly` shim).

## Verification
- `yarn tsc --noEmit` — clean
- `yarn test:ci` — 431/431 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)