### PR TITLE
Repo optimization pass: dead-code removal, main typecheck fix, search/carousel memoization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/
     supabase.ts        createClient<Database>() — import this, never re-create
     api.ts             fetchHeroStats / fetchHeroDetails / fetchFirstIssue
     db/
-      heroes.ts        getHeroesByCategory()
+      heroes.ts        barrel → heroes/ (core, feed, categories, relationships, transforms)
       favourites.ts    isFavourited / addFavourite / removeFavourite / getFavouriteCount
   types/
     database.generated.ts   Auto-generated from Supabase — NEVER edit manually

--- a/app/(tabs)/search/index.web.tsx
+++ b/app/(tabs)/search/index.web.tsx
@@ -1,7 +1,7 @@
 // app/search.web.tsx — Search experience (web).
 // Desktop: committed results driven by the nav field (?q= in the URL).
 // Idle (any width): full-screen browse surface — Recent searches + category pods.
-import { useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -42,21 +42,23 @@ const sk = StyleSheet.create({
 });
 
 // ── Card ────────────────────────────────────────────────────────────────────────
-function HeroCard({
+// Memoised: the screen re-renders on every keystroke (inputQuery), but the search
+// is debounced — so `heroes` (and each hero object) stays referentially stable
+// between keystrokes. Paired with stable `onSelect`/`onPeek` handlers, memo lets
+// all up-to-300 cards skip re-rendering until the result set actually changes.
+const HeroCard = memo(function HeroCard({
   hero,
-  onPress,
-  onLongPress,
-  onInfo,
+  onSelect,
+  onPeek,
 }: {
   hero: HeroSearchResult;
-  onPress: () => void;
-  onLongPress?: () => void;
-  onInfo?: () => void;
+  onSelect: (id: string) => void;
+  onPeek: (hero: HeroSearchResult) => void;
 }) {
   return (
     <Pressable
-      onPress={onPress}
-      onLongPress={onLongPress}
+      onPress={() => onSelect(hero.id)}
+      onLongPress={() => onPeek(hero)}
       delayLongPress={300}
       style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
         [card.wrap, hovered && (card.wrapHover as object)] as object
@@ -83,27 +85,25 @@ function HeroCard({
               {hero.name}
             </Text>
           </View>
-          {onInfo && (
-            <Pressable
-              onPress={onInfo}
-              accessibilityLabel={`About ${hero.name}`}
-              pointerEvents={hovered ? 'auto' : 'none'}
-              style={({ hovered: chipHovered }: { pressed: boolean; hovered?: boolean }) =>
-                [
-                  card.infoChip,
-                  { opacity: hovered ? 1 : 0 },
-                  chipHovered && (card.infoChipHover as object),
-                ] as object
-              }
-            >
-              <Ionicons name="information" size={15} color={COLORS.beige} />
-            </Pressable>
-          )}
+          <Pressable
+            onPress={() => onPeek(hero)}
+            accessibilityLabel={`About ${hero.name}`}
+            pointerEvents={hovered ? 'auto' : 'none'}
+            style={({ hovered: chipHovered }: { pressed: boolean; hovered?: boolean }) =>
+              [
+                card.infoChip,
+                { opacity: hovered ? 1 : 0 },
+                chipHovered && (card.infoChipHover as object),
+              ] as object
+            }
+          >
+            <Ionicons name="information" size={15} color={COLORS.beige} />
+          </Pressable>
         </>
       )}
     </Pressable>
   );
-}
+});
 const card = StyleSheet.create({
   wrap: {
     width: '100%', // WebKit won't stretch an aspect-ratio grid item to the track
@@ -196,12 +196,21 @@ export default function WebSearchScreen() {
   const showIdle = !hasCriteria;
   const browseCovers = useBrowseCovers(showIdle);
 
-  const goToHero = (id: string) => {
-    if (trimmed) addSearch(trimmed);
-    router.push(`/character/${id}`);
-  };
-
   const [peek, setPeek] = useState<PeekHero | null>(null);
+
+  // Stable handlers so the memoised HeroCards don't re-render on every keystroke.
+  // `trimmed` changes per keystroke, so read it through a ref to keep goToHero
+  // referentially stable (addSearch, router and setPeek are already stable).
+  const trimmedRef = useRef(trimmed);
+  trimmedRef.current = trimmed;
+  const goToHero = useCallback(
+    (id: string) => {
+      if (trimmedRef.current) addSearch(trimmedRef.current);
+      router.push(`/character/${id}`);
+    },
+    [addSearch, router],
+  );
+  const openPeek = useCallback((hero: HeroSearchResult) => setPeek(hero), []);
 
   // The mobile header is position:fixed (see styles.mobileFixedHeader for why),
   // so it's out of flow — reserve its measured height with a spacer below so the
@@ -336,13 +345,7 @@ export default function WebSearchScreen() {
                   <SkeletonCard key={i} opacity={skeletonOpacity} />
                 ))
               : heroes.map((hero) => (
-                  <HeroCard
-                    key={hero.id}
-                    hero={hero}
-                    onPress={() => goToHero(hero.id)}
-                    onLongPress={() => setPeek(hero)}
-                    onInfo={() => setPeek(hero)}
-                  />
+                  <HeroCard key={hero.id} hero={hero} onSelect={goToHero} onPeek={openPeek} />
                 ))}
           </View>
           {!loading && heroes.length === 0 && (

--- a/src/components/HeroCard.tsx
+++ b/src/components/HeroCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { COLORS } from '../constants/colors';
 import { HeroImage } from './HeroImage';
@@ -24,7 +25,17 @@ interface HeroCardProps {
  * the zoom. Dimensions are passed in explicitly so the card never depends on
  * the Link.AppleZoom wrapper stretching it.
  */
-export function HeroCard({ id, name, imageUrl, portraitUrl, width, height }: HeroCardProps) {
+// Memoised: all props are primitives, so the default shallow comparison lets each
+// card skip re-rendering when its carousel row re-renders (swipe/scroll/index
+// state) but the card's own data is unchanged.
+export const HeroCard = memo(function HeroCard({
+  id,
+  name,
+  imageUrl,
+  portraitUrl,
+  width,
+  height,
+}: HeroCardProps) {
   return (
     <View collapsable={false} style={[styles.card, { width, height }]}>
       <HeroImage
@@ -44,7 +55,7 @@ export function HeroCard({ id, name, imageUrl, portraitUrl, width, height }: Her
       </View>
     </View>
   );
-}
+});
 
 export const HERO_CARD_RADIUS = 64;
 

--- a/src/components/admin/health/SubTabs.tsx
+++ b/src/components/admin/health/SubTabs.tsx
@@ -58,6 +58,8 @@ export function SubTabs<T extends string>({
 
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 12 },
+  // Mobile: one no-wrap line, tighter gaps so every sub-tab fits without scroll.
+  rowNarrow: { flexWrap: 'nowrap', gap: 4 },
   pill: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -67,8 +69,11 @@ const styles = StyleSheet.create({
     borderRadius: 9,
     backgroundColor: 'rgba(255,255,255,0.07)',
   },
+  // Mobile: slimmer pills (less horizontal padding, icons dropped in the view).
+  pillNarrow: { paddingHorizontal: 10, paddingVertical: 6, gap: 4 },
   pillOn: { backgroundColor: COLORS.orange },
   pillText: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: 'rgba(255,255,255,0.65)' },
+  pillTextNarrow: { fontSize: 12 },
   pillTextOn: { color: '#fff' },
   badge: {
     minWidth: 18,

--- a/src/lib/db/heroes/core.ts
+++ b/src/lib/db/heroes/core.ts
@@ -1,11 +1,5 @@
 import { supabase } from '../../supabase';
-import type {
-  Hero,
-  HeroSearchResult,
-  HeroesByCategory,
-  PublisherFilter,
-  AlignmentFilter,
-} from './types';
+import type { Hero, HeroSearchResult, PublisherFilter, AlignmentFilter } from './types';
 
 const norm = (s: string) => s.toLowerCase().replace(/[\s\-_.]/g, '');
 
@@ -34,18 +28,6 @@ export function rankResults(list: HeroSearchResult[], query: string): HeroSearch
     })
     .sort((a, b) => a.score - b.score)
     .map((s) => s.h);
-}
-
-export async function getHeroesByCategory(): Promise<HeroesByCategory> {
-  const { data, error } = await supabase.from('heroes').select('*').order('name');
-
-  if (error) throw error;
-
-  return {
-    popular: data.filter((h) => h.category === 'popular'),
-    villain: data.filter((h) => h.category === 'villain'),
-    xmen: data.filter((h) => h.category === 'xmen'),
-  };
 }
 
 export async function getHeroByComicvineId(cvId: string): Promise<Hero | null> {

--- a/src/lib/db/heroes/types.ts
+++ b/src/lib/db/heroes/types.ts
@@ -18,12 +18,6 @@ export type HeroSearchResult = Pick<
   | 'aliases'
 >;
 
-export interface HeroesByCategory {
-  popular: Hero[];
-  villain: Hero[];
-  xmen: Hero[];
-}
-
 export interface FirstAppearanceCover {
   id: string;
   name: string;


### PR DESCRIPTION
## Repo optimization pass

A series of small, focused cleanups + perf wins from a repo health survey. Four commits, each independently scoped:

### 1. Remove dead `getHeroesByCategory()` (`refactor(db)`)
No callers anywhere in `src/`/`app/` — the only references were CLAUDE.md and its own definition. It also carried a latent bug the project's own conventions warn against:

```ts
const { data } = await supabase.from('heroes').select('*').order('name'); // no .limit()/.range()
```
- **Silent truncation:** no `.limit()`/`.range()` on the 3,000+ row `heroes` table → PostgREST's 1000-row cap quietly drops categories.
- **Over-fetch:** every column for every row, then filtered to 3 categories client-side.

Live category browsing already uses the correctly-paginated `getAllHeroesBySlug` (`fetchAllPages`), so this is pure dead-code removal.

### 2. Fix broken `main` typecheck (`fix(SubTabs)`)
While verifying #1 against CI, `Type Check` was already **red on `main`** — independent of this work. Commit `7c287f8` shipped `SubTabs.tsx` referencing `styles.rowNarrow`, `styles.pillNarrow`, `styles.pillTextNarrow`, none of which existed (`TS2339` ×3). Added the three keys implementing the documented mobile intent (one no-wrap line, tighter pills). Restores green typecheck for the branch and for `main` once merged.

### 3. Memoize web-search `HeroCard` (`perf(search/web)`)
The web search screen re-renders on every keystroke (`inputQuery`), but search is debounced — so the result set (up to 300) is unchanged between keystrokes. `HeroCard` was un-memoized with fresh inline closures each render, so all 300 image cards reconciled per keystroke. Wrapped in `React.memo` with referentially-stable `onSelect`/`onPeek` handlers. Keeps typing smooth on broad queries.

### 4. Memoize shared home/explore `HeroCard` (`perf(home)`)
The carousel portrait card is purely presentational with all-primitive props but was un-memoized, so every card reconciled whenever its row re-rendered (swipe/scroll/index state). Wrapped in `React.memo` — default shallow comparison is exact for primitive props, so it's a zero-risk win across every rail that renders it.

### Verification
All CI green: Type Check ✅, Test ✅, Lint ✅, Web Build ✅, CodeQL ✅. No behavioural changes — dead-code removal, a typecheck fix, and two render-only memoizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWk7khBr8jcdZoZwjnMZc1)_