### PR TITLE
fix(web): keep iOS Safari status bar a consistent navy across pages

### DIFF
--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -1397,7 +1397,9 @@ export default function WebProfileScreen() {
 
 // ── Mobile-only styles (native parity) ───────────────────────────────────────
 const mob = StyleSheet.create({
-  root: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige fills the full scroll height over the
+  // now-navy body — flex:1 clamps to 100dvh and would leak navy past the fold.
+  root: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   scroll: { paddingBottom: 0 },
 
   // Cover
@@ -1816,7 +1818,9 @@ const mob = StyleSheet.create({
 
 // ── Desktop-only styles ───────────────────────────────────────────────────────
 const desk = StyleSheet.create({
-  root: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige fills the full scroll height over the
+  // now-navy body — flex:1 clamps to 100dvh and would leak navy past the fold.
+  root: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
 
   // Cover
   cover: {

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -74,12 +74,13 @@ html, body, #root {
   height: 100%;
   height: 100dvh !important;
 }
-/* The document's DEFAULT background. The iOS Safari status-bar inset and the
-   frosted toolbar show whatever the body background is at that moment, so the
-   default has to be the app's dark backdrop (deep-navy) — otherwise every
-   loading/transition phase (font load, auth settle, the landing iframe's splash)
-   shows a beige body through the bars before a route paints its own canvas.
-   Content pages override this to beige at runtime via useWebCanvas, so the
-   frosted toolbar still reads transparent over beige content there. */
+/* The document background, pinned deep-navy on EVERY route. In a plain iOS Safari
+   tab both the status-bar strip and the bottom toolbar are tinted from the body
+   background, so keeping it a single dark value gives consistent dark system
+   chrome on every page (instead of it flipping to each screen's content colour)
+   and keeps every loading/transition phase dark. Light screens paint their own
+   beige on a container that fills the full scroll height — the navy body only
+   shows through the system chrome and on overscroll, never under content. Screens
+   declare this via useScreenChrome, which no longer repaints the body. */
 html, body { background-color: #0b1820; overscroll-behavior-y: none; }
 `;

--- a/app/biography/[id].web.tsx
+++ b/app/biography/[id].web.tsx
@@ -508,7 +508,10 @@ export default function WebBiographyScreen() {
 }
 
 const styles = StyleSheet.create({
-  scroll: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige (desktop) grows to the full scroll height
+  // over the now-navy body; flex:1 clamps to 100dvh and would leak navy past the
+  // fold. Mobile overrides the fill to deepNavy below (canvas is already ink).
+  scroll: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   // Mobile: the scroll surface goes dark so the header fuses uninterrupted into the
   // dark status strip (no beige peeking between). The beige comes from mobileBody.
   scrollDarkMobile: { backgroundColor: COLORS.deepNavy } as object,

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -2830,7 +2830,10 @@ function CharacterSkeleton({ isDesktop, showHeart }: { isDesktop: boolean; showH
 }
 
 const sk = StyleSheet.create({
-  scroll: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige grows to the FULL scroll height: under
+  // document scroll, flex:1 clamps to 100dvh (RNW Views set min-height:0) and the
+  // now-navy body would show past the fold. minHeight fills ≥ viewport and grows.
+  scroll: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   scrollContent: { width: '100%' },
   bodyWrap: { maxWidth: 1180, alignSelf: 'center', width: '100%', paddingBottom: 0 },
 
@@ -2946,7 +2949,10 @@ const styles = StyleSheet.create({
     color: COLORS.navy,
   },
 
-  scroll: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige grows to the FULL scroll height: under
+  // document scroll, flex:1 clamps to 100dvh (RNW Views set min-height:0) and the
+  // now-navy body would show past the fold. minHeight fills ≥ viewport and grows.
+  scroll: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   // Cold-load shell: deepNavy so the anti-flash `pre` window (and web refresh)
   // fuses with the boot LogoLoader and the skeleton's dark stage — no beige flash.
   loadingShell: { flex: 1, backgroundColor: COLORS.deepNavy },

--- a/app/issue/[id].tsx
+++ b/app/issue/[id].tsx
@@ -852,7 +852,9 @@ const cast = StyleSheet.create({
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: COLORS.beige },
-  webPage: { width: '100%', backgroundColor: COLORS.beige },
+  // minHeight floors the beige at one viewport so a short page doesn't leak the
+  // now-navy body below it; grows to content past that under document scroll.
+  webPage: { width: '100%', minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   loading: {
     flex: 1,
     backgroundColor: COLORS.beige,

--- a/app/title/[id].tsx
+++ b/app/title/[id].tsx
@@ -437,7 +437,14 @@ const styles = StyleSheet.create({
   loadingShell: { flex: 1, backgroundColor: COLORS.deepNavy },
   // Web: document-scrolled page (no inner ScrollView) so the body bleeds under
   // the iOS Safari toolbar. paddingBottom keeps the last card off the toolbar.
-  webPage: { width: '100%', backgroundColor: COLORS.beige, paddingBottom: 40 },
+  // minHeight floors the beige at one viewport so a short page doesn't leak the
+  // now-navy body below it; grows to content past that under document scroll.
+  webPage: {
+    width: '100%',
+    minHeight: '100dvh',
+    backgroundColor: COLORS.beige,
+    paddingBottom: 40,
+  } as object,
   // Positioned wrapper for the body so the FadeOutSkeleton overlay (absoluteFill)
   // scopes to the body region and aligns with it (the body floats up across the
   // seam via marginTop, which the overlay inherits identically).

--- a/src/components/legal/LegalScreen.tsx
+++ b/src/components/legal/LegalScreen.tsx
@@ -75,7 +75,9 @@ export function LegalScreen({ doc }: { doc: LegalDoc }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: COLORS.beige },
+  // minHeight (not flex:1) so the beige fills the full scroll height over the
+  // now-navy body — flex:1 clamps to 100dvh and would leak navy past the fold.
+  container: { minHeight: '100dvh', backgroundColor: COLORS.beige } as object,
   scroll: { paddingHorizontal: 20, maxWidth: 720, width: '100%', alignSelf: 'center' },
   backBtn: {
     width: 38,

--- a/src/hooks/useScreenChrome.ts
+++ b/src/hooks/useScreenChrome.ts
@@ -1,32 +1,43 @@
+import { SURFACE } from '../constants/colors';
 import { useChromeColor } from '../contexts/WebChromeContext';
 import { useWebCanvas } from './useWebCanvas';
 
 interface ScreenChrome {
   /**
-   * Colour at the very top of the screen — the iOS status-bar tint, the
-   * status-bar cover, and the web TopBar all lock to it. Should match the page's
-   * own top section (the dark band or hero stage). Omit it and it falls back to
-   * `canvas`, so the top can never silently drift to the deep-navy default —
-   * the cause of the status-bar vs. bottom-toolbar colour mismatch.
+   * Colour at the very top of the screen — the iOS status-bar tint (in a
+   * Home-Screen/standalone install), the status-bar cover, and the web TopBar all
+   * lock to it. Should match the page's own top section (the dark band or hero
+   * stage). Omit it and it falls back to `canvas`.
    */
   top?: string;
   /**
-   * The document canvas: the content body and the iOS Safari bottom-toolbar
-   * zone (what the frosted toolbar blurs, and what shows past the fold and on
-   * overscroll). Pass the screen's dominant body colour — `SURFACE.paper` for
-   * light screens, `SURFACE.ink` for full-dark ones.
+   * The screen's dominant CONTENT colour — `SURFACE.paper` for light screens,
+   * `SURFACE.ink` for full-dark ones. Each screen paints this on its own
+   * container (sized to the full scroll height), NOT on the document body.
+   *
+   * Note: this no longer touches `<body>`. In a plain iOS Safari tab both the top
+   * status bar and the bottom toolbar are tinted from the `<body>` background, so
+   * letting each page paint the body its own colour made that system chrome flip
+   * per page (beige on content pages, navy on Explore — the bug this hook now
+   * prevents). The body is pinned to a single deep-navy instead; see below.
    */
   canvas: string;
 }
 
 /**
- * Single source of truth for a web screen's top edge and canvas. Wraps the two
- * previously independent systems (`useChromeColor` for the top chrome,
- * `useWebCanvas` for the document background) so a page declares both together
- * and they can't drift apart. Web-only — both underlying hooks no-op without a
- * `document`.
+ * Single source of truth for a web screen's top edge and canvas. Web-only —
+ * both underlying hooks no-op without a `document`.
+ *
+ * The document `<body>`/`<html>` background is pinned to the app's deep-navy on
+ * EVERY route (`SURFACE.ink`), so the iOS Safari system chrome — status bar and
+ * bottom toolbar, both tinted from `<body>` in a tab — reads a consistent dark on
+ * every page instead of mirroring the page's content colour. Light screens still
+ * look beige because they paint their own beige container that fills the full
+ * scroll height; the navy body only shows through the system chrome and on
+ * overscroll. (In a Home-Screen/standalone install, `useChromeColor` additionally
+ * drives the real status-bar cover + theme-color to `top`.)
  */
 export function useScreenChrome({ top, canvas }: ScreenChrome) {
-  useWebCanvas(canvas);
+  useWebCanvas(SURFACE.ink);
   useChromeColor(top ?? canvas);
 }


### PR DESCRIPTION
## What & why

On mobile iOS Safari the top status-bar strip (time/battery) changed color as you moved between pages — beige on the character detail page, dark navy on Explore.

**Root cause:** In a plain Safari tab, the top status-bar strip **and** the bottom toolbar are both tinted from the document `<body>` background — this is Safari's own chrome, which no in-page element can repaint and which ignores the app's dynamic `theme-color` meta. Each screen was painting `<body>` its own content color via `useScreenChrome`'s `canvas` (beige on content pages, navy on Explore), so the system chrome mirrored whatever page you were on. The existing `AdaptiveStatusBarCover` + `theme-color` machinery only takes effect in a Home-Screen/standalone install, not a normal tab. And because the top and bottom bars share the same `<body>` source, a two-tone "dark top / beige bottom" is not achievable in a tab.

**Decision:** consistent navy chrome everywhere (top + bottom), preserving the bottom content flow-through.

## Changes

- **Pin `<body>`/`<html>` to the app's deep-navy on every route.** `useScreenChrome` no longer repaints the body with each screen's content color, so the status bar + bottom toolbar read a consistent navy on every page. (`src/hooks/useScreenChrome.ts`, `app/+html.tsx`)
- **Prevent a navy leak past the fold.** With a navy body, a beige container clamped to one viewport (`flex:1`, which RNW pins to 100dvh via `min-height:0`) would show navy under the content below the fold. Each light screen's canvas container now uses a full-height beige fill (`minHeight:'100dvh'`, grows with content) so beige backs the entire scroll. Fixed screens: character, profile (mobile + desktop), biography (desktop), legal, title, issue.
- Dark screens (Explore / Search / Arena / category / team) already declare a dark canvas, so they're unaffected.

The bottom content flow-through is preserved — only the system chrome and overscroll gutters read navy, which is the intended tradeoff.

## Verification

- **Layout fix verified in Chromium** (faithful reproduction of the RNW layout): `flex:1` leaves ~1556px below the fold un-backed by the beige canvas (where navy would leak), while `minHeight:'100dvh'` backs the full document height (leak = 0).
- No test files exercise the changed code; the style edits reuse the already-shipped `minHeight:'100dvh' … } as object` pattern from the auth screens.
- Could not run `yarn test:ci` / `tsc` in the CI sandbox (registry bulk-fetch is blocked by egress policy); the diff touches only web view styles and a web-only hook.

## On-device note

Privacy/Terms (legal) pages declare a light top but will now get a navy status bar like every other page — consistent with "navy everywhere," but worth an eyeball if a different treatment is wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yG9ADfyP9B9MvageS3FL7

---
_Generated by [Claude Code](https://claude.ai/code/session_017yG9ADfyP9B9MvageS3FL7)_