### PR TITLE
Point canonical origin at mythique.app custom domain

### DIFF
--- a/scripts/fetch-og-site.mjs
+++ b/scripts/fetch-og-site.mjs
@@ -4,7 +4,7 @@
 //   node scripts/fetch-og-site.mjs [origin]   (default: production SITE_URL)
 import { writeFile } from 'node:fs/promises';
 
-const origin = process.argv[2] ?? 'https://mythique-wiki.vercel.app';
+const origin = process.argv[2] ?? 'https://mythique.app';
 const url = `${origin}/api/og`;
 
 const res = await fetch(url);

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -16,9 +16,9 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 // Mirrors SITE_URL in src/constants/site.ts (this standalone build script can't
-// import TS). Override at build time with SITEMAP_BASE_URL. Flip both when the
-// custom domain is attached.
-const BASE_URL = (process.env.SITEMAP_BASE_URL || 'https://mythique-wiki.vercel.app').replace(
+// import TS). Override at build time with SITEMAP_BASE_URL. Keep in sync with
+// SITE_URL if the origin ever changes.
+const BASE_URL = (process.env.SITEMAP_BASE_URL || 'https://mythique.app').replace(
   /\/$/,
   '',
 );

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,9 +1,9 @@
 // Canonical production origin — the single source of truth for SEO canonical /
-// Open Graph URLs (SeoHead, app/+html.tsx). When the custom domain
-// (mythique.app) is attached in Vercel, flip this one line.
+// Open Graph URLs (SeoHead, app/+html.tsx). Points at the custom domain
+// (mythique.app); update this one line if the origin ever changes.
 //
 // The sitemap generator (scripts/generate-sitemap.mjs) is a standalone build
 // script that can't import this TS module; it mirrors the same default and can
 // be overridden at build time with the SITEMAP_BASE_URL env var. Keep the two in
 // sync.
-export const SITE_URL = 'https://mythique-wiki.vercel.app';
+export const SITE_URL = 'https://mythique.app';


### PR DESCRIPTION
## Summary

Now that the `mythique.app` DNS/custom domain is set up, flip the app's canonical origin from the Vercel preview host (`mythique-wiki.vercel.app`) to `mythique.app`. This is the single source of truth for all public-facing URLs, so it fixes what link-preview crawlers and search engines see.

## Changes

- **`src/constants/site.ts`** — `SITE_URL` → `https://mythique.app`. This drives every canonical URL, Open Graph `og:url`/`og:image`, Twitter card image, and share-meta link (consumed by `app/+html.tsx`, `SeoHead.tsx`, `app/character/[id].web.tsx`, `app/compare/…web.tsx`, `api/_lib/shareMeta.ts`).
- **`scripts/generate-sitemap.mjs`** — mirrored `BASE_URL` default → `https://mythique.app`. This feeds the sitemap index, the ~22k content URLs, and the auto-generated `robots.txt` (`Sitemap:` directive), so all three now advertise the correct host. Still overridable via `SITEMAP_BASE_URL`.
- **`scripts/fetch-og-site.mjs`** — OG-snapshot dev helper default updated for consistency.
- Refreshed the now-stale "flip this when the domain is attached" comments.

## robots.txt

No new file needed — `scripts/generate-sitemap.mjs` already emits `dist/robots.txt` at build time (allow all, `Disallow: /admin`, `Sitemap:` directive) from the same `BASE_URL`, so this change also corrects its sitemap URL.

## Not covered here (external config — must be done before/with deploy)

- **Vercel** — attach `mythique.app` as a custom domain.
- **Supabase → Auth → URL Configuration** — set Site URL and add `https://mythique.app` to the redirect allowlist (auth uses `window.location.origin`, so it's rejected otherwise).
- **Google OAuth / Apple Sign In** — add `https://mythique.app` to authorized origins.

⚠️ Deploy only once `mythique.app` is actually serving in Vercel, so crawlers fetching posted links don't hit a dead origin for OG images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avqn4Lyw2SSzmv9TL1sfkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avqn4Lyw2SSzmv9TL1sfkb)_