### PR TITLE
Fix /api/og 500 — move OG card renderer to the Edge runtime

### DIFF
--- a/api/og.tsx
+++ b/api/og.tsx
@@ -3,11 +3,17 @@
 //   /api/og?a=<id>&b=<id> — VS card (both portraits, tale of the tape)
 //   /api/og (no params) — site-wide brand card (snapshotted to public/og.png
 //                         by scripts/fetch-og-site.mjs)
-// Fonts are read from assets/fonts (shipped via includeFiles in vercel.json).
-// Any failure falls back to the brand card — never a broken image.
+//
+// Runs on the Edge runtime: standalone @vercel/og functions must be Edge for
+// Vercel to bundle the underlying satori/resvg WASM — on the Node runtime the
+// renderer fails to initialise. Fonts are therefore loaded via URL imports
+// (traced + inlined by the bundler) rather than node:fs, which Edge lacks.
+//
+// Any failure falls back to a redirect to the static brand card (public/og.png)
+// so a share link never yields a broken image.
 import { ImageResponse } from '@vercel/og';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+
+export const config = { runtime: 'edge' };
 
 const NAVY = '#0b1820';
 const BEIGE = '#f5ebdc';
@@ -34,17 +40,22 @@ async function fetchHero(id: string): Promise<OgHero | null> {
   return rows[0] ?? null;
 }
 
-function font(file: string) {
-  return readFileSync(join(process.cwd(), 'assets', 'fonts', file));
-}
-
-let fonts: { name: string; data: Buffer; style: 'normal' }[] | null = null;
+// Edge runtime has no node:fs — load the font bytes via URL imports so the
+// bundler traces and inlines them. Cached across warm invocations.
+let fontsPromise: Promise<{ name: string; data: ArrayBuffer; style: 'normal' }[]> | null = null;
 function getFonts() {
-  fonts ??= [
-    { name: 'Flame', data: font('Flame-Regular.ttf'), style: 'normal' },
-    { name: 'FlameSans', data: font('FlameSans-Regular.ttf'), style: 'normal' },
-  ];
-  return fonts;
+  fontsPromise ??= Promise.all([
+    fetch(new URL('../assets/fonts/Flame-Regular.ttf', import.meta.url)).then((r) =>
+      r.arrayBuffer(),
+    ),
+    fetch(new URL('../assets/fonts/FlameSans-Regular.ttf', import.meta.url)).then((r) =>
+      r.arrayBuffer(),
+    ),
+  ]).then(([flame, flameSans]) => [
+    { name: 'Flame', data: flame, style: 'normal' as const },
+    { name: 'FlameSans', data: flameSans, style: 'normal' as const },
+  ]);
+  return fontsPromise;
 }
 
 const wordmark = (size = 30) => (
@@ -239,8 +250,8 @@ function vsCard(a: OgHero, b: OgHero, imgA: string | null, imgB: string | null) 
 const art = (h: OgHero) => h.portrait_url || h.image_url;
 
 export default async function handler(req: Request) {
-  let card = siteCard();
   try {
+    let card = siteCard();
     const { searchParams } = new URL(req.url);
     const heroId = searchParams.get('hero');
     const aId = searchParams.get('a');
@@ -252,15 +263,16 @@ export default async function handler(req: Request) {
       const [a, b] = await Promise.all([fetchHero(aId), fetchHero(bId)]);
       if (a && b) card = vsCard(a, b, art(a), art(b));
     }
+    return new ImageResponse(card, {
+      width: 1200,
+      height: 630,
+      fonts: await getFonts(),
+      headers: {
+        'cache-control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+      },
+    });
   } catch {
-    // brand card fallback
+    // Never emit a broken image — fall back to the static brand card.
+    return Response.redirect(new URL('/og.png', req.url).toString(), 302);
   }
-  return new ImageResponse(card, {
-    width: 1200,
-    height: 630,
-    fonts: getFonts(),
-    headers: {
-      'cache-control': 'public, s-maxage=86400, stale-while-revalidate=604800',
-    },
-  });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "buildCommand": "yarn expo export -p web && node scripts/generate-sitemap.mjs",
   "outputDirectory": "dist",
-  "functions": {
-    "api/og.tsx": { "includeFiles": "assets/fonts/**" }
-  },
   "rewrites": [
     {
       "source": "/character/:id",


### PR DESCRIPTION
## Problem

`/api/og` — the dynamic Open Graph card renderer used for character and who-would-win share previews — returns **HTTP 500 (`FUNCTION_INVOCATION_FAILED`)** for every request, including the no-param site card. This is pre-existing (it fails on the old `mythique-wiki.vercel.app` host too, and the file hasn't changed since it was added), so it's unrelated to the domain move — but it means deep share links show no preview image.

## Root cause

A **standalone** `@vercel/og` function (this repo isn't Next.js — `api/og.tsx` is a bare Vercel function) must run on the **Edge runtime** so Vercel bundles the underlying satori/resvg WASM engine. The function had no runtime declared and loaded fonts via `node:fs` `readFileSync`, which pinned it to the **Node runtime**, where `@vercel/og` fails to initialise. The sibling `/api/share-meta` Node function works fine, confirming the failure is specific to the image renderer.

## Fix

- Declare `export const config = { runtime: 'edge' }`.
- Load font bytes via `fetch(new URL('../assets/fonts/…', import.meta.url))` (traced + inlined by the bundler) instead of `node:fs`, which Edge lacks. Cached across warm invocations.
- Wrap the handler so any render failure redirects (302) to the static `/og.png` brand card — a share link can never yield a broken image.
- Remove the now-unused `functions`/`includeFiles` entry from `vercel.json` (Edge functions can't use `includeFiles`, and the stale matcher would fail the build).

Card layouts (site / character / vs) are unchanged.

## Verification

- `yarn typecheck` — clean.
- `yarn eslint api/og.tsx` — clean.
- `yarn jest __tests__/api/shareMeta.test.ts` — 8/8 pass.
- Runtime behaviour must be confirmed against the Vercel deploy (the renderer can only run on Vercel's Edge runtime): after merge, `curl -I https://mythique.app/api/og` should return **200** with `content-type: image/png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avqn4Lyw2SSzmv9TL1sfkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avqn4Lyw2SSzmv9TL1sfkb)_