### PR TITLE
Add Instagram carousel pipelines (matchup + character file)

### DIFF
--- a/scripts/social/README.md
+++ b/scripts/social/README.md
@@ -1,13 +1,15 @@
-# Social reel pipeline
+# Social content pipelines
 
-Generates fast-cut 9:16 "who would win" videos (TikTok / Reels / Shorts) from
-real matchup data, styled like the app's matchup screen. One command produces a
-batch of ready-to-post `.mp4`s plus captions.
+Generate on-brand social content from **real matchup data**, styled like the
+app's matchup screen. Two tools share one data layer (`lib.mjs`):
 
-## What it does
+- **`generate-reels.mjs`** — fast-cut 9:16 videos for TikTok / Reels / Shorts (`.mp4`)
+- **`generate-carousels.mjs`** — 4:5 Instagram carousel slides (`.png` set)
 
-For each matchup it pulls **real data** using only the public (publishable)
-Supabase key — the same read path the app uses, no secret key:
+## What they do
+
+Per matchup, using only the public (publishable) Supabase key — the same read
+path the app uses, no secret key:
 
 - portraits + the six stats + `fame_score` from the `heroes` table
 - the community vote split from the `get_matchup_tally` RPC
@@ -25,29 +27,42 @@ cross-universe pairs. Pass `--matchup "A,B"` to force one.
 - `yarn add -D playwright-core` and a Chrome/Chromium
   (defaults to `channel: "chrome"`; or set `PW_CHROME=/path/to/chromium`)
 - `ffmpeg` on `PATH` (`brew install ffmpeg`), or set `FFMPEG=/path/to/ffmpeg`
+  — **reels only**; carousels need no ffmpeg
 - `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_KEY` in `.env.local`
 
 ## Usage
 
 ```sh
-# preview the matchups it would pick (no rendering)
+# preview the matchups either tool would pick (no rendering)
 node scripts/social/generate-reels.mjs --count 8 --dry-run
 
-# generate 8 videos + captions into out/social/<slug>/
+# TikTok/Reels videos -> out/social/<slug>/video.mp4 + caption.txt
 node scripts/social/generate-reels.mjs --count 8
 
-# force a specific matchup
-node scripts/social/generate-reels.mjs --matchup "Goku,Superman"
+# Instagram carousels -> out/social/<slug>/carousel/slide-1..4.png + caption.txt
+node scripts/social/generate-carousels.mjs --count 8
+
+# force a specific matchup (either tool)
+node scripts/social/generate-carousels.mjs --matchup "Goku,Superman"
 ```
 
-Each matchup lands in `out/social/<a>-vs-<b>/` as `video.mp4` + `caption.txt`.
+The carousel is 4 slides: cover / hook, tale of the tape, verdict + winner,
+fan vote + CTA. Upload them in order.
 
 ## Posting
 
-The videos are **silent by design**. Upload to TikTok / Reels and add a
-**trending sound** in-app — the cuts are spaced to snap to a beat, and in-app
-audio gets far more reach than baked-in music. (Use a **Creator** account, not
-Business: Business accounts can only use the commercial music library, which
-excludes trending sounds.)
+**Reels** are **silent by design** — add a **trending sound** in-app. The cuts
+are spaced to snap to a beat, and in-app audio gets far more reach than baked-in
+music. Use a **Creator** account, not Business: Business accounts can only use
+the commercial music library, which excludes trending sounds.
+
+**Carousels** drive swipes and saves; keep the payoff (winner) off slide 1 so
+people swipe to the end.
 
 `out/` is git-ignored; nothing generated is committed.
+
+## Files
+
+- `lib.mjs` — shared: env, Supabase (public key), selection, data hydrate,
+  fonts/portraits, and the render helpers (`renderPng`, `renderVideo`).
+- `generate-reels.mjs` / `generate-carousels.mjs` — the two templates + CLI.

--- a/scripts/social/README.md
+++ b/scripts/social/README.md
@@ -4,7 +4,8 @@ Generate on-brand social content from **real matchup data**, styled like the
 app's matchup screen. Two tools share one data layer (`lib.mjs`):
 
 - **`generate-reels.mjs`** — fast-cut 9:16 videos for TikTok / Reels / Shorts (`.mp4`)
-- **`generate-carousels.mjs`** — 4:5 Instagram carousel slides (`.png` set)
+- **`generate-carousels.mjs`** — 4:5 matchup carousel slides (`.png` set)
+- **`generate-bios.mjs`** — 4:5 character-showcase "character file" carousel (portrait, power stats, profile dossier, aliases) — flexes the catalogue depth
 
 ## What they do
 
@@ -39,10 +40,14 @@ node scripts/social/generate-reels.mjs --count 8 --dry-run
 # TikTok/Reels videos -> out/social/<slug>/video.mp4 + caption.txt
 node scripts/social/generate-reels.mjs --count 8
 
-# Instagram carousels -> out/social/<slug>/carousel/slide-1..4.png + caption.txt
+# Instagram matchup carousels -> out/social/<slug>/carousel/slide-1..4.png + caption.txt
 node scripts/social/generate-carousels.mjs --count 8
 
-# force a specific matchup (either tool)
+# Character-file carousels -> out/social/bio-<slug>/slide-1..4.png + caption.txt
+node scripts/social/generate-bios.mjs --count 8
+node scripts/social/generate-bios.mjs --character "Batman"
+
+# force a specific matchup
 node scripts/social/generate-carousels.mjs --matchup "Goku,Superman"
 ```
 

--- a/scripts/social/generate-bios.mjs
+++ b/scripts/social/generate-bios.mjs
@@ -52,12 +52,11 @@ function slideDossier(h, F, year) {
     ['OCCUPATION', clip(h.occupation, 46)],
     ['TEAMS', clip(h.group_affiliation, 46)],
   ].filter(([, v]) => realVal(v));
-  const rows = fields.map(([l, v]) => `<div style="margin:0 0 38px 0;padding:0 90px">
-      <div style="font-size:30px;letter-spacing:4px;color:${GOLD};margin-bottom:6px">${l}</div>
-      <div style="font-family:'S';font-size:50px;color:${CREAM};line-height:1.1">${esc(v)}</div></div>`).join('');
-  return slide(F, `
-   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">DOSSIER</div>
-   <div style="position:absolute;top:220px;left:0;right:0">${rows}</div>`);
+  const rows = fields.map(([l, v]) => `<div style="margin-bottom:40px">
+      <div style="font-size:30px;letter-spacing:4px;color:${GOLD};margin-bottom:8px">${l}</div>
+      <div style="font-family:'S';font-size:52px;color:${CREAM};line-height:1.12">${esc(v)}</div></div>`).join('');
+  return slide(F, `<div class="body"><div class="h1">DOSSIER</div>
+    <div style="width:100%;max-width:820px;text-align:left">${rows}</div></div>`);
 }
 
 function slideNumbers(h, F, year) {
@@ -67,64 +66,56 @@ function slideNumbers(h, F, year) {
     h.issue_count ? [fmt(h.issue_count), 'COMIC ISSUES'] : null,
     h.wikidata_sitelinks ? [fmt(h.wikidata_sitelinks), 'LANGUAGES'] : null,
   ].filter(Boolean).slice(0, 4);
-  const cells = tiles.map((t) => `<div style="width:410px;height:300px;margin:16px;border-radius:40px;border:2px solid rgba(224,168,62,.32);background:rgba(245,235,220,.04);display:flex;flex-direction:column;align-items:center;justify-content:center">
+  const cells = tiles.map((t) => `<div style="width:420px;height:320px;margin:18px;border-radius:40px;border:2px solid rgba(224,168,62,.32);background:rgba(245,235,220,.04);display:flex;flex-direction:column;align-items:center;justify-content:center">
       <div class="pop" style="font-size:120px;color:${CREAM}">${t[0]}</div>
-      <div style="font-size:32px;letter-spacing:3px;color:${GOLD};margin-top:6px">${t[1]}</div></div>`).join('');
-  return slide(F, `
-   <div style="position:absolute;top:104px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">BY THE NUMBERS</div>
-   <div style="position:absolute;top:280px;left:70px;right:70px;display:flex;flex-wrap:wrap;justify-content:center">${cells}</div>`);
+      <div style="font-size:32px;letter-spacing:3px;color:${GOLD};margin-top:10px">${t[1]}</div></div>`).join('');
+  return slide(F, `<div class="body"><div class="h1">BY THE NUMBERS</div>
+    <div class="full" style="display:flex;flex-wrap:wrap;justify-content:center">${cells}</div></div>`);
 }
 
 function slideStats(h, F) {
   const rows = STAT_KEYS.map((k) => {
     const v = h[k] ?? 0;
-    return `<div style="margin:0 0 28px 0;padding:0 90px">
-      <div style="display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:10px"><span style="font-size:38px;letter-spacing:3px;color:${GOLD}">${k.toUpperCase()}</span><span class="pop" style="font-size:64px;color:${CREAM}">${v}</span></div>
-      <div style="height:34px;border-radius:20px;overflow:hidden;background:#0e2330;border:4px solid rgba(245,235,220,.15)"><div style="width:${v}%;height:100%;background:linear-gradient(90deg, ${O}, ${GOLD})"></div></div></div>`;
+    return `<div style="margin-bottom:34px">
+      <div style="display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:12px"><span style="font-size:38px;letter-spacing:3px;color:${GOLD}">${k.toUpperCase()}</span><span class="pop" style="font-size:64px;color:${CREAM}">${v}</span></div>
+      <div style="height:36px;border-radius:20px;overflow:hidden;background:#0e2330;border:4px solid rgba(245,235,220,.15)"><div style="width:${v}%;height:100%;background:linear-gradient(90deg, ${O}, ${GOLD})"></div></div></div>`;
   }).join('');
-  return slide(F, `
-   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">POWER STATS</div>
-   <div style="position:absolute;top:210px;left:0;right:0">${rows}</div>`);
+  return slide(F, `<div class="body"><div class="h1">POWER STATS</div><div class="full">${rows}</div></div>`);
 }
 
 function slideAbilities(h, F) {
   const powers = (Array.isArray(h.powers) ? h.powers : []).slice(0, 12);
-  const chips = powers.map((p) => `<div style="display:inline-block;margin:12px;padding:18px 38px;border-radius:100px;border:2px solid rgba(224,168,62,.42);background:rgba(245,235,220,.05);font-size:46px;color:${CREAM}">${esc(p)}</div>`).join('');
-  return slide(F, `
-   <div style="position:absolute;top:120px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">ABILITIES</div>
-   <div style="position:absolute;top:270px;left:70px;right:70px;text-align:center">${chips}</div>`);
+  const chips = powers.map((p) => `<div style="display:inline-block;margin:14px;padding:20px 40px;border-radius:100px;border:2px solid rgba(224,168,62,.42);background:rgba(245,235,220,.05);font-size:48px;color:${CREAM}">${esc(p)}</div>`).join('');
+  return slide(F, `<div class="body"><div class="h1">ABILITIES</div><div class="full">${chips}</div></div>`);
 }
 
 function thumbRow(label, tone, people) {
-  const cells = people.map((p) => `<div style="display:inline-block;width:200px;margin:0 8px;text-align:center;vertical-align:top">
-      <div style="width:158px;height:158px;border-radius:50%;overflow:hidden;border:5px solid ${tone};margin:0 auto;box-shadow:0 10px 30px rgba(0,0,0,.5)"><img src="${p.img}" style="width:100%;height:100%;object-fit:cover"></div>
-      <div style="font-family:'S';font-size:28px;color:${CREAM};margin-top:12px;line-height:1.05">${esc(clip(p.name, 16))}</div></div>`).join('');
-  return `<div style="margin-bottom:44px"><div style="text-align:center;font-size:40px;letter-spacing:5px;color:${tone};margin-bottom:20px">${label}</div><div style="text-align:center;white-space:nowrap">${cells}</div></div>`;
+  const cells = people.map((p) => `<div style="display:inline-block;width:210px;margin:0 8px;text-align:center;vertical-align:top">
+      <div style="width:168px;height:168px;border-radius:50%;overflow:hidden;border:5px solid ${tone};margin:0 auto;box-shadow:0 10px 30px rgba(0,0,0,.5)"><img src="${p.img}" style="width:100%;height:100%;object-fit:cover"></div>
+      <div style="font-family:'S';font-size:29px;color:${CREAM};margin-top:14px;line-height:1.05">${esc(clip(p.name, 16))}</div></div>`).join('');
+  return `<div style="margin-bottom:60px"><div style="text-align:center;font-size:42px;letter-spacing:5px;color:${tone};margin-bottom:24px">${label}</div><div style="text-align:center;white-space:nowrap">${cells}</div></div>`;
 }
 
 function slideAssociates(F, groups) {
   const rows = groups.map((g) => thumbRow(g.label, g.tone, g.people)).join('');
-  return slide(F, `
-   <div style="position:absolute;top:88px;left:0;right:0;text-align:center;font-size:60px;letter-spacing:4px;color:${GOLD}" class="stroke">KNOWN ASSOCIATES</div>
-   <div style="position:absolute;top:210px;left:30px;right:30px">${rows}</div>`);
+  return slide(F, `<div class="body"><div class="h1">KNOWN ASSOCIATES</div><div class="full">${rows}</div></div>`);
 }
 
 function slideFacts(h, F, facts) {
-  const items = facts.map((f) => `<div style="display:flex;align-items:flex-start;gap:26px;margin:0 80px 44px 80px;text-align:left">
-      <div style="color:${GOLD};font-size:60px;line-height:1">◆</div>
-      <div style="font-family:'S';font-size:52px;color:${CREAM};line-height:1.24">${f}</div></div>`).join('');
-  return slide(F, `
-   <div style="position:absolute;top:120px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">DID YOU KNOW</div>
-   <div style="position:absolute;top:320px;left:0;right:0">${items}</div>`);
+  const items = facts.map((f) => `<div style="display:flex;align-items:flex-start;gap:28px;margin-bottom:52px;text-align:left">
+      <div style="color:${GOLD};font-size:56px;line-height:1.05">◆</div>
+      <div style="font-family:'S';font-size:54px;color:${CREAM};line-height:1.26">${f}</div></div>`).join('');
+  return slide(F, `<div class="body"><div class="h1">DID YOU KNOW</div>
+    <div style="width:100%;max-width:860px">${items}</div></div>`);
 }
 
 function slideCta(h, F) {
-  return slide(F, `
-   <div style="position:absolute;top:300px;left:0;right:0;text-align:center;font-size:54px;color:${CREAM}">one of <span class="g">34,000+</span> characters</div>
-   <div style="position:absolute;top:470px;left:0;right:0;text-align:center;font-size:78px" class="stroke">full profile on <span class="g">mythique.app</span></div>
-   <div style="position:absolute;top:610px;left:0;right:0;text-align:center;font-family:'S';font-size:42px;color:#9db4c4">stats · powers · rivalries · every matchup</div>
-   <div style="position:absolute;top:820px;left:0;right:0;text-align:center;font-size:64px" class="stroke">follow <span class="g">@mythiqueapp</span></div>
-   <div style="position:absolute;top:940px;left:0;right:0;text-align:center;font-family:'S';font-size:38px;color:#9db4c4">for daily matchups & character files</div>`);
+  return slide(F, `<div class="body">
+    <div style="font-size:54px;color:${CREAM};margin-bottom:70px">one of <span class="g">34,000+</span> characters</div>
+    <div style="font-size:82px;margin-bottom:16px" class="stroke">full profile on <span class="g">mythique.app</span></div>
+    <div style="font-family:'S';font-size:42px;color:#9db4c4;margin-bottom:90px">stats · powers · rivalries · every matchup</div>
+    <div style="font-size:66px;margin-bottom:16px" class="stroke">follow <span class="g">@mythiqueapp</span></div>
+    <div style="font-family:'S';font-size:38px;color:#9db4c4">for daily matchups &amp; character files</div></div>`);
 }
 
 function buildFacts(h, year, enemies) {

--- a/scripts/social/generate-bios.mjs
+++ b/scripts/social/generate-bios.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Mythique character-showcase carousels — a 4:5 "character file" that flexes the
-// depth of the catalogue for a single character: portrait, power stats, profile
-// dossier, and aliases. Shows off what a Mythique page holds.
+// Mythique character-file carousels — a rich 4:5 dossier for one character that
+// flexes the catalogue depth: cover, profile, by-the-numbers footprint, power
+// stats, abilities, associates (enemies/allies/family), and did-you-know facts.
 //
 //   node scripts/social/generate-bios.mjs --character "Batman"
 //   node scripts/social/generate-bios.mjs --count 6            # random popular
@@ -12,36 +12,67 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
-  loadEnv, makeSb, heroFullByName, popularHeroes, portraitDataUri, fonts,
-  OUT_DIR, renderPng, COLORS, slide, STAT_KEYS,
+  loadEnv, makeSb, heroFullByName, popularHeroes, portraitDataUri, imgDataUri,
+  getRelated, getFamily, getFact, fonts, OUT_DIR, renderPng, COLORS, slide, STAT_KEYS,
 } from './lib.mjs';
 
 const { O, T, GOLD, CREAM, NAVY } = COLORS;
+const RED = '#e2503f';
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const clip = (s, n) => { s = String(s ?? ''); return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s; };
 const titlecase = (s) => String(s ?? '').replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
-
 const realVal = (v) => v && String(v).trim() && String(v).trim() !== '-';
+const fmt = (n) => Number(n).toLocaleString('en-US');
+const YEAR = new Date().getFullYear();
 
 function tagline(h) {
   const name = h.name.toLowerCase();
   const aliases = (Array.isArray(h.aliases) ? h.aliases : [])
-    .filter((a) => a && a.trim().length > 3 && a.length <= 24
-      && a.toLowerCase() !== name
-      && !a.toLowerCase().startsWith(name) // drop "Batman II", "Superman Prime"
-      && !/[0-9]/.test(a));
-  const epithet = aliases.find((a) => /^the\s/i.test(a)) || aliases[0];
-  return (epithet || h.publisher || 'Mythique').toUpperCase();
+    .filter((a) => a && a.trim().length > 3 && a.length <= 24 && a.toLowerCase() !== name
+      && !a.toLowerCase().startsWith(name) && !/[0-9]/.test(a));
+  return ((aliases.find((a) => /^the\s/i.test(a)) || aliases[0]) || h.publisher || 'Mythique').toUpperCase();
 }
 
+// ---- slides ----
 function slideCover(h, img, F) {
-  const inner = `
+  return slide(F, `
    <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:34px;letter-spacing:8px;color:${GOLD}">CHARACTER FILE</div>
    <div style="position:absolute;top:150px;left:40px;right:40px;text-align:center;font-size:110px;color:${CREAM}" class="stroke">${esc(h.name.toUpperCase())}</div>
    <div class="sqc" style="position:absolute;top:326px;left:50%;transform:translateX(-50%);width:600px;height:660px;border:8px solid ${GOLD};box-shadow:0 24px 70px rgba(0,0,0,.6),0 0 90px -18px ${GOLD}"><img src="${img}"><div class="glare"></div></div>
    <div style="position:absolute;top:1030px;left:0;right:0;text-align:center;font-size:52px;letter-spacing:5px;color:${GOLD}">${esc(tagline(h))}</div>
-   <div style="position:absolute;top:1108px;left:0;right:0;text-align:center;font-family:'S';font-size:34px;color:#9db4c4">${esc(h.publisher || '')}  ·  swipe →</div>`;
-  return slide(F, inner);
+   <div style="position:absolute;top:1108px;left:0;right:0;text-align:center;font-family:'S';font-size:34px;color:#9db4c4">${esc(h.publisher || '')}  ·  swipe →</div>`);
+}
+
+function slideDossier(h, F, year) {
+  const fields = [
+    ['REAL NAME', h.full_name],
+    ['FIRST APPEARANCE', year ? `${h.first_appearance || ''} (${year})`.trim() : h.first_appearance],
+    ['RACE', h.race],
+    ['ALIGNMENT', h.alignment ? titlecase(h.alignment) : ''],
+    ['OCCUPATION', clip(h.occupation, 46)],
+    ['TEAMS', clip(h.group_affiliation, 46)],
+  ].filter(([, v]) => realVal(v));
+  const rows = fields.map(([l, v]) => `<div style="margin:0 0 38px 0;padding:0 90px">
+      <div style="font-size:30px;letter-spacing:4px;color:${GOLD};margin-bottom:6px">${l}</div>
+      <div style="font-family:'S';font-size:50px;color:${CREAM};line-height:1.1">${esc(v)}</div></div>`).join('');
+  return slide(F, `
+   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">DOSSIER</div>
+   <div style="position:absolute;top:220px;left:0;right:0">${rows}</div>`);
+}
+
+function slideNumbers(h, F, year) {
+  const tiles = [
+    year ? [fmt(YEAR - year), 'YEARS ACTIVE'] : null,
+    h.movie_count ? [fmt(h.movie_count), 'FILM APPEARANCES'] : null,
+    h.issue_count ? [fmt(h.issue_count), 'COMIC ISSUES'] : null,
+    h.wikidata_sitelinks ? [fmt(h.wikidata_sitelinks), 'LANGUAGES'] : null,
+  ].filter(Boolean).slice(0, 4);
+  const cells = tiles.map((t) => `<div style="width:410px;height:300px;margin:16px;border-radius:40px;border:2px solid rgba(224,168,62,.32);background:rgba(245,235,220,.04);display:flex;flex-direction:column;align-items:center;justify-content:center">
+      <div class="pop" style="font-size:120px;color:${CREAM}">${t[0]}</div>
+      <div style="font-size:32px;letter-spacing:3px;color:${GOLD};margin-top:6px">${t[1]}</div></div>`).join('');
+  return slide(F, `
+   <div style="position:absolute;top:104px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">BY THE NUMBERS</div>
+   <div style="position:absolute;top:280px;left:70px;right:70px;display:flex;flex-wrap:wrap;justify-content:center">${cells}</div>`);
 }
 
 function slideStats(h, F) {
@@ -51,51 +82,107 @@ function slideStats(h, F) {
       <div style="display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:10px"><span style="font-size:38px;letter-spacing:3px;color:${GOLD}">${k.toUpperCase()}</span><span class="pop" style="font-size:64px;color:${CREAM}">${v}</span></div>
       <div style="height:34px;border-radius:20px;overflow:hidden;background:#0e2330;border:4px solid rgba(245,235,220,.15)"><div style="width:${v}%;height:100%;background:linear-gradient(90deg, ${O}, ${GOLD})"></div></div></div>`;
   }).join('');
-  const inner = `
+  return slide(F, `
    <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">POWER STATS</div>
-   <div style="position:absolute;top:210px;left:0;right:0">${rows}</div>`;
-  return slide(F, inner);
+   <div style="position:absolute;top:210px;left:0;right:0">${rows}</div>`);
 }
 
-function slideProfile(h, F) {
-  const fields = [
-    ['REAL NAME', h.full_name],
-    ['FIRST APPEARANCE', h.first_appearance],
-    ['RACE', h.race],
-    ['ALIGNMENT', h.alignment ? titlecase(h.alignment) : ''],
-    ['OCCUPATION', clip(h.occupation, 46)],
-    ['TEAM', clip(h.group_affiliation, 46)],
-  ].filter(([, v]) => realVal(v));
-  const rows = fields.map(([label, v]) => `<div style="margin:0 0 40px 0;padding:0 90px">
-      <div style="font-size:30px;letter-spacing:4px;color:${GOLD};margin-bottom:6px">${label}</div>
-      <div style="font-family:'S';font-size:50px;color:${CREAM};line-height:1.1">${esc(v)}</div></div>`).join('');
-  const inner = `
-   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">PROFILE</div>
-   <div style="position:absolute;top:220px;left:0;right:0">${rows}</div>`;
-  return slide(F, inner);
+function slideAbilities(h, F) {
+  const powers = (Array.isArray(h.powers) ? h.powers : []).slice(0, 12);
+  const chips = powers.map((p) => `<div style="display:inline-block;margin:12px;padding:18px 38px;border-radius:100px;border:2px solid rgba(224,168,62,.42);background:rgba(245,235,220,.05);font-size:46px;color:${CREAM}">${esc(p)}</div>`).join('');
+  return slide(F, `
+   <div style="position:absolute;top:120px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">ABILITIES</div>
+   <div style="position:absolute;top:270px;left:70px;right:70px;text-align:center">${chips}</div>`);
 }
 
-function slideAka(h, F) {
-  const aliases = (Array.isArray(h.aliases) ? h.aliases : []).filter((a) => a && a.toLowerCase() !== h.name.toLowerCase()).slice(0, 4);
-  const chips = aliases.map((a) => `<div style="display:inline-block;margin:10px;padding:16px 34px;border-radius:100px;border:2px solid rgba(224,168,62,.4);background:rgba(245,235,220,.05);font-size:44px;color:${CREAM}">${esc(a)}</div>`).join('');
-  const inner = `
-   <div style="position:absolute;top:150px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">ALSO KNOWN AS</div>
-   <div style="position:absolute;top:300px;left:80px;right:80px;text-align:center">${chips || `<div style="font-family:'S';font-size:44px;color:#9db4c4">${esc(h.name)}</div>`}</div>
-   <div style="position:absolute;top:760px;left:0;right:0;text-align:center;font-size:52px;color:${CREAM}">one of <span class="g">34,000+</span> characters</div>
-   <div style="position:absolute;top:930px;left:0;right:0;text-align:center;font-size:70px" class="stroke">full profile on <span class="g">mythique.app</span></div>
-   <div style="position:absolute;top:1070px;left:0;right:0;text-align:center;font-family:'S';font-size:40px;color:#9db4c4">follow @mythiqueapp for daily matchups</div>`;
-  return slide(F, inner);
+function thumbRow(label, tone, people) {
+  const cells = people.map((p) => `<div style="display:inline-block;width:200px;margin:0 8px;text-align:center;vertical-align:top">
+      <div style="width:158px;height:158px;border-radius:50%;overflow:hidden;border:5px solid ${tone};margin:0 auto;box-shadow:0 10px 30px rgba(0,0,0,.5)"><img src="${p.img}" style="width:100%;height:100%;object-fit:cover"></div>
+      <div style="font-family:'S';font-size:28px;color:${CREAM};margin-top:12px;line-height:1.05">${esc(clip(p.name, 16))}</div></div>`).join('');
+  return `<div style="margin-bottom:44px"><div style="text-align:center;font-size:40px;letter-spacing:5px;color:${tone};margin-bottom:20px">${label}</div><div style="text-align:center;white-space:nowrap">${cells}</div></div>`;
+}
+
+function slideAssociates(F, groups) {
+  const rows = groups.map((g) => thumbRow(g.label, g.tone, g.people)).join('');
+  return slide(F, `
+   <div style="position:absolute;top:88px;left:0;right:0;text-align:center;font-size:60px;letter-spacing:4px;color:${GOLD}" class="stroke">KNOWN ASSOCIATES</div>
+   <div style="position:absolute;top:210px;left:30px;right:30px">${rows}</div>`);
+}
+
+function slideFacts(h, F, facts) {
+  const items = facts.map((f) => `<div style="display:flex;align-items:flex-start;gap:26px;margin:0 80px 44px 80px;text-align:left">
+      <div style="color:${GOLD};font-size:60px;line-height:1">◆</div>
+      <div style="font-family:'S';font-size:52px;color:${CREAM};line-height:1.24">${f}</div></div>`).join('');
+  return slide(F, `
+   <div style="position:absolute;top:120px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">DID YOU KNOW</div>
+   <div style="position:absolute;top:320px;left:0;right:0">${items}</div>`);
+}
+
+function slideCta(h, F) {
+  return slide(F, `
+   <div style="position:absolute;top:300px;left:0;right:0;text-align:center;font-size:54px;color:${CREAM}">one of <span class="g">34,000+</span> characters</div>
+   <div style="position:absolute;top:470px;left:0;right:0;text-align:center;font-size:78px" class="stroke">full profile on <span class="g">mythique.app</span></div>
+   <div style="position:absolute;top:610px;left:0;right:0;text-align:center;font-family:'S';font-size:42px;color:#9db4c4">stats · powers · rivalries · every matchup</div>
+   <div style="position:absolute;top:820px;left:0;right:0;text-align:center;font-size:64px" class="stroke">follow <span class="g">@mythiqueapp</span></div>
+   <div style="position:absolute;top:940px;left:0;right:0;text-align:center;font-family:'S';font-size:38px;color:#9db4c4">for daily matchups & character files</div>`);
+}
+
+function buildFacts(h, year, enemies) {
+  const out = [];
+  if (year) out.push(`${esc(h.name)} first appeared in <b style="color:${GOLD}">${year}</b>, over <b style="color:${GOLD}">${YEAR - year}</b> years of stories.`);
+  const powers = Array.isArray(h.powers) ? h.powers : [];
+  if (powers.length) out.push(`Wields <b style="color:${GOLD}">${powers.length}</b> distinct abilities in the catalogue.`);
+  if (enemies.length >= 2) out.push(`Has clashed with icons like <b style="color:${GOLD}">${esc(enemies[0].name)}</b> &amp; <b style="color:${GOLD}">${esc(enemies[1].name)}</b>.`);
+  if (out.length < 3 && h.fame_score != null) out.push(`Mythique fame score: <b style="color:${GOLD}">${h.fame_score}/100</b>.`);
+  return out.slice(0, 3);
 }
 
 function caption(h) {
   const tl = titlecase(tagline(h));
+  const bits = [h.movie_count && `${h.movie_count} films`, h.issue_count && `${fmt(h.issue_count)} comics`].filter(Boolean).join('  ·  ');
   return [
-    `Meet ${h.name} — ${tl}. 🦸`, ``,
-    [h.first_appearance && `First appearance: ${h.first_appearance}`, h.race && `Race: ${h.race}`].filter(Boolean).join('  ·  '),
-    ``,
-    `Full profile, powers and every matchup on mythique.app — one of 34,000+ characters.`, ``,
+    `The full file on ${h.name} — ${tl}. 🦸`, ``,
+    bits ? `${bits}. Powers, rivalries, and every matchup on mythique.app.` : `Powers, rivalries, and every matchup on mythique.app.`,
+    `One of 34,000+ characters.`, ``,
     `#${h.name.replace(/[^a-z0-9]/gi, '')} #${(h.publisher || '').replace(/[^a-z0-9]/gi, '')} #superheroes #comics #anime #marvel #dc #mythique`,
   ].join('\n');
+}
+
+async function withThumbs(rows, n) {
+  const picked = (rows || []).filter((r) => r.portrait_url || r.image_md_url || r.image_url).slice(0, n);
+  const out = [];
+  for (const r of picked) {
+    const img = await imgDataUri(r.portrait_url || r.image_md_url || r.image_url);
+    if (img) out.push({ name: r.name, img });
+  }
+  return out;
+}
+
+async function build(sb, h, F) {
+  const [img, year, enemiesRaw, alliesRaw, familyRaw] = await Promise.all([
+    portraitDataUri(h),
+    getFact(sb, h.id, 'first_appearance_year'),
+    getRelated(sb, h.id, 'enemy', 5),
+    getRelated(sb, h.id, 'ally', 5),
+    getFamily(sb, h.id, 5),
+  ]);
+  const yr = year ? parseInt(year, 10) : null;
+  const [enemies, allies, family] = await Promise.all([withThumbs(enemiesRaw, 4), withThumbs(alliesRaw, 4), withThumbs(familyRaw, 4)]);
+  const groups = [
+    enemies.length && { label: 'ENEMIES', tone: RED, people: enemies },
+    allies.length && { label: 'ALLIES', tone: T, people: allies },
+    family.length && { label: 'FAMILY', tone: GOLD, people: family },
+  ].filter(Boolean).slice(0, 3);
+
+  const slides = [slideCover(h, img, F), slideDossier(h, F, yr)];
+  if (year || h.movie_count || h.issue_count || h.wikidata_sitelinks) slides.push(slideNumbers(h, F, yr));
+  slides.push(slideStats(h, F));
+  if ((h.powers || []).length) slides.push(slideAbilities(h, F));
+  if (groups.length) slides.push(slideAssociates(F, groups));
+  const facts = buildFacts(h, yr, enemies);
+  if (facts.length) slides.push(slideFacts(h, F, facts));
+  slides.push(slideCta(h, F));
+  return slides;
 }
 
 async function main() {
@@ -113,7 +200,6 @@ async function main() {
     heroes = [h];
   } else {
     const pool = await popularHeroes(sb, Math.max(count * 3, 30));
-    // deterministic-but-varied sample from the top of the pool
     heroes = pool.filter((_, i) => i % 3 === 0).slice(0, count);
   }
 
@@ -124,8 +210,7 @@ async function main() {
   const F = fonts();
   mkdirSync(OUT_DIR, { recursive: true });
   for (const h of heroes) {
-    const img = await portraitDataUri(h);
-    const slides = [slideCover(h, img, F), slideStats(h, F), slideProfile(h, F), slideAka(h, F)];
+    const slides = await build(sb, h, F);
     const slug = h.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
     const dir = join(OUT_DIR, `bio-${slug}`);
     mkdirSync(dir, { recursive: true });

--- a/scripts/social/generate-bios.mjs
+++ b/scripts/social/generate-bios.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Mythique character-showcase carousels — a 4:5 "character file" that flexes the
+// depth of the catalogue for a single character: portrait, power stats, profile
+// dossier, and aliases. Shows off what a Mythique page holds.
+//
+//   node scripts/social/generate-bios.mjs --character "Batman"
+//   node scripts/social/generate-bios.mjs --count 6            # random popular
+//   node scripts/social/generate-bios.mjs --count 6 --dry-run
+//
+// See ./README.md. Shared data layer + slide shell live in ./lib.mjs.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  loadEnv, makeSb, heroFullByName, popularHeroes, portraitDataUri, fonts,
+  OUT_DIR, renderPng, COLORS, slide, STAT_KEYS,
+} from './lib.mjs';
+
+const { O, T, GOLD, CREAM, NAVY } = COLORS;
+const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const clip = (s, n) => { s = String(s ?? ''); return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s; };
+const titlecase = (s) => String(s ?? '').replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+
+const realVal = (v) => v && String(v).trim() && String(v).trim() !== '-';
+
+function tagline(h) {
+  const name = h.name.toLowerCase();
+  const aliases = (Array.isArray(h.aliases) ? h.aliases : [])
+    .filter((a) => a && a.trim().length > 3 && a.length <= 24
+      && a.toLowerCase() !== name
+      && !a.toLowerCase().startsWith(name) // drop "Batman II", "Superman Prime"
+      && !/[0-9]/.test(a));
+  const epithet = aliases.find((a) => /^the\s/i.test(a)) || aliases[0];
+  return (epithet || h.publisher || 'Mythique').toUpperCase();
+}
+
+function slideCover(h, img, F) {
+  const inner = `
+   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:34px;letter-spacing:8px;color:${GOLD}">CHARACTER FILE</div>
+   <div style="position:absolute;top:150px;left:40px;right:40px;text-align:center;font-size:110px;color:${CREAM}" class="stroke">${esc(h.name.toUpperCase())}</div>
+   <div class="sqc" style="position:absolute;top:326px;left:50%;transform:translateX(-50%);width:600px;height:660px;border:8px solid ${GOLD};box-shadow:0 24px 70px rgba(0,0,0,.6),0 0 90px -18px ${GOLD}"><img src="${img}"><div class="glare"></div></div>
+   <div style="position:absolute;top:1030px;left:0;right:0;text-align:center;font-size:52px;letter-spacing:5px;color:${GOLD}">${esc(tagline(h))}</div>
+   <div style="position:absolute;top:1108px;left:0;right:0;text-align:center;font-family:'S';font-size:34px;color:#9db4c4">${esc(h.publisher || '')}  ·  swipe →</div>`;
+  return slide(F, inner);
+}
+
+function slideStats(h, F) {
+  const rows = STAT_KEYS.map((k) => {
+    const v = h[k] ?? 0;
+    return `<div style="margin:0 0 28px 0;padding:0 90px">
+      <div style="display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:10px"><span style="font-size:38px;letter-spacing:3px;color:${GOLD}">${k.toUpperCase()}</span><span class="pop" style="font-size:64px;color:${CREAM}">${v}</span></div>
+      <div style="height:34px;border-radius:20px;overflow:hidden;background:#0e2330;border:4px solid rgba(245,235,220,.15)"><div style="width:${v}%;height:100%;background:linear-gradient(90deg, ${O}, ${GOLD})"></div></div></div>`;
+  }).join('');
+  const inner = `
+   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">POWER STATS</div>
+   <div style="position:absolute;top:210px;left:0;right:0">${rows}</div>`;
+  return slide(F, inner);
+}
+
+function slideProfile(h, F) {
+  const fields = [
+    ['REAL NAME', h.full_name],
+    ['FIRST APPEARANCE', h.first_appearance],
+    ['RACE', h.race],
+    ['ALIGNMENT', h.alignment ? titlecase(h.alignment) : ''],
+    ['OCCUPATION', clip(h.occupation, 46)],
+    ['TEAM', clip(h.group_affiliation, 46)],
+  ].filter(([, v]) => realVal(v));
+  const rows = fields.map(([label, v]) => `<div style="margin:0 0 40px 0;padding:0 90px">
+      <div style="font-size:30px;letter-spacing:4px;color:${GOLD};margin-bottom:6px">${label}</div>
+      <div style="font-family:'S';font-size:50px;color:${CREAM};line-height:1.1">${esc(v)}</div></div>`).join('');
+  const inner = `
+   <div style="position:absolute;top:92px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:5px;color:${GOLD}" class="stroke">PROFILE</div>
+   <div style="position:absolute;top:220px;left:0;right:0">${rows}</div>`;
+  return slide(F, inner);
+}
+
+function slideAka(h, F) {
+  const aliases = (Array.isArray(h.aliases) ? h.aliases : []).filter((a) => a && a.toLowerCase() !== h.name.toLowerCase()).slice(0, 4);
+  const chips = aliases.map((a) => `<div style="display:inline-block;margin:10px;padding:16px 34px;border-radius:100px;border:2px solid rgba(224,168,62,.4);background:rgba(245,235,220,.05);font-size:44px;color:${CREAM}">${esc(a)}</div>`).join('');
+  const inner = `
+   <div style="position:absolute;top:150px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">ALSO KNOWN AS</div>
+   <div style="position:absolute;top:300px;left:80px;right:80px;text-align:center">${chips || `<div style="font-family:'S';font-size:44px;color:#9db4c4">${esc(h.name)}</div>`}</div>
+   <div style="position:absolute;top:760px;left:0;right:0;text-align:center;font-size:52px;color:${CREAM}">one of <span class="g">34,000+</span> characters</div>
+   <div style="position:absolute;top:930px;left:0;right:0;text-align:center;font-size:70px" class="stroke">full profile on <span class="g">mythique.app</span></div>
+   <div style="position:absolute;top:1070px;left:0;right:0;text-align:center;font-family:'S';font-size:40px;color:#9db4c4">follow @mythiqueapp for daily matchups</div>`;
+  return slide(F, inner);
+}
+
+function caption(h) {
+  const tl = titlecase(tagline(h));
+  return [
+    `Meet ${h.name} — ${tl}. 🦸`, ``,
+    [h.first_appearance && `First appearance: ${h.first_appearance}`, h.race && `Race: ${h.race}`].filter(Boolean).join('  ·  '),
+    ``,
+    `Full profile, powers and every matchup on mythique.app — one of 34,000+ characters.`, ``,
+    `#${h.name.replace(/[^a-z0-9]/gi, '')} #${(h.publisher || '').replace(/[^a-z0-9]/gi, '')} #superheroes #comics #anime #marvel #dc #mythique`,
+  ].join('\n');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (f, d) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : d; };
+  const dry = args.includes('--dry-run');
+  const count = parseInt(get('--count', '6'), 10);
+  const character = get('--character', null);
+
+  const sb = makeSb(loadEnv());
+  let heroes;
+  if (character) {
+    const h = await heroFullByName(sb, character);
+    if (!h) { console.error('Character not found:', character); process.exit(1); }
+    heroes = [h];
+  } else {
+    const pool = await popularHeroes(sb, Math.max(count * 3, 30));
+    // deterministic-but-varied sample from the top of the pool
+    heroes = pool.filter((_, i) => i % 3 === 0).slice(0, count);
+  }
+
+  console.log(`\n${heroes.length} character(s):`);
+  for (const h of heroes) console.log(`  ${h.name} (${h.publisher || '—'}, fame ${h.fame_score})`);
+  if (dry) return;
+
+  const F = fonts();
+  mkdirSync(OUT_DIR, { recursive: true });
+  for (const h of heroes) {
+    const img = await portraitDataUri(h);
+    const slides = [slideCover(h, img, F), slideStats(h, F), slideProfile(h, F), slideAka(h, F)];
+    const slug = h.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const dir = join(OUT_DIR, `bio-${slug}`);
+    mkdirSync(dir, { recursive: true });
+    console.log(`Rendering ${h.name} character file (${slides.length} slides)...`);
+    for (let i = 0; i < slides.length; i++) await renderPng(slides[i], join(dir, `slide-${i + 1}.png`), 1080, 1350);
+    writeFileSync(join(dir, 'caption.txt'), caption(h));
+    console.log(`  -> ${dir}`);
+  }
+  console.log('\nDone. Upload slides in order as an Instagram carousel.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/social/generate-carousels.mjs
+++ b/scripts/social/generate-carousels.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Mythique carousel generator — 4:5 (1080x1350) Instagram carousel slides for
+// a matchup, from real data, styled like the app. Outputs a swipe set of PNGs
+// plus a caption.
+//
+//   node scripts/social/generate-carousels.mjs --count 6
+//   node scripts/social/generate-carousels.mjs --matchup "Goku,Superman"
+//   node scripts/social/generate-carousels.mjs --count 6 --dry-run
+//
+// Slides: 1) cover / hook  2) tale of the tape  3) verdict + winner
+//         4) fan vote + CTA.  See ./README.md.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  loadEnv, makeSb, selectMatchups, resolveManual, hydrate, fonts, slugFor,
+  OUT_DIR, renderPng, COLORS, grainUri, fontFace, STAT_KEYS,
+} from './lib.mjs';
+
+const { O, T, GOLD, CREAM, NAVY } = COLORS;
+const cap1 = (s) => s.charAt(0).toUpperCase() + s.slice(1);
+
+const BASE = (F) => `${fontFace(F)}
+*{margin:0;padding:0;box-sizing:border-box;}html,body{width:1080px;height:1350px;overflow:hidden;background:${NAVY};font-family:'F';color:${CREAM};}
+.page{position:relative;width:1080px;height:1350px;overflow:hidden;background:radial-gradient(60% 44% at 50% 32%, rgba(224,168,62,.12), transparent 62%), radial-gradient(120% 90% at 50% 8%, #12242f, ${NAVY} 72%);}
+.dots{position:absolute;inset:0;background-image:radial-gradient(circle, rgba(224,168,62,.10) 1.3px, transparent 1.9px);background-size:30px;-webkit-mask-image:radial-gradient(130% 100% at 50% 40%, transparent 42%, #000);opacity:.55;}
+.grain{position:absolute;inset:0;background-image:url("${grainUri()}");background-size:340px;opacity:.05;mix-blend-mode:overlay;}
+.foot{position:absolute;bottom:46px;left:0;right:0;display:flex;align-items:center;justify-content:center;gap:16px;opacity:.9;}
+.foot .wm{font-family:'R';font-size:40px;color:${CREAM};}.foot .at{font-family:'F';font-size:26px;color:${GOLD};letter-spacing:1px;}
+.g{color:${GOLD};}.o{color:${O};}.t{color:${T};}
+.sqc{position:relative;border-radius:23%/17%;overflow:hidden;box-shadow:0 24px 60px rgba(0,0,0,.6);}
+.sqc img{width:100%;height:100%;object-fit:cover;}.sqc img.flip{transform:scaleX(-1);}.sqc .glare{position:absolute;inset:0;background:linear-gradient(120deg,rgba(255,255,255,.13),transparent 40%);}
+.stroke{-webkit-text-stroke:8px ${NAVY};paint-order:stroke fill;}
+`;
+
+const page = (F, inner, extra = '') => `<!doctype html><html><head><meta charset="utf-8"><style>${BASE(F)}${extra}</style></head><body><div class="page"><div class="dots"></div><div class="grain"></div>${inner}<div class="foot"><span class="wm">mythique</span><span class="at">@mythiqueapp</span></div></div></body></html>`;
+
+const brandFootHidden = ''; // slides all share the footer
+
+function slideCover(M, F) {
+  const inner = `
+   <div style="position:absolute;top:96px;left:60px;right:60px;text-align:center;font-size:88px" class="stroke"><span class="o">${M.a.name}</span> <span class="g">vs</span> <span class="t">${M.b.name}</span></div>
+   <div class="sqc" style="position:absolute;top:400px;left:70px;width:420px;height:540px;border:7px solid ${O};box-shadow:0 24px 60px rgba(0,0,0,.6),0 0 60px -12px ${O}"><img src="${M.a.img}"><div class="glare"></div></div>
+   <div class="sqc" style="position:absolute;top:400px;right:70px;width:420px;height:540px;border:7px solid ${T};box-shadow:0 24px 60px rgba(0,0,0,.6),0 0 60px -12px ${T}"><img class="flip" src="${M.b.img}"><div class="glare"></div></div>
+   <div style="position:absolute;top:640px;left:50%;transform:translateX(-50%);width:150px;height:150px;border-radius:50%;background:${NAVY};border:6px solid ${GOLD};color:${GOLD};display:flex;align-items:center;justify-content:center;font-size:66px;box-shadow:0 0 0 9px ${NAVY},0 0 60px rgba(224,168,62,.7);z-index:5">VS</div>
+   <div style="position:absolute;top:1010px;left:0;right:0;text-align:center;font-size:96px" class="stroke">WHO WOULD <span class="g">WIN?</span></div>
+   <div style="position:absolute;top:1150px;left:0;right:0;text-align:center;font-family:'S';font-size:38px;color:#9db4c4">swipe to find out →</div>`;
+  return page(F, inner);
+}
+
+function slideTape(M, F) {
+  const rows = STAT_KEYS.map((k) => {
+    const av = M.stats[k], bv = M.stats2[k];
+    const pa = Math.round((av / (av + bv || 1)) * 100);
+    const ca = bv > av ? '#64757f' : O; // strict loser goes muted; ties stay full colour
+    const cb = av > bv ? '#64757f' : T;
+    return `<div style="margin:0 0 22px 0">
+      <div style="text-align:center;font-size:31px;letter-spacing:3px;color:${GOLD};margin-bottom:8px">${k.toUpperCase()}</div>
+      <div style="display:flex;align-items:center;gap:24px;padding:0 70px">
+        <span class="stroke" style="width:150px;text-align:right;font-size:62px;color:${ca}">${av}</span>
+        <div style="flex:1;height:32px;border-radius:20px;overflow:hidden;display:flex;border:4px solid rgba(245,235,220,.15);background:#0e2330"><div style="width:${pa}%;background:${O}"></div><div style="flex:1;background:${T}"></div></div>
+        <span class="stroke" style="width:150px;text-align:left;font-size:62px;color:${cb}">${bv}</span>
+      </div></div>`;
+  }).join('');
+  const inner = `
+   <div style="position:absolute;top:76px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">TALE OF THE TAPE</div>
+   <div style="position:absolute;top:180px;left:70px;right:70px;display:flex;justify-content:space-between;font-size:52px" class="stroke"><span class="o">${M.a.name}</span><span class="t">${M.b.name}</span></div>
+   <div style="position:absolute;top:276px;left:0;right:0">${rows}</div>`;
+  return page(F, inner);
+}
+
+function slideVerdict(M, F) {
+  const win = M[M.winner];
+  const inner = `
+   <div style="position:absolute;top:96px;left:0;right:0;text-align:center;font-size:52px;letter-spacing:6px;color:${GOLD}">WINNER</div>
+   <div style="position:absolute;top:150px;left:50%;transform:translateX(-50%);width:220px;height:8px;background:${GOLD};border-radius:6px"></div>
+   <div class="sqc" style="position:absolute;top:230px;left:50%;transform:translateX(-50%);width:470px;height:600px;border:8px solid ${GOLD};box-shadow:0 0 120px 8px rgba(224,168,62,.75)"><img class="${win.flip ? 'flip' : ''}" src="${win.img}"><div class="glare"></div></div>
+   <div style="position:absolute;top:836px;left:0;right:0;text-align:center;font-size:96px;color:${GOLD}" class="stroke">${win.name} WINS</div>
+   <div style="position:absolute;top:964px;left:90px;right:90px;text-align:center;font-family:'R';font-size:46px;line-height:1.32;color:${CREAM}"><span style="color:${GOLD};font-size:76px;vertical-align:-16px">&ldquo;</span>${M.verdict}<span style="color:${GOLD};font-size:76px;vertical-align:-16px">&rdquo;</span></div>`;
+  return page(F, inner);
+}
+
+function slideVote(M, F) {
+  const lead = M.voteA >= M.voteB ? M.a.name : M.b.name;
+  const inner = `
+   <div style="position:absolute;top:150px;left:0;right:0;text-align:center;font-size:80px" class="stroke">BUT THE <span class="g">FANS</span><br>DISAGREE</div>
+   <div style="position:absolute;top:560px;left:90px;right:90px;height:80px;border-radius:44px;overflow:hidden;display:flex;border:6px solid rgba(245,235,220,.2)"><div style="width:${M.voteA}%;background:${O}"></div><div style="flex:1;background:${T}"></div></div>
+   <div style="position:absolute;top:680px;left:90px;right:90px;display:flex;justify-content:space-between;font-size:96px" class="stroke"><span class="o">${M.voteA}%</span><span class="t">${M.voteB}%</span></div>
+   <div style="position:absolute;top:840px;left:0;right:0;text-align:center;font-family:'S';font-size:44px;color:#9db4c4">${lead} is winning the vote</div>
+   <div style="position:absolute;top:990px;left:0;right:0;text-align:center;font-size:76px" class="stroke">who's <span class="g">YOUR</span> pick?</div>
+   <div style="position:absolute;top:1110px;left:0;right:0;text-align:center;font-family:'S';font-size:40px;color:${CREAM}">comment below 👇  ·  vote on mythique.app</div>`;
+  return page(F, inner);
+}
+
+function buildSlides(M, F) {
+  return [slideCover(M, F), slideTape(M, F), slideVerdict(M, F), slideVote(M, F)];
+}
+
+function buildMatchup(h) {
+  const stats = Object.fromEntries(STAT_KEYS.map((k) => [k, h.ka[k] ?? 0]));
+  const stats2 = Object.fromEntries(STAT_KEYS.map((k) => [k, h.kb[k] ?? 0]));
+  return {
+    a: { name: h.ka.name.toUpperCase(), img: h.portraitA, flip: false },
+    b: { name: h.kb.name.toUpperCase(), img: h.portraitB, flip: true },
+    winner: h.winner, verdict: h.verdict, voteA: h.voteA, voteB: h.voteB, stats, stats2,
+  };
+}
+
+function caption(M) {
+  const a = M.a.name, b = M.b.name, w = M[M.winner].name;
+  const lead = M.voteA >= M.voteB ? a : b;
+  return [
+    `${cap1(a.toLowerCase())} vs ${cap1(b.toLowerCase())} — who would win? Swipe for the tale of the tape 🥊`, ``,
+    `Our model gives it to ${cap1(w.toLowerCase())}, but the fans have ${cap1(lead.toLowerCase())} ahead ${Math.max(M.voteA, M.voteB)}/${Math.min(M.voteA, M.voteB)}.`,
+    `Who's right? Drop your pick 👇`, ``,
+    `Explore 34,000+ characters and settle any matchup on mythique.app`, ``,
+    `#whowouldwin #${a.replace(/[^a-z0-9]/gi, '')} #${b.replace(/[^a-z0-9]/gi, '')} #superheroes #anime #marvel #dc #comics #powerscaling #mythique`,
+  ].join('\n');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (f, d) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : d; };
+  const dry = args.includes('--dry-run');
+  const count = parseInt(get('--count', '6'), 10);
+  const manual = get('--matchup', null);
+
+  const sb = makeSb(loadEnv());
+  const selections = manual ? [await resolveManual(sb, manual)] : (console.log(`Selecting ${count} popular, close-vote matchups...`), await selectMatchups(sb, count));
+
+  console.log(`\n${selections.length} matchup(s):`);
+  for (const s of selections) console.log(`  ${s.ka.name} vs ${s.kb.name}  —  ${s.pctA}/${s.pctB}  (${s.total} votes)`);
+  if (dry) return;
+
+  const F = fonts();
+  mkdirSync(OUT_DIR, { recursive: true });
+  for (const s of selections) {
+    const M = buildMatchup(await hydrate(sb, s));
+    const dir = join(OUT_DIR, slugFor(s), 'carousel');
+    mkdirSync(dir, { recursive: true });
+    const slides = buildSlides(M, F);
+    console.log(`Rendering ${slugFor(s)} carousel (${slides.length} slides)...`);
+    for (let i = 0; i < slides.length; i++) {
+      await renderPng(slides[i], join(dir, `slide-${i + 1}.png`), 1080, 1350);
+    }
+    writeFileSync(join(dir, 'caption.txt'), caption(M));
+    console.log(`  -> ${dir}`);
+  }
+  console.log('\nDone. Upload slides in order as an Instagram carousel.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/social/generate-carousels.mjs
+++ b/scripts/social/generate-carousels.mjs
@@ -14,28 +14,13 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   loadEnv, makeSb, selectMatchups, resolveManual, hydrate, fonts, slugFor,
-  OUT_DIR, renderPng, COLORS, grainUri, fontFace, STAT_KEYS,
+  OUT_DIR, renderPng, COLORS, slide, STAT_KEYS,
 } from './lib.mjs';
 
 const { O, T, GOLD, CREAM, NAVY } = COLORS;
 const cap1 = (s) => s.charAt(0).toUpperCase() + s.slice(1);
-
-const BASE = (F) => `${fontFace(F)}
-*{margin:0;padding:0;box-sizing:border-box;}html,body{width:1080px;height:1350px;overflow:hidden;background:${NAVY};font-family:'F';color:${CREAM};}
-.page{position:relative;width:1080px;height:1350px;overflow:hidden;background:radial-gradient(60% 44% at 50% 32%, rgba(224,168,62,.12), transparent 62%), radial-gradient(120% 90% at 50% 8%, #12242f, ${NAVY} 72%);}
-.dots{position:absolute;inset:0;background-image:radial-gradient(circle, rgba(224,168,62,.10) 1.3px, transparent 1.9px);background-size:30px;-webkit-mask-image:radial-gradient(130% 100% at 50% 40%, transparent 42%, #000);opacity:.55;}
-.grain{position:absolute;inset:0;background-image:url("${grainUri()}");background-size:340px;opacity:.05;mix-blend-mode:overlay;}
-.foot{position:absolute;bottom:46px;left:0;right:0;display:flex;align-items:center;justify-content:center;gap:16px;opacity:.9;}
-.foot .wm{font-family:'R';font-size:40px;color:${CREAM};}.foot .at{font-family:'F';font-size:26px;color:${GOLD};letter-spacing:1px;}
-.g{color:${GOLD};}.o{color:${O};}.t{color:${T};}
-.sqc{position:relative;border-radius:23%/17%;overflow:hidden;box-shadow:0 24px 60px rgba(0,0,0,.6);}
-.sqc img{width:100%;height:100%;object-fit:cover;}.sqc img.flip{transform:scaleX(-1);}.sqc .glare{position:absolute;inset:0;background:linear-gradient(120deg,rgba(255,255,255,.13),transparent 40%);}
-.stroke{-webkit-text-stroke:8px ${NAVY};paint-order:stroke fill;}
-`;
-
-const page = (F, inner, extra = '') => `<!doctype html><html><head><meta charset="utf-8"><style>${BASE(F)}${extra}</style></head><body><div class="page"><div class="dots"></div><div class="grain"></div>${inner}<div class="foot"><span class="wm">mythique</span><span class="at">@mythiqueapp</span></div></div></body></html>`;
-
-const brandFootHidden = ''; // slides all share the footer
+const STAT_TITLE = 'HEAD TO HEAD'; // stat comparison slide heading
+const page = (F, inner, extra = '') => slide(F, inner, extra);
 
 function slideCover(M, F) {
   const inner = `
@@ -57,13 +42,13 @@ function slideTape(M, F) {
     return `<div style="margin:0 0 22px 0">
       <div style="text-align:center;font-size:31px;letter-spacing:3px;color:${GOLD};margin-bottom:8px">${k.toUpperCase()}</div>
       <div style="display:flex;align-items:center;gap:24px;padding:0 70px">
-        <span class="stroke" style="width:150px;text-align:right;font-size:62px;color:${ca}">${av}</span>
+        <span class="pop" style="width:150px;text-align:right;font-size:62px;color:${ca}">${av}</span>
         <div style="flex:1;height:32px;border-radius:20px;overflow:hidden;display:flex;border:4px solid rgba(245,235,220,.15);background:#0e2330"><div style="width:${pa}%;background:${O}"></div><div style="flex:1;background:${T}"></div></div>
-        <span class="stroke" style="width:150px;text-align:left;font-size:62px;color:${cb}">${bv}</span>
+        <span class="pop" style="width:150px;text-align:left;font-size:62px;color:${cb}">${bv}</span>
       </div></div>`;
   }).join('');
   const inner = `
-   <div style="position:absolute;top:76px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">TALE OF THE TAPE</div>
+   <div style="position:absolute;top:76px;left:0;right:0;text-align:center;font-size:64px;letter-spacing:4px;color:${GOLD}" class="stroke">${STAT_TITLE}</div>
    <div style="position:absolute;top:180px;left:70px;right:70px;display:flex;justify-content:space-between;font-size:52px" class="stroke"><span class="o">${M.a.name}</span><span class="t">${M.b.name}</span></div>
    <div style="position:absolute;top:276px;left:0;right:0">${rows}</div>`;
   return page(F, inner);
@@ -75,7 +60,7 @@ function slideVerdict(M, F) {
    <div style="position:absolute;top:96px;left:0;right:0;text-align:center;font-size:52px;letter-spacing:6px;color:${GOLD}">WINNER</div>
    <div style="position:absolute;top:150px;left:50%;transform:translateX(-50%);width:220px;height:8px;background:${GOLD};border-radius:6px"></div>
    <div class="sqc" style="position:absolute;top:230px;left:50%;transform:translateX(-50%);width:470px;height:600px;border:8px solid ${GOLD};box-shadow:0 0 120px 8px rgba(224,168,62,.75)"><img class="${win.flip ? 'flip' : ''}" src="${win.img}"><div class="glare"></div></div>
-   <div style="position:absolute;top:836px;left:0;right:0;text-align:center;font-size:96px;color:${GOLD}" class="stroke">${win.name} WINS</div>
+   <div style="position:absolute;top:836px;left:0;right:0;text-align:center;font-size:96px;color:${GOLD}" class="pop">${win.name} WINS</div>
    <div style="position:absolute;top:964px;left:90px;right:90px;text-align:center;font-family:'R';font-size:46px;line-height:1.32;color:${CREAM}"><span style="color:${GOLD};font-size:76px;vertical-align:-16px">&ldquo;</span>${M.verdict}<span style="color:${GOLD};font-size:76px;vertical-align:-16px">&rdquo;</span></div>`;
   return page(F, inner);
 }
@@ -85,7 +70,7 @@ function slideVote(M, F) {
   const inner = `
    <div style="position:absolute;top:150px;left:0;right:0;text-align:center;font-size:80px" class="stroke">BUT THE <span class="g">FANS</span><br>DISAGREE</div>
    <div style="position:absolute;top:560px;left:90px;right:90px;height:80px;border-radius:44px;overflow:hidden;display:flex;border:6px solid rgba(245,235,220,.2)"><div style="width:${M.voteA}%;background:${O}"></div><div style="flex:1;background:${T}"></div></div>
-   <div style="position:absolute;top:680px;left:90px;right:90px;display:flex;justify-content:space-between;font-size:96px" class="stroke"><span class="o">${M.voteA}%</span><span class="t">${M.voteB}%</span></div>
+   <div style="position:absolute;top:680px;left:90px;right:90px;display:flex;justify-content:space-between;font-size:96px" class="pop"><span class="o">${M.voteA}%</span><span class="t">${M.voteB}%</span></div>
    <div style="position:absolute;top:840px;left:0;right:0;text-align:center;font-family:'S';font-size:44px;color:#9db4c4">${lead} is winning the vote</div>
    <div style="position:absolute;top:990px;left:0;right:0;text-align:center;font-size:76px" class="stroke">who's <span class="g">YOUR</span> pick?</div>
    <div style="position:absolute;top:1110px;left:0;right:0;text-align:center;font-family:'S';font-size:40px;color:${CREAM}">comment below 👇  ·  vote on mythique.app</div>`;

--- a/scripts/social/generate-reels.mjs
+++ b/scripts/social/generate-reels.mjs
@@ -1,195 +1,36 @@
 #!/usr/bin/env node
-// Mythique social reel generator.
-//
-// Generates fast-cut 9:16 "who would win" videos (TikTok / Reels / Shorts) from
-// REAL matchup data, styled like the app's matchup screen. One command makes a
-// batch of ready-to-post mp4s plus captions.
+// Mythique reel generator — fast-cut 9:16 "who would win" videos for
+// TikTok / Reels / Shorts, from real matchup data, styled like the app.
 //
 //   node scripts/social/generate-reels.mjs --count 8
 //   node scripts/social/generate-reels.mjs --matchup "Goku,Superman"
-//   node scripts/social/generate-reels.mjs --count 10 --dry-run   # list picks only
+//   node scripts/social/generate-reels.mjs --count 10 --dry-run
 //
-// Everything runs off the PUBLIC (publishable/anon) Supabase key — the same
-// read path the app uses. No secret key. Reads EXPO_PUBLIC_SUPABASE_URL /
-// EXPO_PUBLIC_SUPABASE_KEY from .env.local (or the environment).
-//
-// Requirements (local machine):
-//   - Node >= 18 (global fetch)
-//   - playwright-core  (yarn add -D playwright-core) + a Chrome/Chromium
-//       set PW_CHROME to an executable, or it uses channel:"chrome"
-//   - ffmpeg on PATH (brew install ffmpeg), or set FFMPEG=/path/to/ffmpeg
-//
-// Data flow per matchup:
-//   heroes table  -> portraits + 6 stats + fame_score      (public key)
-//   winner        -> computed from stats (more stat wins), matching the app
-//   get_matchup_tally RPC -> real community vote split       (public key)
-//   generate-verdict edge fn -> cached verdict, else Gemini  (public key)
+// See ./README.md for setup. Shared data layer lives in ./lib.mjs.
 
-import { readFileSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  loadEnv, makeSb, selectMatchups, resolveManual, hydrate, fonts, slugFor,
+  OUT_DIR, renderVideo, COLORS, grainUri, fontFace,
+} from './lib.mjs';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const OUT_DIR = join(ROOT, 'out', 'social');
-const STAT_KEYS = ['intelligence', 'strength', 'speed', 'durability', 'power', 'combat'];
-
-// Curated marquee rivalries — the ones people show up to argue about. Filled out
-// with random popular pairs. Names are resolved to ids against the heroes table.
-const RIVALRIES = [
-  ['Goku', 'Superman'], ['Batman', 'Iron Man'], ['Hulk', 'Superman'],
-  ['Thanos', 'Darkseid'], ['Naruto', 'Ichigo'], ['Spider-Man', 'Batman'],
-  ['Thor', 'Superman'], ['Wolverine', 'Deadpool'], ['Saitama', 'Goku'],
-  ['Doctor Strange', 'Zatanna'], ['Flash', 'Quicksilver'], ['Joker', 'Green Goblin'],
-];
-
-// Selection thresholds
-const MIN_VOTES = 40; // a matchup people actually engaged with
-const MAX_SPREAD = 18; // |pct - 50| <= this => close/controversial => gets talking
-const FAME_POOL = 160; // sample random pairs from the top-N most famous
-
-// ---------- env ----------
-function loadEnv() {
-  const envPath = join(ROOT, '.env.local');
-  const out = {};
-  if (existsSync(envPath)) {
-    for (const line of readFileSync(envPath, 'utf8').split('\n')) {
-      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
-      if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, '');
-    }
-  }
-  const url = process.env.EXPO_PUBLIC_SUPABASE_URL || out.EXPO_PUBLIC_SUPABASE_URL;
-  const key = process.env.EXPO_PUBLIC_SUPABASE_KEY || out.EXPO_PUBLIC_SUPABASE_KEY;
-  if (!url || !key) {
-    console.error('Missing EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_KEY (checked .env.local and env).');
-    process.exit(1);
-  }
-  return { url, key };
-}
-
-// ---------- supabase (public key) ----------
-function makeSb({ url, key }) {
-  const headers = { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' };
-  return {
-    async rest(path) {
-      const r = await fetch(`${url}/rest/v1/${path}`, { headers });
-      if (!r.ok) throw new Error(`REST ${path} -> ${r.status}`);
-      return r.json();
-    },
-    async rpc(fn, body) {
-      const r = await fetch(`${url}/rest/v1/rpc/${fn}`, { method: 'POST', headers, body: JSON.stringify(body) });
-      if (!r.ok) throw new Error(`RPC ${fn} -> ${r.status}`);
-      return r.json();
-    },
-    async invoke(fn, body) {
-      const r = await fetch(`${url}/functions/v1/${fn}`, { method: 'POST', headers, body: JSON.stringify(body) });
-      if (!r.ok) throw new Error(`fn ${fn} -> ${r.status}`);
-      return r.json();
-    },
-  };
-}
-
-const q = (s) => encodeURIComponent(s);
-const statWins = (a, b) => {
-  let wa = 0, wb = 0;
-  for (const k of STAT_KEYS) { if ((a[k] ?? 0) > (b[k] ?? 0)) wa++; else if ((b[k] ?? 0) > (a[k] ?? 0)) wb++; }
-  return [wa, wb];
-};
-
-async function heroByName(sb, name) {
-  const sel = 'id,name,publisher,portrait_url,image_url,image_md_url,fame_score,' + STAT_KEYS.join(',');
-  const rows = await sb.rest(`heroes?name=eq.${q(name)}&select=${sel}&limit=1`);
-  return rows[0] || null;
-}
-async function famousPool(sb) {
-  const sel = 'id,name,publisher,portrait_url,image_url,image_md_url,fame_score,' + STAT_KEYS.join(',');
-  return sb.rest(`heroes?select=${sel}&order=fame_score.desc&limit=${FAME_POOL}`);
-}
-
-// A matchup is postable if it has a real, close-ish vote split.
-async function evaluate(sb, a, b) {
-  const [ka, kb] = a.id <= b.id ? [a, b] : [b, a]; // tally normalizes smaller id as A
-  let tally;
-  try { tally = await sb.rpc('get_matchup_tally', { p_a: ka.id, p_b: kb.id }); } catch { return null; }
-  const total = tally.total ?? 0;
-  if (total < MIN_VOTES) return null;
-  const pctKa = Math.round((tally.votes_a / total) * 100);
-  if (Math.abs(pctKa - 50) > MAX_SPREAD) return null;
-  return { ka, kb, votesA: tally.votes_a, votesB: tally.votes_b, total, pctA: pctKa, pctB: 100 - pctKa };
-}
-
-const shuffle = (arr) => { for (let i = arr.length - 1; i > 0; i--) { const j = ((i + 1) * 2654435761) % (i + 1); [arr[i], arr[j]] = [arr[j], arr[i]]; } return arr; };
-
-async function selectMatchups(sb, count) {
-  const picks = [];
-  const seen = new Set();
-  const key = (a, b) => [a, b].sort().join(':');
-  // 1) curated rivalries first (people show up for these)
-  for (const [na, nb] of shuffle([...RIVALRIES])) {
-    if (picks.length >= count) break;
-    const a = await heroByName(sb, na), b = await heroByName(sb, nb);
-    if (!a || !b || seen.has(key(a.id, b.id))) continue;
-    const ev = await evaluate(sb, a, b);
-    if (ev) { seen.add(key(a.id, b.id)); picks.push(ev); }
-  }
-  // 2) fill with random popular cross-publisher pairs
-  if (picks.length < count) {
-    const pool = await famousPool(sb);
-    let attempts = 0;
-    while (picks.length < count && attempts < 400) {
-      attempts++;
-      const a = pool[Math.floor((attempts * 2654435761) % pool.length)];
-      const b = pool[Math.floor((attempts * 40503) % pool.length)];
-      if (!a || !b || a.id === b.id || seen.has(key(a.id, b.id))) continue;
-      if (a.publisher && a.publisher === b.publisher) continue; // cross-universe = more argument
-      const ev = await evaluate(sb, a, b);
-      if (ev) { seen.add(key(a.id, b.id)); picks.push(ev); }
-    }
-  }
-  return picks;
-}
-
-// ---------- assets ----------
-const b64 = (p) => readFileSync(p).toString('base64');
-function fonts() {
-  return {
-    R: b64(join(ROOT, 'node_modules/@expo-google-fonts/righteous/400Regular/Righteous_400Regular.ttf')),
-    F: b64(join(ROOT, 'assets/fonts/Flame-Bold.ttf')),
-    S: b64(join(ROOT, 'assets/fonts/FlameSans-Regular.ttf')),
-  };
-}
-async function portraitDataUri(hero) {
-  const src = hero.portrait_url || hero.image_url || hero.image_md_url;
-  const r = await fetch(src);
-  const buf = Buffer.from(await r.arrayBuffer());
-  const mime = src.endsWith('.png') ? 'image/png' : 'image/jpeg';
-  return `data:${mime};base64,${buf.toString('base64')}`;
-}
-
-// ---------- render template (app aesthetic, fast-cut) ----------
 function buildHtml(M, F) {
-  const O = '#e8823a', T = '#37a3c4', GOLD = '#e0a83e', CREAM = '#f5ebdc', NAVY = '#06121a';
-  const grain = `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%' height='100%' filter='url(#n)'/></svg>`)}`;
+  const { O, T, GOLD, CREAM, NAVY } = COLORS;
+  const grain = grainUri();
   const card = (c) => `<div class="sqin ${c.dim ? 'loser' : ''}"><img class="${c.flip ? 'flip' : ''}" src="${c.img}"><div class="glare"></div></div><div class="pname" style="color:${c.col}">${c.name}</div>`;
   const a = M.a, b = M.b;
   const stats = M.stats.map((s, i) => {
     const aw = s[1] >= s[2];
     return `<div class="scene stat" id="s_stat${i}">
-      <div class="rlabel">ROUND ${i + 1}</div>
-      <div class="statname">${s[0]}</div>
+      <div class="rlabel">ROUND ${i + 1}</div><div class="statname">${s[0]}</div>
       <div class="snums"><span class="na cnt" data-to="${s[1]}">0</span><span class="vs2">vs</span><span class="nb cnt" data-to="${s[2]}">0</span></div>
       <div class="track"><div class="fa" style="width:${Math.round((s[1] / (s[1] + s[2])) * 100)}%"></div><div class="fb"></div></div>
-      <div class="wlabel" style="color:${aw ? O : T}">${aw ? a.name : b.name} TAKES IT</div>
-    </div>`;
+      <div class="wlabel" style="color:${aw ? O : T}">${aw ? a.name : b.name} TAKES IT</div></div>`;
   }).join('');
-  return `<!doctype html><html><head><meta charset="utf-8"><style>
-@font-face{font-family:'R';src:url(data:font/ttf;base64,${F.R});}
-@font-face{font-family:'F';src:url(data:font/ttf;base64,${F.F});}
-@font-face{font-family:'S';src:url(data:font/ttf;base64,${F.S});}
-*{margin:0;padding:0;box-sizing:border-box;}
-html,body{width:1080px;height:1920px;overflow:hidden;background:${NAVY};font-family:'F';}
-.root{position:relative;width:1080px;height:1920px;overflow:hidden;
- background:radial-gradient(60% 44% at 50% 34%, rgba(224,168,62,.12), transparent 62%), radial-gradient(120% 90% at 50% 10%, #12242f, ${NAVY} 70%);}
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${fontFace(F)}
+*{margin:0;padding:0;box-sizing:border-box;}html,body{width:1080px;height:1920px;overflow:hidden;background:${NAVY};font-family:'F';}
+.root{position:relative;width:1080px;height:1920px;overflow:hidden;background:radial-gradient(60% 44% at 50% 34%, rgba(224,168,62,.12), transparent 62%), radial-gradient(120% 90% at 50% 10%, #12242f, ${NAVY} 70%);}
 .dots{position:absolute;inset:0;background-image:radial-gradient(circle, rgba(224,168,62,.10) 1.4px, transparent 2px);background-size:30px;-webkit-mask-image:radial-gradient(130% 100% at 50% 40%, transparent 40%, #000);opacity:.6;}
 .grain{position:absolute;inset:0;background-image:url("${grain}");background-size:340px;opacity:.05;mix-blend-mode:overlay;}
 .scene{position:absolute;inset:0;opacity:0;}.scene.on{opacity:1;}
@@ -233,38 +74,29 @@ html,body{width:1080px;height:1920px;overflow:hidden;background:${NAVY};font-fam
 .ctaq{top:430px;font-size:118px;}.ctabig{position:absolute;top:1120px;left:0;right:0;text-align:center;font-family:'R';font-size:120px;color:${CREAM};}
 .ctah{position:absolute;top:1280px;left:0;right:0;text-align:center;font-size:52px;color:${GOLD};}
 @keyframes slam{from{opacity:0;transform:scale(.6)}70%{transform:scale(1.07)}to{opacity:1;transform:scale(1)}}
-@keyframes inL{from{opacity:0;transform:translateX(-120px)}to{opacity:1;transform:none}}
-@keyframes inR{from{opacity:0;transform:translateX(120px)}to{opacity:1;transform:none}}
+@keyframes inL{from{opacity:0;transform:translateX(-120px)}to{opacity:1;transform:none}}@keyframes inR{from{opacity:0;transform:translateX(120px)}to{opacity:1;transform:none}}
 @keyframes pop{from{opacity:0;transform:translateX(-50%) scale(.2)}to{opacity:1;transform:translateX(-50%) scale(1)}}
-@keyframes flash{from{opacity:.9}to{opacity:0}}
-@keyframes xin{from{opacity:0;transform:scale(2) rotate(-18deg)}to{opacity:1;transform:scale(1) rotate(-10deg)}}
+@keyframes flash{from{opacity:.9}to{opacity:0}}@keyframes xin{from{opacity:0;transform:scale(2) rotate(-18deg)}to{opacity:1;transform:scale(1) rotate(-10deg)}}
 @keyframes upIn{from{opacity:0;transform:translateY(36px)}to{opacity:1;transform:none}}
 </style></head><body>
 <div class="root"><div class="dots"></div><div class="grain"></div>
- <div class="scene" id="s_hook">
-  <div class="cap title"><span class=o>${a.name}</span> <span class="g">vs</span> <span class=t>${b.name}</span></div>
-  <div class="sq l" style="--tc:${O}">${card({ ...a, col: O })}</div>
-  <div class="sq r" style="--tc:${T}">${card({ ...b, col: T })}</div>
-  <div class="vs">VS</div><div class="cap subq">who <span class="g">actually</span> wins?</div><div class="flash"></div>
- </div>
+ <div class="scene" id="s_hook"><div class="cap title"><span class=o>${a.name}</span> <span class="g">vs</span> <span class=t>${b.name}</span></div>
+  <div class="sq l" style="--tc:${O}">${card({ ...a, col: O })}</div><div class="sq r" style="--tc:${T}">${card({ ...b, col: T })}</div>
+  <div class="vs">VS</div><div class="cap subq">who <span class="g">actually</span> wins?</div><div class="flash"></div></div>
  ${stats}
  <div class="scene" id="s_sus"><div class="cap qbig">SO WHO<br>WINS<span class="g">?</span></div></div>
- <div class="scene" id="s_win">
-  <div class="winnerlbl">WINNER<span class="u"></span></div>
-  <div class="sq l" style="--tc:${O}">${card({ ...a, col: O, flip: false, dim: M.winner === 'b' })}</div>
-  <div class="sq r" style="--tc:${T}">${card({ ...b, col: T, flip: b.flip, dim: M.winner === 'a' })}</div>
+ <div class="scene" id="s_win"><div class="winnerlbl">WINNER<span class="u"></span></div>
+  <div class="sq l" style="--tc:${O}">${card({ ...a, col: O, dim: M.winner === 'b' })}</div>
+  <div class="sq r" style="--tc:${T}">${card({ ...b, col: T, dim: M.winner === 'a' })}</div>
   <div class="wglow" style="${M.winner === 'b' ? 'right:60px;left:auto' : 'left:60px'}"></div>
   <div class="xmark" style="${M.winner === 'b' ? 'left:150px' : 'right:150px'}">X</div>
-  <div class="bigwin">${M[M.winner].name} WINS</div><div class="flash"></div>
- </div>
- <div class="scene" id="s_verdict"><div class="vlabel">THE VERDICT</div>
-  <div class="vquote"><span class="mark">&ldquo;</span>${M.verdict}<span class="mark">&rdquo;</span></div></div>
+  <div class="bigwin">${M[M.winner].name} WINS</div><div class="flash"></div></div>
+ <div class="scene" id="s_verdict"><div class="vlabel">THE VERDICT</div><div class="vquote"><span class="mark">&ldquo;</span>${M.verdict}<span class="mark">&rdquo;</span></div></div>
  <div class="scene" id="s_twist"><div class="cap title">BUT FANS<br><span class="g">DISAGREE</span></div>
   <div class="vbar"><div class="a" style="width:${M.voteA}%"></div><div class="b"></div></div>
   <div class="vpc"><span class="pa">${M.voteA}%</span><span class="pb">${M.voteB}%</span></div>
   <div class="cap" style="top:1330px;font-size:60px">${M.voteA >= M.voteB ? a.name : b.name} is <span class="g">winning the vote</span></div></div>
- <div class="scene" id="s_cta"><div class="cap ctaq">who's <span class="g">YOUR</span><br>pick?</div>
-  <div class="ctabig">mythique</div><div class="ctah">@mythiqueapp  ·  34,000+ characters</div></div>
+ <div class="scene" id="s_cta"><div class="cap ctaq">who's <span class="g">YOUR</span><br>pick?</div><div class="ctabig">mythique</div><div class="ctah">@mythiqueapp  ·  34,000+ characters</div></div>
 </div>
 <script>
 function cu(el,to,d){var t0=null;function s(ts){if(!t0)t0=ts;var k=Math.min(1,(ts-t0)/d);el.textContent=Math.round(k*to);if(k<1)requestAnimationFrame(s);}requestAnimationFrame(s);}
@@ -273,38 +105,31 @@ tl.forEach(function(t){setTimeout(function(){var el=document.getElementById(t[0]
 </script></body></html>`;
 }
 
-async function render(html, outMp4, workDir) {
-  const pw = await import('playwright-core');
-  const launchOpts = process.env.PW_CHROME ? { executablePath: process.env.PW_CHROME } : { channel: 'chrome' };
-  const browser = await pw.chromium.launch({ ...launchOpts, args: ['--no-sandbox'] });
-  const ctx = await browser.newContext({ viewport: { width: 1080, height: 1920 }, recordVideo: { dir: workDir, size: { width: 1080, height: 1920 } } });
-  const page = await ctx.newPage();
-  await page.setContent(html, { waitUntil: 'networkidle' });
-  await page.waitForTimeout(13300);
-  await page.close(); await ctx.close(); await browser.close();
-  const { readdirSync } = await import('node:fs');
-  const webm = join(workDir, readdirSync(workDir).find((f) => f.endsWith('.webm')));
-  const ffmpeg = process.env.FFMPEG || 'ffmpeg';
-  execFileSync(ffmpeg, ['-y', '-i', webm, '-vf', 'fps=30,format=yuv420p', '-c:v', 'libx264', '-preset', 'medium', '-crf', '20', '-movflags', '+faststart', outMp4], { stdio: 'ignore' });
+function buildMatchup(h) {
+  return {
+    a: { name: h.ka.name.toUpperCase(), img: h.portraitA, flip: false },
+    b: { name: h.kb.name.toUpperCase(), img: h.portraitB, flip: true },
+    winner: h.winner, verdict: h.verdict, voteA: h.voteA, voteB: h.voteB,
+    stats: [
+      ['COMBAT', h.ka.combat ?? 0, h.kb.combat ?? 0],
+      ['SPEED', h.ka.speed ?? 0, h.kb.speed ?? 0],
+      ['INTELLIGENCE', h.ka.intelligence ?? 0, h.kb.intelligence ?? 0],
+    ],
+  };
 }
 
 function caption(M) {
-  const a = M.a.name, b = M.b.name;
-  const w = M[M.winner].name;
+  const a = M.a.name, b = M.b.name, w = M[M.winner].name;
   const lead = M.voteA >= M.voteB ? a : b;
   return [
-    `${a} vs ${b} — who actually wins? 🥊`,
-    ``,
+    `${a} vs ${b} — who actually wins? 🥊`, ``,
     `Our model says ${w}. But the fans have ${lead} ahead ${Math.max(M.voteA, M.voteB)}/${Math.min(M.voteA, M.voteB)} 👀`,
-    `"${M.verdict}"`,
-    ``,
-    `Who's your pick? Settle it on mythique.app`,
-    ``,
+    `"${M.verdict}"`, ``,
+    `Who's your pick? Settle it on mythique.app`, ``,
     `#whowouldwin #${a.replace(/[^a-z0-9]/gi, '')} #${b.replace(/[^a-z0-9]/gi, '')} #superheroes #anime #marvel #dc #powerscaling #mythique`,
   ].join('\n');
 }
 
-// ---------- main ----------
 async function main() {
   const args = process.argv.slice(2);
   const get = (f, d) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : d; };
@@ -312,21 +137,8 @@ async function main() {
   const count = parseInt(get('--count', '6'), 10);
   const manual = get('--matchup', null);
 
-  const env = loadEnv();
-  const sb = makeSb(env);
-
-  let selections;
-  if (manual) {
-    const [na, nb] = manual.split(',').map((s) => s.trim());
-    const a = await heroByName(sb, na), b = await heroByName(sb, nb);
-    if (!a || !b) { console.error('Could not find one of:', na, nb); process.exit(1); }
-    const ev = await evaluate(sb, a, b);
-    if (!ev) { console.warn('Note: that matchup has few/no votes; the fan bar may be empty.'); }
-    selections = [ev || { ka: a.id <= b.id ? a : b, kb: a.id <= b.id ? b : a, votesA: 0, votesB: 0, total: 0, pctA: 50, pctB: 50 }];
-  } else {
-    console.log(`Selecting ${count} popular, close-vote matchups...`);
-    selections = await selectMatchups(sb, count);
-  }
+  const sb = makeSb(loadEnv());
+  const selections = manual ? [await resolveManual(sb, manual)] : (console.log(`Selecting ${count} popular, close-vote matchups...`), await selectMatchups(sb, count));
 
   console.log(`\n${selections.length} matchup(s):`);
   for (const s of selections) console.log(`  ${s.ka.name} vs ${s.kb.name}  —  ${s.pctA}/${s.pctB}  (${s.total} votes)`);
@@ -335,41 +147,14 @@ async function main() {
   const F = fonts();
   mkdirSync(OUT_DIR, { recursive: true });
   for (const s of selections) {
-    // Orient: A = ka (left, orange, no flip), B = kb (right, teal, flipped to face in)
-    const [wa, wb] = statWins(s.ka, s.kb);
-    const winner = wa >= wb ? 'a' : 'b';
-    let verdict = '';
-    try {
-      const r = await sb.invoke('generate-verdict', {
-        heroAId: s.ka.id, heroBId: s.kb.id, heroA: s.ka.name, heroB: s.kb.name,
-        winsA: wa, winsB: wb,
-        statsA: Object.fromEntries(STAT_KEYS.map((k) => [k, s.ka[k] ?? 0])),
-        statsB: Object.fromEntries(STAT_KEYS.map((k) => [k, s.kb[k] ?? 0])),
-      });
-      verdict = r.verdict || '';
-    } catch (e) { console.warn('verdict fetch failed:', e.message); }
-
-    const M = {
-      a: { name: s.ka.name.toUpperCase(), img: await portraitDataUri(s.ka), flip: false },
-      b: { name: s.kb.name.toUpperCase(), img: await portraitDataUri(s.kb), flip: true },
-      winner, verdict,
-      voteA: s.pctA, voteB: s.pctB,
-      stats: [
-        ['COMBAT', s.ka.combat ?? 0, s.kb.combat ?? 0],
-        ['SPEED', s.ka.speed ?? 0, s.kb.speed ?? 0],
-        ['INTELLIGENCE', s.ka.intelligence ?? 0, s.kb.intelligence ?? 0],
-      ],
-    };
-    const slug = `${s.ka.name}-vs-${s.kb.name}`.toLowerCase().replace(/[^a-z0-9]+/g, '-');
-    const dir = join(OUT_DIR, slug);
+    const M = buildMatchup(await hydrate(sb, s));
+    const dir = join(OUT_DIR, slugFor(s));
     mkdirSync(dir, { recursive: true });
-    const html = buildHtml(M, F);
     const mp4 = join(dir, 'video.mp4');
-    console.log(`Rendering ${slug} ...`);
-    await render(html, mp4, dir);
+    console.log(`Rendering ${slugFor(s)} ...`);
+    await renderVideo(buildHtml(M, F), mp4, dir);
     writeFileSync(join(dir, 'caption.txt'), caption(M));
-    console.log(`  -> ${mp4}`);
-    console.log(`  -> ${join(dir, 'caption.txt')}`);
+    console.log(`  -> ${mp4}\n  -> ${join(dir, 'caption.txt')}`);
   }
   console.log('\nDone. Add a trending sound in-app when you upload.');
 }

--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -75,6 +75,17 @@ export async function heroByName(sb, name) {
   const rows = await sb.rest(`heroes?name=eq.${q(name)}&select=${HERO_SELECT}&limit=1`);
   return rows[0] || null;
 }
+
+// Extended profile fields for character-showcase (bio) carousels.
+const HERO_FULL = HERO_SELECT + ',full_name,first_appearance,alignment,race,occupation,aliases,place_of_birth,group_affiliation';
+export async function heroFullByName(sb, name) {
+  const rows = await sb.rest(`heroes?name=eq.${q(name)}&select=${HERO_FULL}&limit=1`);
+  return rows[0] || null;
+}
+// Random popular characters for bio showcases.
+export async function popularHeroes(sb, n) {
+  return sb.rest(`heroes?select=${HERO_FULL}&order=fame_score.desc&limit=${n}`);
+}
 export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=fame_score.desc&limit=${FAME_POOL}`);
 
 // A matchup is postable if it has a real, close-ish vote split.
@@ -155,6 +166,7 @@ export function fonts() {
   return {
     R: b64(join(ROOT, 'node_modules/@expo-google-fonts/righteous/400Regular/Righteous_400Regular.ttf')),
     F: b64(join(ROOT, 'assets/fonts/Flame-Bold.ttf')),
+    FR: b64(join(ROOT, 'assets/fonts/Flame-Regular.ttf')),
     S: b64(join(ROOT, 'assets/fonts/FlameSans-Regular.ttf')),
   };
 }
@@ -168,7 +180,27 @@ export async function portraitDataUri(hero) {
 
 export const COLORS = { O: '#e8823a', T: '#37a3c4', GOLD: '#e0a83e', CREAM: '#f5ebdc', NAVY: '#06121a' };
 export const grainUri = () => `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%' height='100%' filter='url(#n)'/></svg>`)}`;
-export const fontFace = (F) => `@font-face{font-family:'R';src:url(data:font/ttf;base64,${F.R});}@font-face{font-family:'F';src:url(data:font/ttf;base64,${F.F});}@font-face{font-family:'S';src:url(data:font/ttf;base64,${F.S});}`;
+export const fontFace = (F) => `@font-face{font-family:'R';src:url(data:font/ttf;base64,${F.R});}@font-face{font-family:'F';src:url(data:font/ttf;base64,${F.F});}@font-face{font-family:'FR';src:url(data:font/ttf;base64,${F.FR});}@font-face{font-family:'S';src:url(data:font/ttf;base64,${F.S});}`;
+
+// Shared 1080x1350 carousel slide shell (navy brand background + footer). Default
+// text is the regular Flame weight ('FR'); use class="pop" for the loud, bold
+// numbers only. Callers supply `inner` (absolutely-positioned content).
+export const slideCss = (F) => {
+  const { O, T, GOLD, CREAM, NAVY } = COLORS;
+  return `${fontFace(F)}
+*{margin:0;padding:0;box-sizing:border-box;}html,body{width:1080px;height:1350px;overflow:hidden;background:${NAVY};font-family:'FR';color:${CREAM};}
+.page{position:relative;width:1080px;height:1350px;overflow:hidden;background:radial-gradient(60% 44% at 50% 32%, rgba(224,168,62,.12), transparent 62%), radial-gradient(120% 90% at 50% 8%, #12242f, ${NAVY} 72%);}
+.dots{position:absolute;inset:0;background-image:radial-gradient(circle, rgba(224,168,62,.10) 1.3px, transparent 1.9px);background-size:30px;-webkit-mask-image:radial-gradient(130% 100% at 50% 40%, transparent 42%, #000);opacity:.55;}
+.grain{position:absolute;inset:0;background-image:url("${grainUri()}");background-size:340px;opacity:.05;mix-blend-mode:overlay;}
+.foot{position:absolute;bottom:46px;left:0;right:0;display:flex;align-items:center;justify-content:center;gap:16px;opacity:.9;}
+.foot .wm{font-family:'R';font-size:40px;color:${CREAM};}.foot .at{font-family:'FR';font-size:26px;color:${GOLD};letter-spacing:1px;}
+.g{color:${GOLD};}.o{color:${O};}.t{color:${T};}
+.sqc{position:relative;border-radius:23%/17%;overflow:hidden;box-shadow:0 24px 60px rgba(0,0,0,.6);}
+.sqc img{width:100%;height:100%;object-fit:cover;}.sqc img.flip{transform:scaleX(-1);}.sqc .glare{position:absolute;inset:0;background:linear-gradient(120deg,rgba(255,255,255,.13),transparent 40%);}
+.stroke{-webkit-text-stroke:3px ${NAVY};paint-order:stroke fill;}
+.pop{font-family:'F';-webkit-text-stroke:7px ${NAVY};paint-order:stroke fill;}`;
+};
+export const slide = (F, inner, extra = '') => `<!doctype html><html><head><meta charset="utf-8"><style>${slideCss(F)}${extra}</style></head><body><div class="page"><div class="dots"></div><div class="grain"></div>${inner}<div class="foot"><span class="wm">mythique</span><span class="at">@mythiqueapp</span></div></div></body></html>`;
 
 async function launchChrome() {
   const pw = await import('playwright-core');

--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -77,7 +77,7 @@ export async function heroByName(sb, name) {
 }
 
 // Extended profile fields for character-showcase (bio) carousels.
-const HERO_FULL = HERO_SELECT + ',full_name,first_appearance,alignment,race,occupation,aliases,place_of_birth,group_affiliation';
+const HERO_FULL = HERO_SELECT + ',full_name,first_appearance,alignment,race,occupation,aliases,place_of_birth,group_affiliation,powers,movie_count,issue_count,wikidata_sitelinks';
 export async function heroFullByName(sb, name) {
   const rows = await sb.rest(`heroes?name=eq.${q(name)}&select=${HERO_FULL}&limit=1`);
   return rows[0] || null;
@@ -85,6 +85,20 @@ export async function heroFullByName(sb, name) {
 // Random popular characters for bio showcases.
 export async function popularHeroes(sb, n) {
   return sb.rest(`heroes?select=${HERO_FULL}&order=fame_score.desc&limit=${n}`);
+}
+
+// Relationship graph (enemies / allies), family, and key/value enrichment facts.
+export async function getRelated(sb, id, kind, limit = 6) {
+  try { return await sb.rpc('get_related_heroes', { p_hero_id: id, p_kind: kind, p_limit: limit, p_same_universe: false }); }
+  catch { return []; }
+}
+export async function getFamily(sb, id, limit = 6) {
+  try { return await sb.rpc('get_family_opponents', { p_hero_id: id, p_limit: limit }); }
+  catch { return []; }
+}
+export async function getFact(sb, id, key) {
+  try { const r = await sb.rest(`hero_facts?hero_id=eq.${id}&key=eq.${q(key)}&select=value&limit=1`); return r[0]?.value ?? null; }
+  catch { return null; }
 }
 export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=fame_score.desc&limit=${FAME_POOL}`);
 
@@ -170,13 +184,17 @@ export function fonts() {
     S: b64(join(ROOT, 'assets/fonts/FlameSans-Regular.ttf')),
   };
 }
-export async function portraitDataUri(hero) {
-  const src = hero.portrait_url || hero.image_url || hero.image_md_url;
-  const r = await fetch(src);
-  const buf = Buffer.from(await r.arrayBuffer());
-  const mime = src.endsWith('.png') ? 'image/png' : 'image/jpeg';
-  return `data:${mime};base64,${buf.toString('base64')}`;
+export async function imgDataUri(src) {
+  if (!src) return null;
+  try {
+    const r = await fetch(src);
+    if (!r.ok) return null;
+    const buf = Buffer.from(await r.arrayBuffer());
+    const mime = src.endsWith('.png') ? 'image/png' : 'image/jpeg';
+    return `data:${mime};base64,${buf.toString('base64')}`;
+  } catch { return null; }
 }
+export const portraitDataUri = (hero) => imgDataUri(hero.portrait_url || hero.image_url || hero.image_md_url);
 
 export const COLORS = { O: '#e8823a', T: '#37a3c4', GOLD: '#e0a83e', CREAM: '#f5ebdc', NAVY: '#06121a' };
 export const grainUri = () => `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%' height='100%' filter='url(#n)'/></svg>`)}`;

--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -1,0 +1,201 @@
+// Shared data + asset layer for the Mythique social pipelines (reels + carousels).
+//
+// Everything reads off the PUBLIC (publishable/anon) Supabase key — the same
+// read path the app uses. No secret key. See ./README.md.
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+export const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+export const OUT_DIR = join(ROOT, 'out', 'social');
+export const STAT_KEYS = ['intelligence', 'strength', 'speed', 'durability', 'power', 'combat'];
+
+// Curated marquee rivalries — the ones people show up to argue about. Filled out
+// with random popular pairs. Names are resolved against the heroes table.
+export const RIVALRIES = [
+  ['Goku', 'Superman'], ['Batman', 'Iron Man'], ['Hulk', 'Superman'],
+  ['Thanos', 'Darkseid'], ['Naruto', 'Ichigo'], ['Spider-Man', 'Batman'],
+  ['Thor', 'Superman'], ['Wolverine', 'Deadpool'], ['Saitama', 'Goku'],
+  ['Doctor Strange', 'Zatanna'], ['Flash', 'Quicksilver'], ['Joker', 'Green Goblin'],
+];
+
+const MIN_VOTES = 40; // people actually engaged with it
+const MAX_SPREAD = 18; // |pct - 50| <= this => close/controversial => gets talking
+const FAME_POOL = 160; // sample random pairs from the top-N most famous
+const HERO_SELECT = 'id,name,publisher,portrait_url,image_url,image_md_url,fame_score,' + STAT_KEYS.join(',');
+const q = (s) => encodeURIComponent(s);
+
+export function loadEnv() {
+  const envPath = join(ROOT, '.env.local');
+  const out = {};
+  if (existsSync(envPath)) {
+    for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+    }
+  }
+  const url = process.env.EXPO_PUBLIC_SUPABASE_URL || out.EXPO_PUBLIC_SUPABASE_URL;
+  const key = process.env.EXPO_PUBLIC_SUPABASE_KEY || out.EXPO_PUBLIC_SUPABASE_KEY;
+  if (!url || !key) {
+    console.error('Missing EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_KEY (checked .env.local and env).');
+    process.exit(1);
+  }
+  return { url, key };
+}
+
+export function makeSb({ url, key }) {
+  const headers = { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' };
+  return {
+    async rest(path) {
+      const r = await fetch(`${url}/rest/v1/${path}`, { headers });
+      if (!r.ok) throw new Error(`REST ${path} -> ${r.status}`);
+      return r.json();
+    },
+    async rpc(fn, body) {
+      const r = await fetch(`${url}/rest/v1/rpc/${fn}`, { method: 'POST', headers, body: JSON.stringify(body) });
+      if (!r.ok) throw new Error(`RPC ${fn} -> ${r.status}`);
+      return r.json();
+    },
+    async invoke(fn, body) {
+      const r = await fetch(`${url}/functions/v1/${fn}`, { method: 'POST', headers, body: JSON.stringify(body) });
+      if (!r.ok) throw new Error(`fn ${fn} -> ${r.status}`);
+      return r.json();
+    },
+  };
+}
+
+export const statWins = (a, b) => {
+  let wa = 0, wb = 0;
+  for (const k of STAT_KEYS) { if ((a[k] ?? 0) > (b[k] ?? 0)) wa++; else if ((b[k] ?? 0) > (a[k] ?? 0)) wb++; }
+  return [wa, wb];
+};
+
+export async function heroByName(sb, name) {
+  const rows = await sb.rest(`heroes?name=eq.${q(name)}&select=${HERO_SELECT}&limit=1`);
+  return rows[0] || null;
+}
+export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=fame_score.desc&limit=${FAME_POOL}`);
+
+// A matchup is postable if it has a real, close-ish vote split.
+export async function evaluate(sb, a, b) {
+  const [ka, kb] = a.id <= b.id ? [a, b] : [b, a]; // tally normalizes smaller id as A
+  let tally;
+  try { tally = await sb.rpc('get_matchup_tally', { p_a: ka.id, p_b: kb.id }); } catch { return null; }
+  const total = tally.total ?? 0;
+  if (total < MIN_VOTES) return null;
+  const pctKa = Math.round((tally.votes_a / total) * 100);
+  if (Math.abs(pctKa - 50) > MAX_SPREAD) return null;
+  return { ka, kb, votesA: tally.votes_a, votesB: tally.votes_b, total, pctA: pctKa, pctB: 100 - pctKa };
+}
+
+const shuffle = (arr) => { for (let i = arr.length - 1; i > 0; i--) { const j = ((i + 1) * 2654435761) % (i + 1); [arr[i], arr[j]] = [arr[j], arr[i]]; } return arr; };
+
+export async function selectMatchups(sb, count) {
+  const picks = [];
+  const seen = new Set();
+  const key = (a, b) => [a, b].sort().join(':');
+  for (const [na, nb] of shuffle([...RIVALRIES])) {
+    if (picks.length >= count) break;
+    const a = await heroByName(sb, na), b = await heroByName(sb, nb);
+    if (!a || !b || seen.has(key(a.id, b.id))) continue;
+    const ev = await evaluate(sb, a, b);
+    if (ev) { seen.add(key(a.id, b.id)); picks.push(ev); }
+  }
+  if (picks.length < count) {
+    const pool = await famousPool(sb);
+    let attempts = 0;
+    while (picks.length < count && attempts < 400) {
+      attempts++;
+      const a = pool[Math.floor((attempts * 2654435761) % pool.length)];
+      const b = pool[Math.floor((attempts * 40503) % pool.length)];
+      if (!a || !b || a.id === b.id || seen.has(key(a.id, b.id))) continue;
+      if (a.publisher && a.publisher === b.publisher) continue; // cross-universe = more argument
+      const ev = await evaluate(sb, a, b);
+      if (ev) { seen.add(key(a.id, b.id)); picks.push(ev); }
+    }
+  }
+  return picks;
+}
+
+export async function resolveManual(sb, spec) {
+  const [na, nb] = spec.split(',').map((s) => s.trim());
+  const a = await heroByName(sb, na), b = await heroByName(sb, nb);
+  if (!a || !b) { console.error('Could not find one of:', na, nb); process.exit(1); }
+  const ev = await evaluate(sb, a, b);
+  if (ev) return ev;
+  console.warn('Note: that matchup has few/no votes; the fan bar may be empty.');
+  const [ka, kb] = a.id <= b.id ? [a, b] : [b, a];
+  return { ka, kb, votesA: 0, votesB: 0, total: 0, pctA: 50, pctB: 50 };
+}
+
+// Fills a selection out with everything a template needs to render.
+export async function hydrate(sb, sel) {
+  const [wa, wb] = statWins(sel.ka, sel.kb);
+  const winner = wa >= wb ? 'a' : 'b';
+  let verdict = '';
+  try {
+    const r = await sb.invoke('generate-verdict', {
+      heroAId: sel.ka.id, heroBId: sel.kb.id, heroA: sel.ka.name, heroB: sel.kb.name,
+      winsA: wa, winsB: wb,
+      statsA: Object.fromEntries(STAT_KEYS.map((k) => [k, sel.ka[k] ?? 0])),
+      statsB: Object.fromEntries(STAT_KEYS.map((k) => [k, sel.kb[k] ?? 0])),
+    });
+    verdict = r.verdict || '';
+  } catch (e) { console.warn('verdict fetch failed:', e.message); }
+  const [portraitA, portraitB] = await Promise.all([portraitDataUri(sel.ka), portraitDataUri(sel.kb)]);
+  return { ka: sel.ka, kb: sel.kb, winner, verdict, voteA: sel.pctA, voteB: sel.pctB, portraitA, portraitB };
+}
+
+export const slugFor = (sel) => `${sel.ka.name}-vs-${sel.kb.name}`.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+// ---- assets ----
+const b64 = (p) => readFileSync(p).toString('base64');
+export function fonts() {
+  return {
+    R: b64(join(ROOT, 'node_modules/@expo-google-fonts/righteous/400Regular/Righteous_400Regular.ttf')),
+    F: b64(join(ROOT, 'assets/fonts/Flame-Bold.ttf')),
+    S: b64(join(ROOT, 'assets/fonts/FlameSans-Regular.ttf')),
+  };
+}
+export async function portraitDataUri(hero) {
+  const src = hero.portrait_url || hero.image_url || hero.image_md_url;
+  const r = await fetch(src);
+  const buf = Buffer.from(await r.arrayBuffer());
+  const mime = src.endsWith('.png') ? 'image/png' : 'image/jpeg';
+  return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+export const COLORS = { O: '#e8823a', T: '#37a3c4', GOLD: '#e0a83e', CREAM: '#f5ebdc', NAVY: '#06121a' };
+export const grainUri = () => `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%' height='100%' filter='url(#n)'/></svg>`)}`;
+export const fontFace = (F) => `@font-face{font-family:'R';src:url(data:font/ttf;base64,${F.R});}@font-face{font-family:'F';src:url(data:font/ttf;base64,${F.F});}@font-face{font-family:'S';src:url(data:font/ttf;base64,${F.S});}`;
+
+async function launchChrome() {
+  const pw = await import('playwright-core');
+  const opts = process.env.PW_CHROME ? { executablePath: process.env.PW_CHROME } : { channel: 'chrome' };
+  return pw.chromium.launch({ ...opts, args: ['--no-sandbox'] });
+}
+
+// Screenshot a full-page HTML to PNG (for carousel slides).
+export async function renderPng(html, outPath, width, height) {
+  const browser = await launchChrome();
+  const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
+  await page.setContent(html, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(300);
+  await page.screenshot({ path: outPath });
+  await browser.close();
+}
+
+// Record an animated HTML page to mp4 (for reels). Requires ffmpeg.
+export async function renderVideo(html, outMp4, workDir, waitMs = 13300) {
+  const { execFileSync } = await import('node:child_process');
+  const browser = await launchChrome();
+  const ctx = await browser.newContext({ viewport: { width: 1080, height: 1920 }, recordVideo: { dir: workDir, size: { width: 1080, height: 1920 } } });
+  const page = await ctx.newPage();
+  await page.setContent(html, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(waitMs);
+  await page.close(); await ctx.close(); await browser.close();
+  const webm = join(workDir, readdirSync(workDir).find((f) => f.endsWith('.webm')));
+  const ffmpeg = process.env.FFMPEG || 'ffmpeg';
+  execFileSync(ffmpeg, ['-y', '-i', webm, '-vf', 'fps=30,format=yuv420p', '-c:v', 'libx264', '-preset', 'medium', '-crf', '20', '-movflags', '+faststart', outMp4], { stdio: 'ignore' });
+}

--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -216,7 +216,12 @@ export const slideCss = (F) => {
 .sqc{position:relative;border-radius:23%/17%;overflow:hidden;box-shadow:0 24px 60px rgba(0,0,0,.6);}
 .sqc img{width:100%;height:100%;object-fit:cover;}.sqc img.flip{transform:scaleX(-1);}.sqc .glare{position:absolute;inset:0;background:linear-gradient(120deg,rgba(255,255,255,.13),transparent 40%);}
 .stroke{-webkit-text-stroke:3px ${NAVY};paint-order:stroke fill;}
-.pop{font-family:'F';-webkit-text-stroke:7px ${NAVY};paint-order:stroke fill;}`;
+.pop{font-family:'F';-webkit-text-stroke:7px ${NAVY};paint-order:stroke fill;}
+/* centered content band: fills the space between the top margin and the footer,
+   vertically centred, so info slides never leave dead space at the bottom */
+.body{position:absolute;left:0;right:0;top:64px;bottom:168px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:0 60px;text-align:center;}
+.h1{font-size:64px;letter-spacing:5px;color:${GOLD};margin:0 0 60px 0;-webkit-text-stroke:3px ${NAVY};paint-order:stroke fill;}
+.full{width:100%;}`;
 };
 export const slide = (F, inner, extra = '') => `<!doctype html><html><head><meta charset="utf-8"><style>${slideCss(F)}${extra}</style></head><body><div class="page"><div class="dots"></div><div class="grain"></div>${inner}<div class="foot"><span class="wm">mythique</span><span class="at">@mythiqueapp</span></div></div></body></html>`;
 


### PR DESCRIPTION
## Summary

Adds Instagram carousel generation alongside the reel pipeline, sharing the same real-data layer and brand shell.

**Two carousel tools:**
- **`generate-carousels.mjs`** — matchup carousel (4 slides: cover / hook → head-to-head stats → verdict + winner → fan vote + CTA).
- **`generate-bios.mjs`** — character-file carousel (cover → power stats → profile dossier → aliases). Flexes the per-character catalogue depth: real name, first appearance, race, alignment, occupation, team, aliases.

Both render 4:5 (1080×1350) PNGs via `playwright-core` (no ffmpeg needed).

## Design updates (from feedback)

- **Regular Flame weight** (`FR`) is now the default display font across carousels; bold (`F`, class `.pop`) is reserved for the loud numbers only.
- Renamed the stat-comparison heading **"Tale of the Tape" → "Head to Head."**
- Stat comparison: tied stats stay full-colour, only strict losers mute.
- Bio polish: tagline prefers an epithet (e.g. "The Dark Knight") over "Name II"; blank/"-" profile fields are dropped.

## Refactor

Extracted the shared data + slide shell into **`lib.mjs`** (`slideCss`/`slide`, `heroFullByName`, `popularHeroes`) so all three generators stay in sync. Reel output unchanged (dry-run verified); both carousels rendered end-to-end (Goku vs Superman + Batman) to check every slide.

## Usage

```sh
node scripts/social/generate-carousels.mjs --count 8
node scripts/social/generate-bios.mjs --character "Batman"
node scripts/social/generate-reels.mjs --count 8      # unchanged
```

Outputs to git-ignored `out/social/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avqn4Lyw2SSzmv9TL1sfkb