### PR TITLE
Fix beige iOS Safari status bar on legal pages

### DIFF
--- a/src/components/legal/LegalScreen.tsx
+++ b/src/components/legal/LegalScreen.tsx
@@ -18,9 +18,13 @@ export function LegalScreen({ doc }: { doc: LegalDoc }) {
   const isWeb = Platform.OS === 'web';
   const topPad = (isWeb ? WEB_NAV_CLEARANCE : insets.top) + 12;
 
-  // Web: document scroll so the beige page bleeds under the iOS Safari toolbar.
-  // No-op on native.
-  useScreenChrome({ top: SURFACE.paper, canvas: SURFACE.paper });
+  // Top edge is deep-navy (matching every other page) so the iOS Safari
+  // status-bar strip and the web nav read dark — never a beige status bar that
+  // blends into the system UI. The canvas stays beige: the body content is
+  // unchanged and scrolling to the bottom shows beige, never a dark peek-through.
+  // Web-only (document scroll also lets the page bleed under the iOS Safari
+  // toolbar); no-op on native.
+  useScreenChrome({ top: SURFACE.ink, canvas: SURFACE.paper });
 
   const content = (
     <>


### PR DESCRIPTION
## Summary

Audited every web-rendered page for how it declares its top-chrome color (the value that drives the iOS Safari status-bar tint, via `useScreenChrome` → `AdaptiveStatusBarCover` + the `theme-color` meta).

**The Privacy and Terms pages** (both rendered by the shared `LegalScreen` component) were the **only** screens in the app declaring a light top (`top: SURFACE.paper`). On mobile web this tinted the iOS Safari status-bar strip — the battery/time area — and the web nav **beige**, so the system UI blended into the page instead of framing it, inconsistent with every other page's deep-navy top.

## Change

`src/components/legal/LegalScreen.tsx` — switch the top edge from `SURFACE.paper` to `SURFACE.ink` (deep navy):

```diff
- useScreenChrome({ top: SURFACE.paper, canvas: SURFACE.paper });
+ useScreenChrome({ top: SURFACE.ink,   canvas: SURFACE.paper });
```

This matches every other screen — e.g. the beige-bodied support page already uses the same `top: ink` / `canvas: paper` pairing.

- **Status bar → deep navy** (`#0b1820`), consistent with the whole app.
- **Canvas stays beige**, so the page body is visually unchanged — no interior restyling required.
- **No dark peek-through at the bottom**: since the canvas remains beige, scrolling to the end still shows beige, never a navy strip.

## Audit result

Verified exhaustively that after this change, all 24 `useScreenChrome` call sites pass `top: SURFACE.ink`, the sole runtime `theme-color` writer (`WebChromeContext`) always resolves to that value, the fallback `DEFAULT_COLOR` is deep navy, and nothing recolors the bar on scroll. The iOS top toolbar is now a constant deep navy on 100% of pages — `LegalScreen` was the single outlier.

## Testing

- `yarn typecheck` — passes
- `yarn eslint src/components/legal/LegalScreen.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbBggweakC3y5TCcdm3rws

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbBggweakC3y5TCcdm3rws)_