### PR TITLE
perf(db) + feat(social): fix nightly relationship rebuild, de-tie top-list rankings

### DIFF
--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -25,6 +25,9 @@ const MIN_VOTES = 40; // people actually engaged with it
 const MAX_SPREAD = 18; // |pct - 50| <= this => close/controversial => gets talking
 const FAME_POOL = 160; // sample random pairs from the top-N most famous
 const HERO_SELECT = 'id,name,publisher,portrait_url,image_url,image_md_url,fame_score,gender,alignment,' + STAT_KEYS.join(',');
+// Strict fame ordering: fame_score bands can tie (esp. tier plateaus), so break
+// ties by the continuous popularity signals, then id, for a stable countdown.
+const FAME_ORDER = 'fame_score.desc.nullslast,wikidata_sitelinks.desc.nullslast,powerstats_total.desc.nullslast,id.asc';
 const q = (s) => encodeURIComponent(s);
 
 export function loadEnv() {
@@ -105,7 +108,7 @@ export async function heroFullByName(sb, name) {
 }
 // Random popular characters for bio showcases.
 export async function popularHeroes(sb, n) {
-  return sb.rest(`heroes?select=${HERO_FULL}&order=fame_score.desc.nullslast&limit=${n}`);
+  return sb.rest(`heroes?select=${HERO_FULL}&order=${FAME_ORDER}&limit=${n}`);
 }
 
 // Relationship graph (enemies / allies), family, and key/value enrichment facts.
@@ -121,7 +124,7 @@ export async function getFact(sb, id, key) {
   try { const r = await sb.rest(`hero_facts?hero_id=eq.${id}&key=eq.${q(key)}&select=value&limit=1`); return r[0]?.value ?? null; }
   catch { return null; }
 }
-export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=fame_score.desc.nullslast&limit=${FAME_POOL}`);
+export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=${FAME_ORDER}&limit=${FAME_POOL}`);
 
 // A matchup is postable if it has a real, close-ish vote split.
 export async function evaluate(sb, a, b) {

--- a/scripts/social/organic-pack.mjs
+++ b/scripts/social/organic-pack.mjs
@@ -320,7 +320,7 @@ function gauntletSlides(h, statKey) {
 // ── data ──────────────────────────────────────────────────────────────────────
 async function pool(sb) {
   const rows = await sb.rest(
-    `heroes?select=${HERO_COLS}&portrait_url=not.is.null&order=fame_score.desc.nullslast&limit=60`,
+    `heroes?select=${HERO_COLS}&portrait_url=not.is.null&order=fame_score.desc.nullslast,wikidata_sitelinks.desc.nullslast,powerstats_total.desc.nullslast,id.asc&limit=60`,
   );
   return rows.map(shape);
 }
@@ -333,30 +333,51 @@ const TOT_QUESTIONS = [
 ];
 const GAUNTLET_STATS = ['strength', 'combat', 'power'];
 // Debatable ranking themes with portraits. Each returns 10 ordered rows.
+// `composite` themes rank by the weighted power_rating (0-100, one decimal) so the
+// countdown shows distinct descending numbers instead of a wall of identical 100s
+// (154 characters tie at power=100, 92 at strength=100). Single-attribute themes
+// still show their raw stat — those repeat at the ceiling, but a continuous
+// tiebreaker chain keeps the top 10 strictly and defensibly ordered.
 const RANK_THEMES = [
   {
     key: 'strongest-villains',
     title: 'Top 10 Strongest Villains',
-    stat: 'strength',
+    stat: 'power_rating',
     color: '#B5302B',
     villain: true,
+    composite: true,
   },
   { key: 'smartest', title: 'Top 10 Smartest Characters', stat: 'intelligence', color: '#15A1AB' },
   { key: 'fastest', title: 'Top 10 Fastest Characters', stat: 'speed', color: '#F9B222' },
   { key: 'best-fighters', title: 'Top 10 Best Fighters', stat: 'combat', color: '#8a4a2b' },
-  { key: 'most-powerful', title: 'Top 10 Most Powerful', stat: 'power', color: '#E77333' },
+  {
+    key: 'most-powerful',
+    title: 'Top 10 Most Powerful',
+    stat: 'power_rating',
+    color: '#E77333',
+    composite: true,
+  },
 ];
 async function rankingRows(sb, theme) {
   const align = theme.villain ? '&alignment=eq.bad' : '';
+  // Strict order: headline metric, then the continuous composite + fame + id so no
+  // two rows tie on placement. Composite themes already sort by power_rating.
+  const order = theme.composite
+    ? `power_rating.desc.nullslast,fame_score.desc.nullslast,id.asc`
+    : `${theme.stat}.desc.nullslast,power_rating.desc.nullslast,fame_score.desc.nullslast,id.asc`;
+  const cols = theme.composite
+    ? 'name,publisher,portrait_url,id,fame_score,power_rating'
+    : `name,publisher,portrait_url,id,fame_score,power_rating,${theme.stat}`;
   const rows = await sb
     .rest(
-      `heroes?select=name,publisher,portrait_url,${theme.stat}&portrait_url=not.is.null&fame_score=gte.20${align}&order=${theme.stat}.desc.nullslast,fame_score.desc.nullslast&limit=10`,
+      `heroes?select=${cols}&portrait_url=not.is.null&fame_score=gte.20${align}&order=${order}&limit=10`,
     )
     .catch(() => []);
   return rows.map((r) => ({
     name: r.name,
     publisher: r.publisher,
-    value: r[theme.stat] ?? 0,
+    // Composite shows one decimal (distinct); raw stats stay integers.
+    value: theme.composite ? Number(r.power_rating ?? 0).toFixed(1) : (r[theme.stat] ?? 0),
     portrait_url: r.portrait_url,
   }));
 }

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -816,22 +816,7 @@ export type Database = {
           related_id?: string
           source?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "hero_relationships_hero_id_fkey"
-            columns: ["hero_id"]
-            isOneToOne: false
-            referencedRelation: "heroes"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "hero_relationships_related_id_fkey"
-            columns: ["related_id"]
-            isOneToOne: false
-            referencedRelation: "heroes"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
       hero_relatives: {
         Row: {
@@ -1017,6 +1002,7 @@ export type Database = {
           portrait_blurhash: string | null
           portrait_url: string | null
           power: number | null
+          power_rating: number | null
           powers: string[] | null
           powerstats_total: number | null
           publisher: string | null
@@ -1096,6 +1082,7 @@ export type Database = {
           portrait_blurhash?: string | null
           portrait_url?: string | null
           power?: number | null
+          power_rating?: number | null
           powers?: string[] | null
           powerstats_total?: number | null
           publisher?: string | null
@@ -1175,6 +1162,7 @@ export type Database = {
           portrait_blurhash?: string | null
           portrait_url?: string | null
           power?: number | null
+          power_rating?: number | null
           powers?: string[] | null
           powerstats_total?: number | null
           publisher?: string | null
@@ -2650,3 +2638,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/migrations/20260714075907_rebuild_relationships_perf.sql
+++ b/supabase/migrations/20260714075907_rebuild_relationships_perf.sql
@@ -1,0 +1,170 @@
+-- Make the nightly relationship rebuild fast and reliable.
+--
+-- rebuild_hero_relationships() had been failing most nights at the 120s
+-- statement_timeout (2026-07-11, -12, -13) and only squeaking through at 109s on
+-- warm cache. Root causes, in order of impact:
+--
+--   1. hero_relationships carried two ON DELETE CASCADE FKs to heroes. Rebuilding
+--      ~400k rows fired ~800k `SELECT 1 FROM heroes ... FOR KEY SHARE` checks —
+--      both a large time cost and the source of lock contention with concurrent
+--      heroes UPDATEs (the enrichment drains), which is where the nightly actually
+--      stalled. The table is a *fully derived cache*: TRUNCATE'd and rebuilt every
+--      night purely from joins against heroes, so every inserted id provably
+--      exists. Referential integrity is guaranteed structurally; orphans from a
+--      mid-day hard delete self-heal on the next rebuild and are invisible to the
+--      read RPCs (they all inner-join back to heroes). Drop the FKs.
+--
+--   2. A trailing `reindex table` (added in 20260713190000) rebuilt every index a
+--      second time — redundant after TRUNCATE+INSERT, which already builds them.
+--
+--   3. The teammate step did two full sequential scans of the 197MB heroes heap.
+--      Cold at 03:40 those cost ~7s each and caused the flap. A covering partial
+--      index (teams arrays max 20 items / 536B, safely btree-includable) makes them
+--      index-only over just the ~19.5k team-bearing rows. The enemy/ally step's own
+--      scan is only ~2s (its cost is the name-join, not the scan) and it warms the
+--      heap cache for the teammate step, so it needs no index — and its enemies/
+--      friends arrays (up to 120 items) exceed the btree tuple limit anyway.
+--
+--   4. Timeout headroom: a function-level SET statement_timeout does not affect the
+--      already-running outer statement, so lift it in the cron command instead.
+--
+-- Reversible: re-add the FKs, drop the two indexes, restore the reindex, and reset
+-- the cron command to `select public.nightly_maintenance();`.
+
+-- 1. Drop the FK overhead + contention.
+alter table public.hero_relationships drop constraint hero_relationships_hero_id_fkey;
+alter table public.hero_relationships drop constraint hero_relationships_related_id_fkey;
+
+-- 2. Covering partial index so the teammate step reads only team-bearing heroes
+--    (index-only), not the full 197MB heap. Columns match exactly what the scan
+--    needs; enrichment writes touch none of them, so heroes UPDATEs stay
+--    HOT-eligible and don't pay index maintenance.
+create index if not exists heroes_team_rebuild
+  on public.heroes (id) include (teams, issue_count, publisher, fame_score)
+  where teams is not null and array_length(teams, 1) > 0;
+
+-- 3. Rebuild fn: drop the redundant trailing REINDEX. The teammate CTEs already
+--    carry the matching `teams is not null ...` predicate, so they pick up
+--    heroes_team_rebuild as-is. Enemy/ally logic is unchanged.
+create or replace function public.rebuild_hero_relationships()
+ returns void
+ language plpgsql
+ set search_path to 'public'
+as $function$
+begin
+  truncate public.hero_relationships;
+
+  -- Enemies / allies — resolved by name; keep the edge if either side is fame >= 5.
+  insert into public.hero_relationships (hero_id, related_id, kind, source, rank, cross_universe)
+  select hero_id, related_id, kind, 'comicvine', rank, cross_universe
+  from (
+    select hero_id, related_id, kind, cross_universe,
+           row_number() over (partition by hero_id, kind order by issue_count desc nulls last) as rank
+    from (
+      select distinct on (h.id, k.kind, nm.nm_name)
+        h.id as hero_id, m.id as related_id, k.kind, m.issue_count,
+        (m.publisher is distinct from h.publisher) as cross_universe
+      from public.heroes h
+      cross join (values ('enemy'), ('ally')) as k(kind)
+      cross join lateral unnest(
+        case when k.kind = 'ally' then h.friends else h.enemies end
+      ) as nm(nm_name)
+      join public.heroes m on m.name = nm.nm_name and m.id <> h.id
+      where h.fame_score >= 5 or m.fame_score >= 5
+      order by h.id, k.kind, nm.nm_name, m.issue_count desc nulls last
+    ) resolved
+  ) ranked
+  where rank <= 60;
+
+  -- Teammates — bounded top-30-per-team candidate side; keep the edge if either
+  -- side is fame >= 5 (applied at the pair join, so the top-30 cap stays by fame/issue_count).
+  insert into public.hero_relationships (hero_id, related_id, kind, source, rank, cross_universe)
+  with team_obj as (
+    select team, hero_id, issue_count, publisher, fame
+    from (
+      select t.team, h.id as hero_id, h.issue_count, h.publisher, h.fame_score as fame,
+             row_number() over (partition by t.team
+                                order by h.issue_count desc nulls last, h.id) as rn
+      from public.heroes h
+      cross join lateral unnest(h.teams) as t(team)
+      where h.teams is not null and array_length(h.teams, 1) > 0
+    ) r
+    where rn <= 30
+  ),
+  subj as (
+    select h.id as hero_id, h.publisher, h.fame_score as fame, t.team
+    from public.heroes h
+    cross join lateral unnest(h.teams) as t(team)
+    where h.teams is not null and array_length(h.teams, 1) > 0
+  ),
+  ranked as (
+    select hero_id, related_id, cross_universe,
+           row_number() over (partition by hero_id order by issue_count desc nulls last) as rank
+    from (
+      select distinct on (s.hero_id, o.hero_id)
+        s.hero_id, o.hero_id as related_id, o.issue_count,
+        (o.publisher is distinct from s.publisher) as cross_universe
+      from subj s
+      join team_obj o on o.team = s.team and o.hero_id <> s.hero_id
+                     and (s.fame >= 5 or o.fame >= 5)
+      order by s.hero_id, o.hero_id, o.issue_count desc nulls last
+    ) resolved
+  )
+  select hero_id, related_id, 'teammate', 'comicvine', rank, cross_universe
+  from ranked
+  where rank <= 30;
+
+  -- Curated marquee rivalries — always kept (all famous pairs), override source/rank.
+  insert into public.hero_relationships (hero_id, related_id, kind, source, rank, cross_universe)
+  with curated(a, b) as (
+    values
+      ('Batman','Superman'),('Batman','Joker'),('Batman','Bane'),
+      ('Superman','Magneto'),('Superman','Captain America'),
+      ('Joker','Captain America'),
+      ('Spider-Man','Green Goblin'),('Spider-Man','Venom'),('Spider-Man','Wolverine'),
+      ('Iron Man','Doctor Doom'),('Iron Man','Wolverine'),('Iron Man','Hulk'),
+      ('Captain America','Magneto'),('Captain America','Doctor Doom'),
+      ('Wolverine','Hulk'),('Wolverine','Sabretooth'),
+      ('Hulk','Thor'),('Thor','Magneto'),('Thor','Loki'),
+      ('Loki','Iron Man'),('Magneto','Cyclops'),
+      ('Wonder Woman','Batman'),('Wonder Woman','Superman'),
+      ('Doctor Strange','Doctor Doom'),('Doctor Strange','Loki'),
+      ('Darth Vader','Superman'),('Darth Vader','Captain America'),
+      ('Cyclops','Mystique'),('Mystique','Wolverine'),('Storm','Magneto')
+  ),
+  pairs(src, dst) as (
+    select a, b from curated
+    union
+    select b, a from curated
+  ),
+  resolved as (
+    select distinct on (p.src, p.dst)
+      ha.id as hero_id, hb.id as related_id,
+      (hb.publisher is distinct from ha.publisher) as cross_universe
+    from pairs p
+    join lateral (
+      select id, publisher from public.heroes where name = p.src
+      order by issue_count desc nulls last limit 1
+    ) ha on true
+    join lateral (
+      select id, publisher from public.heroes where name = p.dst
+      order by issue_count desc nulls last limit 1
+    ) hb on true
+  )
+  select hero_id, related_id, 'enemy', 'curated', 0, cross_universe
+  from resolved
+  where hero_id <> related_id
+  on conflict (hero_id, kind, related_id)
+    do update set source = 'curated', rank = 0;
+end;
+$function$;
+
+-- 4. Give the nightly job real headroom. Session-level SET in the command is the
+--    only reliable way — a function-local SET can't disarm the running statement's
+--    timer. work_mem keeps the rebuild's ~26MB sorts in memory (it runs alone at
+--    03:40). Measured end-to-end: ~110s (flapping/failing) -> ~56s with headroom.
+select cron.schedule(
+  'nightly-maintenance',
+  '40 3 * * *',
+  $cmd$set statement_timeout to '10min'; set work_mem to '128MB'; select public.nightly_maintenance();$cmd$
+);

--- a/supabase/migrations/20260714083135_hero_power_rating.sql
+++ b/supabase/migrations/20260714083135_hero_power_rating.sql
@@ -1,0 +1,63 @@
+-- Add heroes.power_rating: a weighted composite of the six powerstats (0-100) for
+-- overall-strength ranking (social "Top 10 Strongest / Most Powerful" countdowns).
+--
+-- Why: single-stat rankings tie massively at the ceiling — in the famous pool
+-- (fame >= 20) there are 154 characters at power=100, 92 at strength=100, etc., so a
+-- "Top 10 Strongest" shows a wall of identical 100s. A weighted blend of all six
+-- stats produces ~750 distinct values across the famous pool (top tie: 2), giving a
+-- strictly ordered, distinct-number countdown.
+--
+-- Weights favor physical dominance (power/strength/durability) over finesse:
+--   power .25, strength .20, durability .20, combat .15, speed .12, intelligence .08
+--
+-- Implemented as a plain column + trigger (not a GENERATED STORED column) on
+-- purpose: STORED would rewrite the whole 197MB heroes table under ACCESS EXCLUSIVE
+-- and contend with the every-15-min ComicVine drain. The trigger only touches the
+-- ~14k stat-bearing rows. Stats are strictly all-or-nothing (verified: 0 partial),
+-- so null propagates and stat-less heroes get null power_rating (excluded from
+-- rankings via nullslast), exactly as intended.
+--
+-- Reversible: drop the column, trigger, function, and index.
+
+alter table public.heroes add column power_rating numeric(5,2);
+
+comment on column public.heroes.power_rating is
+  'Weighted composite of the six powerstats (0-100) for overall-strength ranking. Maintained by trg_set_power_rating; null when stats are unset.';
+
+create or replace function public.set_power_rating()
+returns trigger
+language plpgsql
+set search_path to 'public'
+as $$
+begin
+  -- Any null stat propagates to null (stat-less heroes stay unranked).
+  new.power_rating := round(
+    (0.25 * new.power
+   + 0.20 * new.strength
+   + 0.20 * new.durability
+   + 0.15 * new.combat
+   + 0.12 * new.speed
+   + 0.08 * new.intelligence)::numeric, 2);
+  return new;
+end $$;
+
+create trigger trg_set_power_rating
+  before insert or update of intelligence, strength, speed, durability, power, combat
+  on public.heroes
+  for each row execute function public.set_power_rating();
+
+-- Backfill existing stat-bearing rows (touches power_rating only, so the trigger
+-- above does not re-fire).
+update public.heroes set power_rating = round(
+    (0.25 * power
+   + 0.20 * strength
+   + 0.20 * durability
+   + 0.15 * combat
+   + 0.12 * speed
+   + 0.08 * intelligence)::numeric, 2)
+where intelligence is not null;
+
+-- Ranking index (partial: only ranked rows).
+create index if not exists heroes_power_rating_idx
+  on public.heroes (power_rating desc nulls last)
+  where power_rating is not null;


### PR DESCRIPTION
Two related DB/social fixes. **Both migrations are already applied to production** (via the Supabase MCP), and the local migration files here are named to match the recorded remote history versions (`20260714075907`, `20260714083135`) — so this PR reconciles the shared migration history with what's live; it does not need to be "deployed" to the DB.

## 1. `perf(db)`: nightly hero-relationship rebuild (commit 1)

`rebuild_hero_relationships()` had been **failing most nights** at the 120s `statement_timeout` (2026-07-11/-12/-13) and only squeaking through at 109s on warm cache, as the catalog reached 50k heroes. Root causes, measured:

- **~800k `FOR KEY SHARE` locks** per rebuild from two `hero_relationships`→`heroes` FKs — both a large time cost and the source of lock contention with the enrichment drains' `heroes` UPDATEs (where the nightly actually stalled).
- A redundant trailing **`REINDEX`** (TRUNCATE+INSERT already builds indexes).
- Two **cold 197MB heap scans** in the teammate step (~7.3s each cold).

Fixes: drop the FKs (`hero_relationships` is a fully-derived cache, integrity guaranteed by the rebuild joins; orphans self-heal nightly and are invisible to inner-join reads), remove the REINDEX, add covering partial index `heroes_team_rebuild` (teammate step **11.3s → 2.6s**, index-only), and lift the nightly cron's `statement_timeout` to 10min + `work_mem` 128MB.

**Result: ~110s (flapping/failing) → ~56s, output byte-identical (399,697 edges).**

Behavior trade-off (documented in the migration header, reversible): a mid-day hard-delete of a hero now leaves orphan edges until the next nightly instead of cascading — harmless since every read RPC inner-joins back to `heroes`.

## 2. `feat(social)`: de-tie top-list rankings (commit 2)

Social "Top 10" countdowns showed walls of identical numbers because single 0–100 powerstats tie hard at the ceiling — in the famous pool: **154 characters at power=100, 92 at strength=100**, etc.

- Add **`heroes.power_rating`**: a weighted composite of the six stats (0–100, trigger-maintained). "Strongest" / "Most Powerful" themes now rank by it (154-way top tie → ~2), shown to one decimal.
- Add continuous **tiebreakers** (`wikidata_sitelinks`, `powerstats_total`, `id`) to all social ranking/pool queries for strict, stable ordering.
- Regenerated DB types (adds `power_rating`; reflects the FK removal from commit 1).

Single-attribute themes (smartest/fastest/fighters) still show their raw stat and can repeat at the ceiling, but are now strictly ordered — a full fix there needs finer-grained stats (deferred by design).

Also run out-of-band (data-only, not in this PR): `recompute_fame_scores()` to break the fame-band plateau (37 → 18 at fame=80).

## Test
- 20/20 social-engine tests pass; syntax clean on edited `.mjs`.
- Live-query mirrors of the new post queries confirmed distinct descending numbers.
- Rebuild verified end-to-end at ~56s with byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)