### PR TITLE
social-engine safety: de-tie rankings, fame floor, exclude real people

### DIFF
--- a/scripts/social/generate-rankings.mjs
+++ b/scripts/social/generate-rankings.mjs
@@ -36,20 +36,29 @@ function titles(opts) {
   return { title, sub };
 }
 
+// "Strongest" and "Most Powerful" are overall-might framings, so rank them by the
+// weighted power_rating composite — a single 0-100 stat ties hard at the ceiling
+// (154 characters at power=100, 92 at strength=100), giving a wall of identical
+// 100s. Single-attribute boards (smartest/fastest/toughest/deadliest) keep their
+// raw stat. Composite values display to one decimal so the countdown descends.
+const COMPOSITE_BY = new Set(['strength', 'power']);
+
 async function fetchRanking(sb, opts) {
-  const metric = opts.by === 'fame' ? 'fame_score' : opts.by;
+  const composite = COMPOSITE_BY.has(opts.by);
+  const metric = opts.by === 'fame' ? 'fame_score' : composite ? 'power_rating' : opts.by;
   const cols = ['id', 'name', 'portrait_url', 'image_url', 'image_md_url', 'publisher', 'alignment', 'fame_score'];
-  if (opts.by !== 'fame') cols.push(opts.by);
+  if (opts.by !== 'fame') cols.push(metric);
   let filter = '';
   if (opts.alignment) filter += `&alignment=eq.${opts.alignment}`;
   if (opts.publisher) filter += `&publisher=eq.${encodeURIComponent(opts.publisher)}`;
+  if (opts.minFame > 0) filter += `&fame_score=gte.${opts.minFame}`;
   let order;
   // issue_count tiebreak: many heroes tie on fame; without it the list order is
   // arbitrary and changes between runs (Elmer Fudd once outranked Venom).
   if (opts.by === 'fame') order = 'fame_score.desc,issue_count.desc.nullslast';
-  else { filter += `&${opts.by}=not.is.null`; order = `${opts.by}.desc.nullslast,fame_score.desc,issue_count.desc.nullslast`; }
+  else { filter += `&${metric}=not.is.null`; order = `${metric}.desc.nullslast,fame_score.desc,issue_count.desc.nullslast`; }
   const rows = await sb.rest(`heroes?select=${cols.join(',')}${filter}&order=${order}&limit=${opts.count}`);
-  return rows.map((r, i) => ({ ...r, rank: i + 1, value: r[metric] ?? 0 }));
+  return rows.map((r, i) => ({ ...r, rank: i + 1, value: composite ? Number(r[metric] ?? 0).toFixed(1) : (r[metric] ?? 0) }));
 }
 
 // ---- slides ----
@@ -125,6 +134,9 @@ async function main() {
     publisher: get('--publisher', null),
     count: parseInt(get('--count', '10'), 10),
     title: get('--title', null),
+    // Floor out unrecognizable characters (obscure all-100 cosmic beings otherwise
+    // top the stat boards). Overridable with --min-fame 0 for a full sweep.
+    minFame: parseInt(get('--min-fame', '20'), 10),
   };
   const dry = args.includes('--dry-run');
   if (!METRIC_WORD[opts.by]) { console.error('--by must be one of:', Object.keys(METRIC_WORD).join(', ')); process.exit(1); }

--- a/scripts/social/generate-rankings.mjs
+++ b/scripts/social/generate-rankings.mjs
@@ -13,7 +13,7 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { loadEnv, makeSb, imgDataUri, fonts, OUT_DIR, renderPng, COLORS, slide } from './lib.mjs';
+import { loadEnv, makeSb, imgDataUri, fonts, OUT_DIR, renderPng, COLORS, slide, REAL_PERSON_FILTER } from './lib.mjs';
 
 const { GOLD, CREAM } = COLORS;
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -57,7 +57,7 @@ async function fetchRanking(sb, opts) {
   // arbitrary and changes between runs (Elmer Fudd once outranked Venom).
   if (opts.by === 'fame') order = 'fame_score.desc,issue_count.desc.nullslast';
   else { filter += `&${metric}=not.is.null`; order = `${metric}.desc.nullslast,fame_score.desc,issue_count.desc.nullslast`; }
-  const rows = await sb.rest(`heroes?select=${cols.join(',')}${filter}&order=${order}&limit=${opts.count}`);
+  const rows = await sb.rest(`heroes?select=${cols.join(',')}${filter}${REAL_PERSON_FILTER}&order=${order}&limit=${opts.count}`);
   return rows.map((r, i) => ({ ...r, rank: i + 1, value: composite ? Number(r[metric] ?? 0).toFixed(1) : (r[metric] ?? 0) }));
 }
 

--- a/scripts/social/lib.mjs
+++ b/scripts/social/lib.mjs
@@ -28,6 +28,12 @@ const HERO_SELECT = 'id,name,publisher,portrait_url,image_url,image_md_url,fame_
 // Strict fame ordering: fame_score bands can tie (esp. tier plateaus), so break
 // ties by the continuous popularity signals, then id, for a stable countdown.
 const FAME_ORDER = 'fame_score.desc.nullslast,wikidata_sitelinks.desc.nullslast,powerstats_total.desc.nullslast,id.asc';
+// Real people (historical figures, politicians, celebrities) are catalogued as
+// 'Non-Fictional' but must NEVER surface in generated posts — assigning them
+// power stats, an alignment, or an AI-written bio is a publicity/defamation risk.
+// They sit at fame <= 13 so the fame gates exclude them in practice today, but
+// keep it explicit so a future re-rating or signal change can't leak them in.
+export const REAL_PERSON_FILTER = '&publisher=not.in.("Non-Fictional")';
 const q = (s) => encodeURIComponent(s);
 
 export function loadEnv() {
@@ -108,7 +114,7 @@ export async function heroFullByName(sb, name) {
 }
 // Random popular characters for bio showcases.
 export async function popularHeroes(sb, n) {
-  return sb.rest(`heroes?select=${HERO_FULL}&order=${FAME_ORDER}&limit=${n}`);
+  return sb.rest(`heroes?select=${HERO_FULL}${REAL_PERSON_FILTER}&order=${FAME_ORDER}&limit=${n}`);
 }
 
 // Relationship graph (enemies / allies), family, and key/value enrichment facts.
@@ -124,7 +130,7 @@ export async function getFact(sb, id, key) {
   try { const r = await sb.rest(`hero_facts?hero_id=eq.${id}&key=eq.${q(key)}&select=value&limit=1`); return r[0]?.value ?? null; }
   catch { return null; }
 }
-export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}&order=${FAME_ORDER}&limit=${FAME_POOL}`);
+export const famousPool = (sb) => sb.rest(`heroes?select=${HERO_SELECT}${REAL_PERSON_FILTER}&order=${FAME_ORDER}&limit=${FAME_POOL}`);
 
 // A matchup is postable if it has a real, close-ish vote split.
 export async function evaluate(sb, a, b) {

--- a/scripts/social/organic-pack.mjs
+++ b/scripts/social/organic-pack.mjs
@@ -12,7 +12,7 @@
 // (movie-poster carousel) · legend (shareable dossier card).
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { loadEnv, makeSb, fonts, renderPng, COLORS, OUT_DIR, ROOT, RIVALRIES } from './lib.mjs';
+import { loadEnv, makeSb, fonts, renderPng, COLORS, OUT_DIR, ROOT, RIVALRIES, REAL_PERSON_FILTER } from './lib.mjs';
 import { adShell } from './ads/shell.mjs';
 
 const { O, T, GOLD, CREAM } = COLORS;
@@ -320,7 +320,7 @@ function gauntletSlides(h, statKey) {
 // ── data ──────────────────────────────────────────────────────────────────────
 async function pool(sb) {
   const rows = await sb.rest(
-    `heroes?select=${HERO_COLS}&portrait_url=not.is.null&order=fame_score.desc.nullslast,wikidata_sitelinks.desc.nullslast,powerstats_total.desc.nullslast,id.asc&limit=60`,
+    `heroes?select=${HERO_COLS}${REAL_PERSON_FILTER}&portrait_url=not.is.null&order=fame_score.desc.nullslast,wikidata_sitelinks.desc.nullslast,powerstats_total.desc.nullslast,id.asc&limit=60`,
   );
   return rows.map(shape);
 }
@@ -370,7 +370,7 @@ async function rankingRows(sb, theme) {
     : `name,publisher,portrait_url,id,fame_score,power_rating,${theme.stat}`;
   const rows = await sb
     .rest(
-      `heroes?select=${cols}&portrait_url=not.is.null&fame_score=gte.20${align}&order=${order}&limit=10`,
+      `heroes?select=${cols}${REAL_PERSON_FILTER}&portrait_url=not.is.null&fame_score=gte.20${align}&order=${order}&limit=10`,
     )
     .catch(() => []);
   return rows.map((r) => ({

--- a/supabase/migrations/20260714140939_exclude_real_people_daily_debate.sql
+++ b/supabase/migrations/20260714140939_exclude_real_people_daily_debate.sql
@@ -1,0 +1,34 @@
+-- Never feature real people (publisher='Non-Fictional' — historical figures,
+-- politicians, celebrities) in the auto-generated daily-debate matchup. Assigning
+-- a real person an opponent, an alignment, and a "who would win" framing is a
+-- publicity/defamation risk. They currently sit at fame <= 13 so the fame >= 60
+-- gate already excludes them, but make it explicit so a future fame re-rating or
+-- signal change can't leak one in. Everything else is unchanged.
+create or replace function public.pick_daily_debate()
+ returns void
+ language plpgsql
+ security definer
+ set search_path to 'public'
+as $function$
+begin
+  insert into public.daily_debate (debate_date, hero_a_id, hero_b_id)
+  select current_date + 1, least(r.hero_id, r.related_id),
+         greatest(r.hero_id, r.related_id)
+  from public.hero_relationships r
+  join public.heroes a on a.id = r.hero_id
+  join public.heroes b on b.id = r.related_id
+  where r.kind = 'enemy'
+    and a.fame_score >= 60 and b.fame_score >= 60
+    and a.publisher is distinct from 'Non-Fictional'
+    and b.publisher is distinct from 'Non-Fictional'
+    and a.portrait_url is not null and b.portrait_url is not null
+    and not exists (
+      select 1 from public.daily_debate dd
+      where dd.debate_date > current_date - 90
+        and dd.hero_a_id = least(r.hero_id, r.related_id)
+        and dd.hero_b_id = greatest(r.hero_id, r.related_id))
+  order by (a.fame_score + b.fame_score) desc, random()
+  limit 1
+  on conflict (debate_date) do nothing;
+end;
+$function$;


### PR DESCRIPTION
Follow-up to PR #66 — a cluster of social-engine correctness/safety fixes found while verifying the ranking work.

## 1. De-tie the standalone rankings generator
`generate-rankings.mjs` still ranked `--by strength` / `--by power` by the raw 0–100 stat, so "Top 10 Most Powerful" rendered a **wall of ten identical 100s** (154 characters tie at `power=100`). Now those overall-might boards rank + display the weighted `power_rating` composite (one decimal, distinct descending); single-attribute boards keep their raw stat.

## 2. Fame floor for stat boards
Added `--min-fame` (default 20). Without it, obscure all-100 cosmic beings (Takion, Man of Miracles) topped the boards over recognizable characters. Overridable with `--min-fame 0`.

## 3. Exclude real people from posts + matchups
Real historical figures, politicians, and celebrities are catalogued as `publisher='Non-Fictional'` (~329 rows: Confucius, JFK, Kim Kardashian…). Assigning them power stats, an alignment, an AI bio, or a "who would win" opponent is a publicity/defamation risk — and the social engine publishes unattended.

Today they're kept out only *by accident* (all sit at fame ≤ 13, so fame gates exclude them); there was **no explicit filter**, and `safety.mjs` even mis-tiers `Non-Fictional` as `'C'`=safe. This makes it explicit and robust:
- Shared `REAL_PERSON_FILTER` applied to `famousPool`, `popularHeroes`, organic-pack pools, and `generate-rankings`.
- Explicit `publisher` guard added to `pick_daily_debate()` (migration `20260714140939`) so the daily matchup can't feature a real person even if one were re-rated above fame 60.

The app's browse/search/explore/feed **already** exclude Non-Fictional; this closes the social-engine + matchup gap.

## Verification
`--dry-run` confirms de-tied recognizable boards; social tests pass 20/20. (PNG render needs `playwright-core`/chromium, not installed in the sandbox.) The `pick_daily_debate` migration is already applied to prod; the local file matches the recorded history version.

## Follow-ups noted, not in this PR
- `safety.mjs` mis-tiers `Non-Fictional` as `'C'` (safe to depict in ads). Now moot since they're excluded from the feeding pools, but worth correcting.
- Separate product decision: whether to purge living real people from the catalog entirely (this PR just keeps them out of generated content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)