### PR TITLE
perf(admin): fix slow /admin/health command-center load (13.5s → ~1s)

### DIFF
--- a/supabase/migrations/20260714142827_speed_up_enrichment_progress.sql
+++ b/supabase/migrations/20260714142827_speed_up_enrichment_progress.sql
@@ -1,0 +1,55 @@
+-- Speed up the admin command-center's slowest tile. enrichment_progress() ran
+-- ELEVEN separate count(*) subqueries; the 6 status counts over heroes each did a
+-- FULL sequential scan of the 197MB heroes heap — ~5s warm and ~13.5s cold (the
+-- "sometimes takes long to load" the admin sees). Two fixes:
+--   1. Single-pass FILTER aggregate: one scan of heroes instead of six.
+--   2. A narrow covering index on the status columns so that single pass becomes
+--      an index-only scan of a ~few-MB index instead of the 197MB heap — fast even
+--      on a cold cache. Columns aren't in any hot write path beyond the enrichment
+--      drains that already touch them.
+-- Output shape is byte-identical; only the plan changes. Reversible: drop the index
+-- and restore the previous 11-subquery body.
+
+create index if not exists heroes_enrichment_counts_idx
+  on public.heroes (comicvine_status, wikidata_status) include (wikidata_enriched_at);
+
+create or replace function public.enrichment_progress()
+ returns jsonb
+ language sql
+ stable
+ set search_path to 'public'
+as $function$
+  with h as (
+    select
+      count(*)                                                                             as total,
+      count(*) filter (where comicvine_status = 'done')                                    as cv_done,
+      count(*) filter (where comicvine_status = 'unmatched')                               as cv_unmatched,
+      count(*) filter (where wikidata_status = 'resolved')                                 as resolved,
+      count(*) filter (where wikidata_status = 'ambiguous')                                as ambiguous,
+      count(*) filter (where wikidata_status = 'unresolved')                               as unresolved,
+      count(*) filter (where wikidata_status = 'resolved' and wikidata_enriched_at is not null) as enriched
+    from heroes
+  ),
+  t as (
+    select
+      count(*) filter (where media_type = 'film')                        as film,
+      count(*) filter (where media_type = 'tv')                          as tv,
+      count(*) filter (where media_type = 'game')                        as game,
+      count(*) filter (where source = 'tmdb' and enrich_status = 'done') as media_done
+    from titles
+  )
+  select jsonb_build_object(
+    'heroesTotal',        h.total,
+    'comicvineDone',      h.cv_done,
+    'comicvineUnmatched', h.cv_unmatched,
+    'resolved',           h.resolved,
+    'ambiguous',          h.ambiguous,
+    'unresolved',         h.unresolved,
+    'enriched',           h.enriched,
+    'filmTitles',         t.film,
+    'tvTitles',           t.tv,
+    'gameTitles',         t.game,
+    'mediaDone',          t.media_done
+  )
+  from h, t;
+$function$;

--- a/supabase/migrations/20260714143052_index_unbranded_worklist.sql
+++ b/supabase/migrations/20260714143052_index_unbranded_worklist.sql
@@ -1,0 +1,11 @@
+-- Second slow query on the admin command-center home: listUnbrandedHeroes did a
+-- full seq scan of the 197MB heroes heap (~7s cold) to find the ~hundreds of
+-- "unbranded but ComicVine-done" heroes, sort them by issue_count, and take 300.
+-- A partial index matching that exact predicate, ordered by issue_count, turns it
+-- into a tiny index scan (a few hundred entries) + ~300 heap fetches.
+-- Predicate mirrors src/lib/db/catalogHealth.ts listUnbrandedHeroes /
+-- UNBRANDED_BUCKETS exactly, so the planner can use it.
+create index if not exists heroes_unbranded_worklist_idx
+  on public.heroes (issue_count desc nulls last)
+  where comicvine_status = 'done'
+    and (publisher is null or publisher in ('Company-Licensed', 'Creator-Owned'));


### PR DESCRIPTION
**Why it "sometimes takes long to load":** two queries the command-center home fires in parallel each did a **full sequential scan of the 197MB `heroes` heap** — fine when the table is cached, painful (7–13s) on a cold cache, which is exactly the intermittent slowness.

## Diagnosis (measured)
| Query (home view) | Before (cold) | After |
|---|---|---|
| `enrichment_progress()` | **~13.5s** | **~1.2s** |
| `listUnbrandedHeroes` | **~7.2s** | **~0.14s** |

Everything else on the home was already fast: `catalog_health` 98ms, `page_views` is tiny (2.4k rows), traffic/community not a factor.

## Fixes (results byte-identical, only the plan changes)
1. **`enrichment_progress()`** ran 11 separate `count(*)` subqueries — the 6 status counts over `heroes` were 6 full seq scans. Rewrote as a **single-pass `FILTER` aggregate** (one scan) and added a narrow **covering index** `heroes_enrichment_counts_idx (comicvine_status, wikidata_status) INCLUDE (wikidata_enriched_at)` so it's now an **index-only scan** (~15MB read instead of ~688MB). Verified: `Index Only Scan`, warm ~12ms.
2. **`listUnbrandedHeroes`** scanned all 50k heroes to find a few hundred "unbranded + ComicVine-done" rows. Added **partial index** `heroes_unbranded_worklist_idx` on `issue_count` matching its exact predicate → tiny index scan + ~300 heap fetches. Verified: `Index Scan`, ~140ms.

`catalog_health` was already single-passed (migration `20260705202608`); `enrichment_progress` just never got the same treatment.

Both migrations are already applied to prod; local filenames match the recorded history versions (`20260714142827`, `20260714143052`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)