### PR TITLE
perf(db): index the two cold heroes scans in refresh_explore_bundle

### DIFF
--- a/supabase/migrations/20260714144633_explore_bundle_partial_indexes.sql
+++ b/supabase/migrations/20260714144633_explore_bundle_partial_indexes.sql
@@ -1,0 +1,18 @@
+-- Speed up the hourly refresh_explore_bundle() (was ~17.6s cold). Its cost is
+-- dominated by two direct heroes queries that heap-scan wide rows on a cold cache:
+--   spotlight_famous: an index scan of powerstats_total>=200 (~8.4k rows) then a
+--     heap filter down to the top 20 (cost ~5979).
+--   newly_added: walks ~46k rows by added_at desc to find the newest 25 'cv-%'
+--     (which are old, so the desc walk skips everything newer first).
+-- Partial indexes matching each predicate return the top-N directly (spotlight_famous
+-- cost 5979 -> 19; newly_added -> index-only scan). Worst-case bundle ~17.6s -> ~8.5s;
+-- the rest is spread across ~13 small components (a background cache, users hit the
+-- cached payload, so further micro-tuning has diminishing returns).
+create index if not exists heroes_spotlight_famous_idx
+  on public.heroes (movie_count desc nulls last, fame_score desc nulls last)
+  where portrait_url is not null and summary is not null
+    and movie_count >= 2 and powerstats_total >= 200;
+
+create index if not exists heroes_newly_added_cv_idx
+  on public.heroes (added_at desc)
+  where id like 'cv-%' and publisher not in ('Non-Fictional', 'In the Public Domain');


### PR DESCRIPTION
Follow-up to PR #68's admin-health work. I took a **data-driven** pass with `pg_stat_statements` + the Supabase performance advisor to find the next hotspots.

## What the data showed
- The historical top queries in `pg_stat_statements` (enrichment drains, ~47% of DB time) were **already fixed** by yesterday's `heroes_enrichment_drain_indexes` migration — the enwiki-resolve drain now runs in **2ms** (was 2.7s). Those totals are just cumulative history.
- The real **current** hotspot is **`refresh_explore_bundle()`** — the hourly explore-cache cron — measured at **8–17.6s**.

## Diagnosis
Profiling the 15 sub-queries: `get_browse_covers` (236ms) and the 8 trending sub-RPCs (886ms total) are fine. The cost is two direct `heroes` queries that heap-scan wide rows cold:
- **`spotlight_famous`** — index-scanned ~8.4k `powerstats_total≥200` rows, then heap-filtered to the top 20 (cost **5979**).
- **`newly_added`** — walked ~46k rows by `added_at desc` to find the newest 25 `'cv-%'` (they're old, so the desc walk skips everything newer).

## Fix
Two matching partial indexes:
- `heroes_spotlight_famous_idx` → cost **5979 → 19** (Index Scan).
- `heroes_newly_added_cv_idx` → **Index-Only Scan**, Heap Fetches: 1.

Worst-case bundle **~17.6s → ~8.5s**. This is a **background cache** (users read the cached payload, never wait on the refresh), so the remaining ~13 small components are left as diminishing returns.

Migration already applied to prod; local filename matches the recorded history version (`20260714144633`).

## Also surfaced by the advisor (not in this PR)
- ~14 RLS policies re-evaluate `auth.<fn>()` per row (wrap in `(select auth.<fn>())`) — mechanical, but low current impact at this scale.
- A handful of unused indexes (write-overhead only) and unindexed FKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)