### PR TITLE
fix(web): kill the three load-time pop-ins (landing FOUC, profile sections, settings admin row)

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // Nearest-tsconfig for the Vercel serverless/edge functions in this folder.
+  // Vercel's function builder type-checks api/ entrypoints with the closest
+  // tsconfig.json; without this one it falls back to CommonJS assumptions and
+  // TypeScript 6 hard-errors on `import.meta` (TS1470) in api/og.tsx — which
+  // MUST use `new URL(..., import.meta.url)` for Edge font asset tracing.
+  // The app's root tsconfig (module: "preserve") still governs editor/CI
+  // type-checking of these files as part of the main project.
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/app/(auth)/forgot-password.web.tsx
+++ b/app/(auth)/forgot-password.web.tsx
@@ -12,6 +12,7 @@ import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useScreenChrome } from '../../src/hooks/useScreenChrome';
+import { PageEndCap } from '../../src/components/web/PageEndCap';
 import { COLORS, SURFACE, SURFACE_GRADIENT } from '../../src/constants/colors';
 import { HeroLogo } from '../../src/components/web/HeroLogo';
 import { Image } from 'expo-image';
@@ -186,6 +187,9 @@ export default function WebForgotPasswordScreen() {
           <View style={styles.mobileCardHandle} />
           {formContent}
         </View>
+        {/* Close the paper card onto the ink floor (constant-ink chrome) —
+            without this the card ends into the raw canvas at the bottom. */}
+        <PageEndCap />
       </View>
     );
   }

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useScreenChrome } from '../../src/hooks/useScreenChrome';
+import { PageEndCap } from '../../src/components/web/PageEndCap';
 import { COLORS, SURFACE, SURFACE_GRADIENT } from '../../src/constants/colors';
 import { HeroLogo } from '../../src/components/web/HeroLogo';
 import { Image } from 'expo-image';
@@ -198,6 +199,9 @@ export default function WebLoginScreen() {
           <View style={styles.cardAccent} />
           {formContent}
         </View>
+        {/* Close the paper card onto the ink floor (constant-ink chrome) —
+            without this the card ends into the raw canvas at the bottom. */}
+        <PageEndCap />
       </View>
     );
   }

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useScreenChrome } from '../../src/hooks/useScreenChrome';
+import { PageEndCap } from '../../src/components/web/PageEndCap';
 import { COLORS, SURFACE, SURFACE_GRADIENT } from '../../src/constants/colors';
 import { HeroLogo } from '../../src/components/web/HeroLogo';
 import { Image } from 'expo-image';
@@ -227,6 +228,9 @@ export default function WebSignupScreen() {
           <View style={styles.cardAccent} />
           {formContent}
         </View>
+        {/* Close the paper card onto the ink floor (constant-ink chrome) —
+            without this the card ends into the raw canvas at the bottom. */}
+        <PageEndCap />
       </View>
     );
   }

--- a/app/(tabs)/versus.web.tsx
+++ b/app/(tabs)/versus.web.tsx
@@ -29,7 +29,7 @@ export default function VersusHubWeb() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
   const contentPad = width < 640 ? 16 : 32;
-  const { matchup, hookText, takesCount, yesterday, iconicPool, loading, mostFeared } =
+  const { matchup, hookText, takesCount, yesterday, iconicPool, loading, feedSettled, mostFeared } =
     useVersusHub();
 
   const openArena = (a: FighterArt, b: FighterArt) => {
@@ -128,7 +128,10 @@ export default function VersusHubWeb() {
             </>
           ) : null}
 
-          {yesterday ? <YesterdayStrip yesterday={yesterday} /> : null}
+          {/* Held until the feed settles: this strip resolves via two chained
+              queries and sits ABOVE the actions, so letting it mount on its own
+              schedule shoved everything below it down mid-load. */}
+          {feedSettled && yesterday ? <YesterdayStrip yesterday={yesterday} /> : null}
 
           {/* ── Secondary actions ── */}
           <View style={s.actions}>
@@ -175,7 +178,10 @@ export default function VersusHubWeb() {
         </View>
       </View>
 
-      {/* ── Battle Discovery feed ── */}
+      {/* ── Battle Discovery feed — revealed as ONE snapshot once every feed
+          source has settled (rows.settled), so sections don't pop in one after
+          another as their individual queries land. ── */}
+      {rows.settled && (
       <View style={[s.feed, { paddingHorizontal: contentPad }] as object}>
         <View style={s.feedInner}>
           {rows.rivalries.length > 0 && (
@@ -275,6 +281,7 @@ export default function VersusHubWeb() {
           </Reveal>
         </View>
       </View>
+      )}
     </View>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,10 +1,24 @@
+import { lazy, Suspense } from 'react';
 import { Platform } from 'react-native';
 import { Redirect } from 'expo-router';
-import LandingPage from '../src/components/landing/LandingPage.dom';
+import { LogoLoader } from '../src/components/ui/LogoLoader';
 import { useWebCanvas } from '../src/hooks/useWebCanvas';
+
+// Code-split: the landing pulls in three.js (the summon stage), which would
+// otherwise ride in the shared entry bundle and slow the boot of EVERY page on
+// every platform. Lazy keeps it in its own chunk, fetched only when a
+// logged-out web visitor actually lands on `/`; native redirects before the
+// chunk is ever requested.
+const LandingPage = lazy(() => import('../src/components/landing/LandingPage.dom'));
 
 export default function Index() {
   useWebCanvas('#0b1820');
   if (Platform.OS !== 'web') return <Redirect href="/explore" />;
-  return <LandingPage dom={{ scrollEnabled: false, matchContents: true }} />;
+  return (
+    // Same ink LogoLoader the boot gate shows, so the chunk fetch reads as a
+    // continuation of the app loading rather than a second distinct phase.
+    <Suspense fallback={<LogoLoader />}>
+      <LandingPage dom={{ scrollEnabled: false, matchContents: true }} />
+    </Suspense>
+  );
 }

--- a/app/settings.web.tsx
+++ b/app/settings.web.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter, Redirect } from 'expo-router';
 import { useAuth } from '../src/hooks/useAuth';
 import { useProfile } from '../src/hooks/useProfile';
+import { useCachedAdminFlag } from '../src/hooks/useCachedAdminFlag';
 import { ChangePasswordModal } from '../src/components/ui/ChangePasswordModal';
 import { providerMeta } from '../src/lib/profile/provider';
 import { openKofi } from '../src/lib/support/kofi';
@@ -88,6 +89,9 @@ export default function WebSettingsScreen() {
   useScreenChrome({ top: SURFACE.ink, canvas: SURFACE.ink });
   const { user, loading: authLoading, signOut, changePassword, deleteAccount } = useAuth();
   const { profile } = useProfile(user?.id);
+  // Last-known admin state so the Admin section doesn't pop in after the
+  // profile query resolves (see useCachedAdminFlag for why this is safe).
+  const isAdmin = useCachedAdminFlag(profile);
   const [signingOut, setSigningOut] = useState(false);
   const [deletingAccount, setDeletingAccount] = useState(false);
   const [showChangePassword, setShowChangePassword] = useState(false);
@@ -162,7 +166,7 @@ export default function WebSettingsScreen() {
           )}
         </SectionShell>
 
-        {profile?.is_admin && (
+        {isAdmin && (
           <SectionShell title="Admin">
             <SettingRow
               icon="stats-chart-outline"

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -2019,6 +2019,9 @@ const CSS = `
     position:fixed; top:0; left:0; right:0; height:100lvh; z-index:9999;
     background:#0b1820;
     display:flex; align-items:center; justify-content:center;
+    /* The root is visibility:hidden while loading (so the toolbar glass can't
+       frost the unrevealed page) — the splash itself must stay visible. */
+    visibility:visible;
   }
   @keyframes loaderDraw {
     0% { stroke-dashoffset:100; }
@@ -2517,6 +2520,14 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
       style={{
         backgroundColor: '#0b1820',
         color: '#f5ebdc',
+        // While the splash is up, the page behind it must be GENUINELY
+        // invisible — iOS Safari's toolbar glass frosts the page content
+        // UNDERNEATH fixed overlays, so the summon particles showed through
+        // the toolbar band while the splash covered the rest of the screen
+        // (an unsyncable mismatch). visibility flips in the same commit the
+        // splash unmounts, so the band and the page reveal as one.
+        // (.page-loader overrides back to visible — visibility is inheritable.)
+        visibility: fontsReady ? undefined : 'hidden',
       }}
     >
       <style dangerouslySetInnerHTML={{ __html: CSS }} />

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1129,8 +1129,12 @@ function createSummoningScene(opts: EngineOpts): SummonEngine {
 /* CSS                                                                 */
 /* ------------------------------------------------------------------ */
 
+// Loaded via an injected <link> on mount (see the fonts effect) — a CSS @import
+// here would only start fetching after this <style> mounts and applies late.
+const FONTS_CSS_URL =
+  'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Righteous&display=swap';
+
 const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Righteous&display=swap');
 
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
@@ -2190,6 +2194,13 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
     };
   }, []);
 
+  // Fonts. The old CSS `@import` (inside the component's injected <style>) only
+  // started fetching after JS mounted, and `document.fonts.ready` resolved
+  // BEFORE those faces were even registered — so the loader faded while the
+  // hero was still in fallback fonts, then everything snapped ("half-baked"
+  // first paint). Instead: inject a real <link> (fetch starts immediately,
+  // preconnected), wait for its CSS to parse, then wait for the actual display
+  // faces before revealing.
   useEffect(() => {
     let done = false;
     const ready = () => {
@@ -2198,8 +2209,37 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
         setFontsReady(true);
       }
     };
-    document.fonts.ready.then(ready);
-    const fallback = setTimeout(ready, 2000); // never leave the hero hidden
+    let link = document.querySelector<HTMLLinkElement>('link[data-landing-fonts]');
+    if (!link) {
+      for (const origin of ['https://fonts.googleapis.com', 'https://fonts.gstatic.com']) {
+        const pre = document.createElement('link');
+        pre.rel = 'preconnect';
+        pre.href = origin;
+        if (origin.includes('gstatic')) pre.crossOrigin = 'anonymous';
+        document.head.appendChild(pre);
+      }
+      link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = FONTS_CSS_URL;
+      link.setAttribute('data-landing-fonts', '1');
+      document.head.appendChild(link);
+    }
+    const cssReady: Promise<unknown> = link.sheet
+      ? Promise.resolve()
+      : new Promise((res) => {
+          link!.addEventListener('load', res, { once: true });
+          link!.addEventListener('error', res, { once: true });
+        });
+    cssReady
+      .then(() =>
+        Promise.all([
+          document.fonts.load("400 24px 'Righteous'"),
+          document.fonts.load("400 16px 'Poppins'"),
+          document.fonts.load("600 16px 'Poppins'"),
+        ]),
+      )
+      .then(ready, ready);
+    const fallback = setTimeout(ready, 3000); // never leave the hero hidden
     return () => clearTimeout(fallback);
   }, []);
 

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1951,7 +1951,11 @@ const CSS = `
      text rises, headlines resolve out of blur, cards settle from scale,
      eyebrows wipe in like the ticker, mosaic art breathes to rest. */
   .reveal { opacity:0; transform:translateY(28px); transition:opacity .8s var(--ease), transform .8s var(--ease), filter .8s var(--ease); will-change:opacity,transform; }
-  .reveal.in { opacity:1; transform:none; filter:none; }
+  /* Release the compositing layer once revealed: permanent will-change keeps
+     every section on its own GPU layer, and iOS Safari clips composited layers
+     to the layout viewport while the bottom toolbar collapses — content in the
+     under-toolbar band showed the bare canvas instead (the "navy band"). */
+  .reveal.in { opacity:1; transform:none; filter:none; will-change:auto; }
   .rv-blur { filter:blur(14px); transform:translateY(14px); }
   .rv-scale { transform:translateY(30px) scale(0.94); }
   .rv-wipe {
@@ -2157,6 +2161,16 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
 export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DOMProps }) {
   const router = useRouter();
   const [fontsReady, setFontsReady] = useState(false);
+  // Unmount the splash after its fade completes — an invisible position:fixed
+  // inset:0 layer left in the DOM keeps a full-viewport composited layer alive
+  // for the page's whole life (iOS Safari paint/compositing hazard, and dead
+  // weight regardless).
+  const [loaderGone, setLoaderGone] = useState(false);
+  useEffect(() => {
+    if (!fontsReady) return;
+    const t = setTimeout(() => setLoaderGone(true), 450); // fade is 400ms
+    return () => clearTimeout(t);
+  }, [fontsReady]);
   const [mode, setMode] = useState<'3d' | 'static'>(() => (detect3DSupport() ? '3d' : 'static'));
   const [summoned, setSummoned] = useState<Summon | null>(null);
   const [debateMatchup, setDebateMatchup] = useState<TodaysMatchup | null>(null);
@@ -2480,18 +2494,20 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
     >
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
-      <div className={`page-loader${fontsReady ? ' ready' : ''}`} aria-hidden="true">
-        <svg width={100} height={100} viewBox="0 0 1024 1024">
-          <path
-            className="loader-path"
-            pathLength={100}
-            d={LOGO_PATH}
-            stroke="#f5ebdc"
-            strokeWidth={12}
-            fill="#f5ebdc"
-          />
-        </svg>
-      </div>
+      {!loaderGone && (
+        <div className={`page-loader${fontsReady ? ' ready' : ''}`} aria-hidden="true">
+          <svg width={100} height={100} viewBox="0 0 1024 1024">
+            <path
+              className="loader-path"
+              pathLength={100}
+              d={LOGO_PATH}
+              stroke="#f5ebdc"
+              strokeWidth={12}
+              fill="#f5ebdc"
+            />
+          </svg>
+        </div>
+      )}
 
       <nav>
         <div className="nav-brand">

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1788,6 +1788,8 @@ const CSS = `
   .debate-side {
     position:absolute; bottom:0; width:50%; height:58%;
     overflow:hidden;
+    mask-image:linear-gradient(to top, #000 0%, #000 74%, transparent 100%);
+    -webkit-mask-image:linear-gradient(to top, #000 0%, #000 74%, transparent 100%);
   }
   .debate-side.l { left:0; }
   .debate-side.r { right:0; }
@@ -1818,7 +1820,7 @@ const CSS = `
     to { opacity:1; transform:none; }
   }
   .debate-side img {
-    position:absolute; inset:0; width:100%; height:100%;
+    position:absolute; left:0; right:0; top:9%; width:100%; height:100%;
     object-fit:cover; object-position:top;
   }
   /* Face each other: mirror side B (portrait art overwhelmingly faces right). */

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1778,7 +1778,7 @@ const CSS = `
   /* The stage: fighters square off from the bottom corners (side B mirrored so
      they FACE each other), the crossfire of takes filling the air between. */
   .debate-stage {
-    position:relative; margin-top:44px; height:380px;
+    position:relative; margin-top:44px;
     border-radius:20px; overflow:hidden;
     border:1px solid var(--border);
     background:
@@ -1787,14 +1787,15 @@ const CSS = `
       var(--card);
     box-shadow:0 30px 80px rgba(0,0,0,0.5);
   }
+  /* The air above the face-off — where the argument happens. */
+  .debate-air { position:relative; height:236px; }
+  /* The face-off row: two halves sized to the ART's aspect, so the FULL
+     portrait always renders — nothing crops, at any viewport width. */
+  .debate-faceoff { display:flex; }
   .debate-side {
-    position:absolute; bottom:0; width:50%; height:58%;
+    position:relative; width:50%; aspect-ratio:1/1;
     overflow:hidden;
-    mask-image:linear-gradient(to top, #000 0%, #000 74%, transparent 100%);
-    -webkit-mask-image:linear-gradient(to top, #000 0%, #000 74%, transparent 100%);
   }
-  .debate-side.l { left:0; }
-  .debate-side.r { right:0; }
   /* Duotone: grayscale art washed in the camp colour (mix-blend color keeps
      luminance, swaps hue — the montage "ghost gallery" trick), so any source
      art harmonises with the section instead of shouting its own palette. */
@@ -1816,7 +1817,7 @@ const CSS = `
      scroll the stage in — the reader causes the confrontation. Transforms are
      cleared once landed so no composited layer outlives the motion. */
   .debate-side img {
-    position:absolute; left:0; right:0; top:9%; width:100%; height:100%;
+    position:absolute; inset:0; width:100%; height:100%;
     object-fit:cover; object-position:top;
   }
   /* Face each other: mirror side B (portrait art overwhelmingly faces right). */
@@ -1844,24 +1845,20 @@ const CSS = `
      conversation cadence, tails aimed at their camp. */
   .debate-bubble {
     position:absolute; z-index:3; max-width:62%;
-    padding:11px 14px 12px; border-radius:14px; text-align:left;
-    font-size:13.5px; line-height:1.45; color:var(--beige);
-    background:rgba(20,33,48,0.92);
-    -webkit-backdrop-filter:blur(8px); backdrop-filter:blur(8px);
-    border:1px solid var(--border);
-    box-shadow:0 14px 40px rgba(0,0,0,0.45);
+    text-align:left;
+    font-size:15px; line-height:1.5; color:var(--beige);
+    text-shadow:0 2px 16px rgba(0,0,0,0.85);
   }
   .debate-bubble .debate-bubble-author {
     display:block; margin-top:6px;
     font-size:10.5px; font-weight:700; letter-spacing:1.2px; text-transform:uppercase;
   }
-  .debate-bubble.a { border-color:rgba(231,115,51,0.45); border-bottom-left-radius:4px; }
-  .debate-bubble.b { border-color:rgba(21,161,171,0.45); border-bottom-right-radius:4px; }
+  .debate-bubble.b { text-align:right; }
   .debate-bubble.a .debate-bubble-author { color:var(--orange); }
   .debate-bubble.b .debate-bubble-author { color:var(--teal); }
-  .debate-bubble.slot1 { top:22px; left:16px; }
-  .debate-bubble.slot2 { top:104px; right:16px; }
-  .debate-bubble.slot3 { top:196px; left:50%; transform:translateX(-50%); max-width:66%; }
+  .debate-bubble.slot1 { top:26px; left:20px; }
+  .debate-bubble.slot2 { top:104px; right:20px; }
+  .debate-bubble.slot3 { top:182px; left:50%; transform:translateX(-50%); max-width:70%; text-align:center; }
   .debate-teaser.in .debate-bubble.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .55s both; }
   .debate-teaser.in .debate-bubble.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.2s both; }
   .debate-teaser.in .debate-bubble.slot3 { animation:debateBubbleC .5s cubic-bezier(.2,1.4,.4,1) 1.9s both; }
@@ -2013,12 +2010,11 @@ const CSS = `
 
     /* Sections */
     .section,.screenshots,.showcase,.cta-section,.debate-teaser { padding:64px 20px; }
-    .debate-stage { height:340px; }
-    .debate-bubble { font-size:12.5px; max-width:72%; }
-    .debate-bubble.slot2 { top:96px; }
-    .debate-bubble.slot3 { top:184px; max-width:76%; }
-    .debate-side { height:52%; }
-    .debate-faceoff-seam { height:52%; }
+    .debate-air { height:212px; }
+    .debate-bubble { font-size:13.5px; max-width:74%; }
+    .debate-bubble.slot1 { top:16px; }
+    .debate-bubble.slot2 { top:88px; }
+    .debate-bubble.slot3 { top:158px; max-width:80%; }
     .section-heading { font-size:clamp(24px,6vw,34px); margin-bottom:16px; }
     .section-sub { font-size:15px; }
 
@@ -2437,15 +2433,19 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
         <p className="section-sub debate-sub">{line}</p>
 
         <div className="debate-stage" ref={stageRef}>
-          <DebateSide hero={heroA} side="l" />
-          <DebateSide hero={heroB} side="r" />
+          <div className="debate-air">
+            {bubbles.map((bubble, idx) => (
+              <div key={idx} className={`debate-bubble ${bubble.side} slot${idx + 1}`}>
+                {bubble.body}
+                <span className="debate-bubble-author">{bubble.author}</span>
+              </div>
+            ))}
+          </div>
+          <div className="debate-faceoff">
+            <DebateSide hero={heroA} side="l" />
+            <DebateSide hero={heroB} side="r" />
+          </div>
           <div className="debate-faceoff-seam" aria-hidden="true" />
-          {bubbles.map((bubble, idx) => (
-            <div key={idx} className={`debate-bubble ${bubble.side} slot${idx + 1}`}>
-              {bubble.body}
-              <span className="debate-bubble-author">{bubble.author}</span>
-            </div>
-          ))}
         </div>
 
         <div className="debate-split">

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1786,11 +1786,27 @@ const CSS = `
     box-shadow:0 30px 80px rgba(0,0,0,0.5);
   }
   .debate-side {
-    position:absolute; bottom:0; width:44%; height:52%;
+    position:absolute; bottom:0; width:50%; height:58%;
     overflow:hidden;
   }
-  .debate-side.l { left:0; border-top-right-radius:18px; }
-  .debate-side.r { right:0; border-top-left-radius:18px; }
+  .debate-side.l { left:0; }
+  .debate-side.r { right:0; }
+  /* Duotone: grayscale art washed in the camp colour (mix-blend color keeps
+     luminance, swaps hue — the montage "ghost gallery" trick), so any source
+     art harmonises with the section instead of shouting its own palette. */
+  .debate-side img { filter:grayscale(1) contrast(1.06); }
+  .debate-side::before {
+    content:''; position:absolute; inset:0; z-index:1; mix-blend-mode:color;
+  }
+  .debate-side.l::before { background:var(--orange); opacity:0.9; }
+  .debate-side.r::before { background:var(--teal); opacity:0.9; }
+  /* Gold hairline where the camps meet — the debate line. */
+  .debate-faceoff-seam {
+    position:absolute; bottom:0; left:50%; width:1px; height:58%; z-index:2;
+    transform:translateX(-50%);
+    background:linear-gradient(to top, rgba(249,178,34,0.9), rgba(249,178,34,0.15) 85%, transparent);
+    box-shadow:0 0 14px rgba(249,178,34,0.5);
+  }
   .debate-teaser.in .debate-side.l { animation:debateSlideL .8s var(--ease) .2s both; }
   .debate-teaser.in .debate-side.r { animation:debateSlideR .8s var(--ease) .2s both; }
   @keyframes debateSlideL {
@@ -1814,14 +1830,16 @@ const CSS = `
   }
   /* Side-colour rim light from each camp's corner + a floor fade. */
   .debate-side.l::after {
-    content:''; position:absolute; inset:0;
-    background:linear-gradient(115deg, rgba(231,115,51,0.30) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.72) 0%, transparent 45%);
+    content:''; position:absolute; inset:0; z-index:2;
+    background:linear-gradient(115deg, rgba(231,115,51,0.22) 0%, transparent 55%),
+               linear-gradient(to top, rgba(11,24,32,0.78) 0%, transparent 40%),
+               linear-gradient(to bottom, rgba(11,24,32,0.55) 0%, transparent 30%);
   }
   .debate-side.r::after {
-    content:''; position:absolute; inset:0;
-    background:linear-gradient(245deg, rgba(21,161,171,0.30) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.72) 0%, transparent 45%);
+    content:''; position:absolute; inset:0; z-index:2;
+    background:linear-gradient(245deg, rgba(21,161,171,0.22) 0%, transparent 55%),
+               linear-gradient(to top, rgba(11,24,32,0.78) 0%, transparent 40%),
+               linear-gradient(to bottom, rgba(11,24,32,0.55) 0%, transparent 30%);
   }
 
   /* The crossfire: takes as side-tinted chat bubbles, popped in on a real
@@ -1858,32 +1876,59 @@ const CSS = `
     to { opacity:1; transform:translateX(-50%); }
   }
 
-  /* Live crowd split — a tug-of-war that fills from 50/50 to the real tally
-     once revealed; the contested boundary carries a small glow. */
-  .debate-split { margin-top:22px; }
+  /* Live crowd split — a tug-of-war rope that fills from 50/50 to the real
+     tally once revealed, with a glowing KNOT at the contested boundary that
+     strains side to side: the argument, visualised as live tension. */
+  .debate-split { margin-top:24px; }
   .debate-split-bar {
-    display:flex; height:10px; border-radius:6px; overflow:hidden; background:var(--surface);
+    position:relative; display:flex; height:14px; border-radius:999px;
+    overflow:visible; background:var(--surface);
   }
   .debate-split-fill { height:100%; transition:width .9s var(--ease); }
   .debate-split-fill.l {
     background:linear-gradient(90deg,#c85f2a,var(--orange));
-    box-shadow:6px 0 14px rgba(231,115,51,0.55);
+    border-radius:999px 0 0 999px;
   }
-  .debate-split-fill.r { background:linear-gradient(90deg,var(--teal),#0f7f88); }
+  .debate-split-fill.r {
+    background:linear-gradient(90deg,var(--teal),#0f7f88);
+    border-radius:0 999px 999px 0;
+  }
+  .debate-knot {
+    position:absolute; top:50%; z-index:2;
+    transition:left .9s var(--ease);
+    transform:translate(-50%,-50%);
+  }
+  .debate-knot-core {
+    display:block; width:26px; height:26px; border-radius:50%;
+    background:#0e1c26; border:2px solid var(--yellow);
+    box-shadow:0 0 22px rgba(249,178,34,0.55), 0 4px 14px rgba(0,0,0,0.6);
+    animation:debateTension 2.6s ease-in-out infinite;
+  }
+  .debate-knot-core::after {
+    content:''; position:absolute; inset:6px; border-radius:50%;
+    background:radial-gradient(circle at 40% 35%, var(--yellow), #c98f1a);
+  }
+  @keyframes debateTension {
+    0%,100% { transform:translateX(-2.5px); }
+    50% { transform:translateX(2.5px); }
+  }
   .debate-split-labels {
-    display:flex; justify-content:space-between; align-items:baseline; gap:10px; margin-top:9px;
-    font-size:12px; font-weight:600; letter-spacing:0.5px; color:var(--muted);
+    display:flex; justify-content:space-between; align-items:baseline; gap:10px; margin-top:12px;
+    font-size:12px; font-weight:700; letter-spacing:0.8px;
+    font-family:'Righteous',sans-serif; color:var(--muted);
   }
   .debate-split-labels .l { color:var(--orange); }
   .debate-split-labels .r { color:var(--teal); }
-  .debate-split-labels .mid { font-weight:500; letter-spacing:0.3px; }
+  .debate-split-labels .mid {
+    font-family:'Poppins',sans-serif; font-weight:500; letter-spacing:0.3px; font-size:11.5px;
+  }
   .debate-teaser .btn-primary { margin-top:30px; }
   @media (prefers-reduced-motion:reduce) {
     .debate-eyebrow,.debate-heading,.debate-sub,.debate-side,.debate-bubble {
       opacity:1 !important; animation:none !important;
     }
     .debate-bubble.slot3 { transform:translateX(-50%) !important; }
-    .debate-live-dot { animation:none !important; }
+    .debate-live-dot, .debate-knot-core { animation:none !important; }
   }
 
   footer {
@@ -1972,7 +2017,8 @@ const CSS = `
     .debate-bubble { font-size:12.5px; max-width:72%; }
     .debate-bubble.slot2 { top:96px; }
     .debate-bubble.slot3 { top:184px; max-width:76%; }
-    .debate-side { width:46%; height:46%; }
+    .debate-side { height:52%; }
+    .debate-faceoff-seam { height:52%; }
     .section-heading { font-size:clamp(24px,6vw,34px); margin-bottom:16px; }
     .section-sub { font-size:15px; }
 
@@ -2312,6 +2358,7 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
         <div className="debate-stage">
           <DebateSide hero={heroA} side="l" />
           <DebateSide hero={heroB} side="r" />
+          <div className="debate-faceoff-seam" aria-hidden="true" />
           {bubbles.map((bubble, idx) => (
             <div key={idx} className={`debate-bubble ${bubble.side} slot${idx + 1}`}>
               {bubble.body}
@@ -2324,11 +2371,19 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
           <div className="debate-split-bar" aria-hidden="true">
             <div className="debate-split-fill l" style={{ width: `${wA}%` }} />
             <div className="debate-split-fill r" style={{ width: `${100 - wA}%` }} />
+            {/* The knot: the contested boundary, straining side to side. */}
+            <span className="debate-knot" style={{ left: `${wA}%` }}>
+              <span className="debate-knot-core" />
+            </span>
           </div>
           <div className="debate-split-labels">
-            <span className="l">{pctA}%</span>
+            <span className="l">
+              {heroA.name} {pctA}%
+            </span>
             <span className="mid">{voteWord}</span>
-            <span className="r">{pctB}%</span>
+            <span className="r">
+              {pctB}% {heroB.name}
+            </span>
           </div>
         </div>
 

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -2137,6 +2137,8 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
         <button className="btn-primary" onClick={goVote}>
           <svg
             className="btn-icon"
+            width={20}
+            height={20}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -2426,6 +2428,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
     <>
       <div className="hero-badge">
         <svg
+          width={14}
+          height={14}
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -2460,6 +2464,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
         <button className="btn-primary" onClick={() => router.push('/explore')}>
           <svg
             className="btn-icon"
+            width={20}
+            height={20}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -2505,7 +2511,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
 
       <nav>
         <div className="nav-brand">
-          <svg className="nav-logo" viewBox="0 0 1024 1024" aria-hidden="true">
+          <svg className="nav-logo" width={32} height={32} viewBox="0 0 1024 1024" aria-hidden="true">
             <path fill="var(--beige)" d={LOGO_PATH} />
           </svg>
           <span className="nav-wordmark">mythique</span>
@@ -2677,7 +2683,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             <div className="feature-card fc-wide reveal rv-scale">
               <div className="fc-copy">
                 <div className="feature-icon">
-                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                     <circle cx="18" cy="5" r="3" />
                     <circle cx="6" cy="12" r="3" />
                     <circle cx="18" cy="19" r="3" />
@@ -2692,7 +2698,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
                 </p>
               </div>
               <div className="fc-visual fc-web" aria-hidden="true">
-                <svg viewBox="0 0 200 170" preserveAspectRatio="none">
+                <svg width="100%" height="100%" viewBox="0 0 200 170" preserveAspectRatio="none">
                   <line
                     x1="84"
                     y1="65"
@@ -2754,7 +2760,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
               style={{ transitionDelay: '80ms' }}
             >
               <div className="feature-icon">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
+                <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M14.5 17.5 3 6V3h3l11.5 11.5" />
                   <path d="m13 19 6-6" />
                   <path d="m16 16 4 4" />
@@ -2792,7 +2798,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             {/* Explore the Universe */}
             <div className="feature-card reveal rv-scale" style={{ transitionDelay: '60ms' }}>
               <div className="feature-icon">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
+                <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z" />
                   <circle cx="12" cy="12" r="3" />
                 </svg>
@@ -2807,7 +2813,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             {/* Deep Profiles */}
             <div className="feature-card reveal rv-scale" style={{ transitionDelay: '120ms' }}>
               <div className="feature-icon">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
+                <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
                   <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
                 </svg>
@@ -2826,7 +2832,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             >
               <div className="fc-copy">
                 <div className="feature-icon">
-                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                     <polygon points="23 7 16 12 23 17 23 7" />
                     <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
                   </svg>
@@ -2850,7 +2856,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             {/* Instant Search */}
             <div className="feature-card reveal rv-scale" style={{ transitionDelay: '160ms' }}>
               <div className="feature-icon">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
+                <svg width={24} height={24} viewBox="0 0 24 24" aria-hidden="true">
                   <circle cx="11" cy="11" r="8" />
                   <line x1="21" y1="21" x2="16.65" y2="16.65" />
                 </svg>
@@ -2955,6 +2961,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
           >
             <svg
               className="btn-icon"
+              width={20}
+              height={20}
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
@@ -3015,7 +3023,7 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
                 ].map((item, i) => (
                   <li key={i}>
                     <span className="check" aria-hidden="true">
-                      <svg viewBox="0 0 12 12">
+                      <svg width={12} height={12} viewBox="0 0 12 12">
                         <polyline points="2 6 5 9 10 3" />
                       </svg>
                     </span>
@@ -3084,6 +3092,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
           >
             <svg
               className="btn-icon"
+              width={20}
+              height={20}
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
@@ -3101,6 +3111,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             <button className="app-store-badge" disabled aria-label="Coming soon to the App Store">
               <svg
                 className="badge-icon"
+                width={28}
+                height={28}
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 aria-hidden="true"
@@ -3115,6 +3127,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
             <button className="app-store-badge" disabled aria-label="Coming soon to Google Play">
               <svg
                 className="badge-icon"
+                width={28}
+                height={28}
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 aria-hidden="true"

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -2006,9 +2006,12 @@ const CSS = `
     .wm-l { opacity:1 !important; animation:none !important; }
   }
 
-  /* Font-loading splash */
+  /* Font-loading splash. height:100lvh (not inset:0): fixed elements pin to
+     the LAYOUT viewport, which stops at the iOS toolbar — the large-viewport
+     height extends the ink under the glass so the splash is edge-to-edge,
+     matching the boot LogoLoader and the page behind it. */
   .page-loader {
-    position:fixed; inset:0; z-index:9999;
+    position:fixed; top:0; left:0; right:0; height:100lvh; z-index:9999;
     background:#0b1820;
     display:flex; align-items:center; justify-content:center;
     transition:opacity 400ms ease;

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -2009,14 +2009,17 @@ const CSS = `
   /* Font-loading splash. height:100lvh (not inset:0): fixed elements pin to
      the LAYOUT viewport, which stops at the iOS toolbar — the large-viewport
      height extends the ink under the glass so the splash is edge-to-edge,
-     matching the boot LogoLoader and the page behind it. */
+     matching the boot LogoLoader and the page behind it.
+     NO opacity fade: the splash and the page behind it are the same ink, so a
+     cross-fade adds nothing — except a translucency ramp that iOS's toolbar
+     glass re-samples on its own cadence (the bottom band visibly faded
+     off-beat). The splash unmounts instantly and the hero's staggered
+     entrance animations carry the whole transition. */
   .page-loader {
     position:fixed; top:0; left:0; right:0; height:100lvh; z-index:9999;
     background:#0b1820;
     display:flex; align-items:center; justify-content:center;
-    transition:opacity 400ms ease;
   }
-  .page-loader.ready { opacity:0; pointer-events:none; }
   @keyframes loaderDraw {
     0% { stroke-dashoffset:100; }
     60%,100% { stroke-dashoffset:0; }
@@ -2163,16 +2166,6 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
 export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DOMProps }) {
   const router = useRouter();
   const [fontsReady, setFontsReady] = useState(false);
-  // Unmount the splash after its fade completes — an invisible position:fixed
-  // inset:0 layer left in the DOM keeps a full-viewport composited layer alive
-  // for the page's whole life (iOS Safari paint/compositing hazard, and dead
-  // weight regardless).
-  const [loaderGone, setLoaderGone] = useState(false);
-  useEffect(() => {
-    if (!fontsReady) return;
-    const t = setTimeout(() => setLoaderGone(true), 450); // fade is 400ms
-    return () => clearTimeout(t);
-  }, [fontsReady]);
   const [mode, setMode] = useState<'3d' | 'static'>(() => (detect3DSupport() ? '3d' : 'static'));
   const [summoned, setSummoned] = useState<Summon | null>(null);
   const [debateMatchup, setDebateMatchup] = useState<TodaysMatchup | null>(null);
@@ -2528,8 +2521,8 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
     >
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
-      {!loaderGone && (
-        <div className={`page-loader${fontsReady ? ' ready' : ''}`} aria-hidden="true">
+      {!fontsReady && (
+        <div className="page-loader" aria-hidden="true">
           <svg width={100} height={100} viewBox="0 0 1024 1024">
             <path
               className="loader-path"

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1750,7 +1750,7 @@ const CSS = `
   /* Entrance choreography — component-local IO ('.in'): the global reveal
      observer only registers first-paint elements and this mounts after
      today's pair resolves. */
-  .debate-eyebrow, .debate-heading, .debate-sub, .debate-side, .debate-bubble { opacity:0; }
+  .debate-eyebrow, .debate-heading, .debate-sub, .debate-bubble { opacity:0; }
   .debate-teaser.in .debate-eyebrow { animation:debateRise .7s var(--ease) both; }
   .debate-teaser.in .debate-heading { animation:debateRise .7s var(--ease) .08s both; }
   .debate-teaser.in .debate-sub { animation:debateRise .7s var(--ease) .16s both; }
@@ -1759,6 +1759,8 @@ const CSS = `
     to { opacity:1; transform:none; }
   }
   .debate-vs-text { color:var(--muted); font-size:0.6em; vertical-align:middle; }
+  .debate-heading .camp-a { color:#f2b28c; }
+  .debate-heading .camp-b { color:#9fd8dd; }
   .debate-live {
     display:inline-flex; align-items:center; gap:7px; margin-left:12px;
     font-size:11px; letter-spacing:2px; color:#ff6b6b; vertical-align:middle;
@@ -1804,21 +1806,15 @@ const CSS = `
   .debate-side.r::before { background:var(--teal); opacity:0.9; }
   /* Gold hairline where the camps meet — the debate line. */
   .debate-faceoff-seam {
-    position:absolute; bottom:0; left:50%; width:1px; height:58%; z-index:2;
-    transform:translateX(-50%);
-    background:linear-gradient(to top, rgba(249,178,34,0.9), rgba(249,178,34,0.15) 85%, transparent);
+    position:absolute; top:0; bottom:0; left:50%; width:1px; z-index:2;
+    transform:translateX(-50%) scaleY(0); transform-origin:top;
+    background:linear-gradient(to bottom, transparent, rgba(249,178,34,0.35) 30%, rgba(249,178,34,0.9));
     box-shadow:0 0 14px rgba(249,178,34,0.5);
   }
-  .debate-teaser.in .debate-side.l { animation:debateSlideL .8s var(--ease) .2s both; }
-  .debate-teaser.in .debate-side.r { animation:debateSlideR .8s var(--ease) .2s both; }
-  @keyframes debateSlideL {
-    from { opacity:0; transform:translateX(-36px); }
-    to { opacity:1; transform:none; }
-  }
-  @keyframes debateSlideR {
-    from { opacity:0; transform:translateX(36px); }
-    to { opacity:1; transform:none; }
-  }
+  /* Busts + seam are SCROLL-DRIVEN (imperative transforms from the section's
+     viewport progress): the camps converge toward the debate line as you
+     scroll the stage in — the reader causes the confrontation. Transforms are
+     cleared once landed so no composited layer outlives the motion. */
   .debate-side img {
     position:absolute; left:0; right:0; top:9%; width:100%; height:100%;
     object-fit:cover; object-position:top;
@@ -1866,9 +1862,9 @@ const CSS = `
   .debate-bubble.slot1 { top:22px; left:16px; }
   .debate-bubble.slot2 { top:104px; right:16px; }
   .debate-bubble.slot3 { top:196px; left:50%; transform:translateX(-50%); max-width:66%; }
-  .debate-teaser.in .debate-bubble.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .65s both; }
-  .debate-teaser.in .debate-bubble.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.25s both; }
-  .debate-teaser.in .debate-bubble.slot3 { animation:debateBubbleC .5s cubic-bezier(.2,1.4,.4,1) 1.85s both; }
+  .debate-teaser.in .debate-bubble.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .55s both; }
+  .debate-teaser.in .debate-bubble.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.2s both; }
+  .debate-teaser.in .debate-bubble.slot3 { animation:debateBubbleC .5s cubic-bezier(.2,1.4,.4,1) 1.9s both; }
   @keyframes debateBubble {
     from { opacity:0; transform:translateY(14px) scale(0.86); }
     to { opacity:1; transform:none; }
@@ -1926,10 +1922,12 @@ const CSS = `
   }
   .debate-teaser .btn-primary { margin-top:30px; }
   @media (prefers-reduced-motion:reduce) {
-    .debate-eyebrow,.debate-heading,.debate-sub,.debate-side,.debate-bubble {
+    .debate-eyebrow,.debate-heading,.debate-sub,.debate-bubble {
       opacity:1 !important; animation:none !important;
     }
     .debate-bubble.slot3 { transform:translateX(-50%) !important; }
+    .debate-side { transform:none !important; opacity:1 !important; }
+    .debate-faceoff-seam { transform:translateX(-50%) scaleY(1) !important; }
     .debate-live-dot, .debate-knot-core { animation:none !important; }
   }
 
@@ -2252,21 +2250,24 @@ interface DebateBubble {
 }
 
 // Teaser only — no inline voting. This section sells the DEBATE (the "Who'd
-// actually win?" section further down owns the fight): the air between the
-// two camps is a live crossfire of real community takes, popped in on a chat
-// cadence, with the tug-of-war tally underneath. The split bar reads the live
-// crowd tally (useMatchupVote, same hook the Compare screen uses) and falls
-// back to the stat-round split until the tally loads, so it's never a flat
-// 50/50 by default.
+// actually win?" section further down owns the fight) as a scroll-told story:
+// (1) the question — camp-tinted names; (2) the camps form — the busts
+// converge toward the gold debate line, DRIVEN BY SCROLL, so the reader causes
+// the confrontation; (3) the argument erupts — real takes fire in on a chat
+// cadence; (4) the line moves — the knot slides to the live tally while the
+// percentages count up from 50/50.
 function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText: string | null }) {
   const router = useRouter();
   const { heroA, heroB, winsA, winsB, verdict } = matchup;
   const { tally } = useMatchupVote(heroA.id, heroB.id);
   const sectionRef = useRef<HTMLElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
   const [seen, setSeen] = useState(false);
   const [takes, setTakes] = useState<Take[]>([]);
+  // Displayed (counting) percentage — starts balanced, counts to the tally.
+  const [shownPctA, setShownPctA] = useState(50);
 
-  // Choreograph in when scrolled into view (component-local IO — the global
+  // Copy reveal + argument cadence trigger (component-local IO — the global
   // reveal observer only registers first-paint elements, and this section
   // mounts after today's pair resolves).
   useEffect(() => {
@@ -2289,6 +2290,59 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
     return () => io.disconnect();
   }, []);
 
+  // Beat 2 — the camps form. Scroll-coupled: progress of the stage through the
+  // lower half of the viewport drives the busts' convergence and the debate
+  // line drawing itself down. Transforms are cleared once landed so no
+  // composited layer outlives the motion (the iOS toolbar-band lesson).
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage || typeof window === 'undefined') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const sideL = stage.querySelector<HTMLElement>('.debate-side.l');
+    const sideR = stage.querySelector<HTMLElement>('.debate-side.r');
+    const seam = stage.querySelector<HTMLElement>('.debate-faceoff-seam');
+    if (!sideL || !sideR || !seam) return;
+    let raf = 0;
+    let done = false;
+    const place = () => {
+      raf = 0;
+      if (done) return;
+      const r = stage.getBoundingClientRect();
+      const vh = window.innerHeight;
+      // 0 when the stage top crosses the viewport bottom → 1 when it reaches ~52% up.
+      const pRaw = (vh - r.top) / (vh * 0.48);
+      const p = Math.min(1, Math.max(0, pRaw));
+      const e = 1 - (1 - p) ** 3; // easeOutCubic
+      if (p >= 1) {
+        // Landed: release the transforms entirely.
+        sideL.style.transform = '';
+        sideR.style.transform = '';
+        sideL.style.opacity = '';
+        sideR.style.opacity = '';
+        seam.style.transform = 'translateX(-50%) scaleY(1)';
+        done = true;
+        window.removeEventListener('scroll', onScroll, true);
+        return;
+      }
+      const shift = (1 - e) * 34; // % of own width still away from the line
+      sideL.style.transform = `translateX(${-shift}%)`;
+      sideR.style.transform = `translateX(${shift}%)`;
+      const fade = String(Math.min(1, 0.25 + e));
+      sideL.style.opacity = fade;
+      sideR.style.opacity = fade;
+      seam.style.transform = `translateX(-50%) scaleY(${e})`;
+    };
+    const onScroll = () => {
+      if (!raf) raf = window.requestAnimationFrame(place);
+    };
+    place();
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      if (raf) window.cancelAnimationFrame(raf);
+    };
+  }, []);
+
   // Today's real hot takes power the crossfire bubbles.
   useEffect(() => {
     let active = true;
@@ -2301,6 +2355,34 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
       active = false;
     };
   }, [heroA.id, heroB.id]);
+
+  const haveTally = !!tally && tally.total > 0;
+  const total = haveTally ? tally.total : winsA + winsB;
+  const votesA = haveTally ? tally.votesA : winsA;
+  const pctA = total > 0 ? Math.round((votesA / total) * 100) : 50;
+
+  // Beat 4 — the line moves: percentages count from 50/50 to the tally in step
+  // with the knot's slide once the section has revealed.
+  useEffect(() => {
+    if (!seen) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setShownPctA(pctA);
+      return;
+    }
+    const from = 50;
+    const startT = performance.now();
+    const DUR = 900; // matches the knot/fill transition
+    let raf = 0;
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startT) / DUR);
+      const e = 1 - (1 - t) ** 3;
+      setShownPctA(Math.round(from + (pctA - from) * e));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seen, pctA]);
 
   // Top takes by agreement, one slot each; editorial camp slogans keep the
   // crossfire alive on days the takes haven't landed yet.
@@ -2323,11 +2405,6 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
     }
   }
 
-  const haveTally = !!tally && tally.total > 0;
-  const total = haveTally ? tally.total : winsA + winsB;
-  const votesA = haveTally ? tally.votesA : winsA;
-  const pctA = total > 0 ? Math.round((votesA / total) * 100) : 50;
-  const pctB = 100 - pctA;
   // Bar geometry: hold 50/50 until revealed (the CSS width transition then
   // animates to the real split), and never let a side collapse to nothing —
   // a 0/100 tally renders 7/93 visually while the labels stay honest.
@@ -2353,11 +2430,13 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
           </span>
         </p>
         <h2 className="section-heading debate-heading">
-          {heroA.name} <span className="debate-vs-text">vs</span> {heroB.name}
+          <span className="camp-a">{heroA.name}</span>{' '}
+          <span className="debate-vs-text">vs</span>{' '}
+          <span className="camp-b">{heroB.name}</span>
         </h2>
         <p className="section-sub debate-sub">{line}</p>
 
-        <div className="debate-stage">
+        <div className="debate-stage" ref={stageRef}>
           <DebateSide hero={heroA} side="l" />
           <DebateSide hero={heroB} side="r" />
           <div className="debate-faceoff-seam" aria-hidden="true" />
@@ -2380,11 +2459,11 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
           </div>
           <div className="debate-split-labels">
             <span className="l">
-              {heroA.name} {pctA}%
+              {heroA.name} {shownPctA}%
             </span>
             <span className="mid">{voteWord}</span>
             <span className="r">
-              {pctB}% {heroB.name}
+              {100 - shownPctA}% {heroB.name}
             </span>
           </div>
         </div>

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1191,6 +1191,11 @@ const CSS = `
     position:absolute; inset:0; width:100%; height:100%;
     opacity:0; transition:opacity 1.1s ease; z-index:1;
     touch-action:pan-y; /* orbit-free: taps summon, scroll stays native */
+    /* Dissolve the particle field into the ink before the hero's bottom edge —
+       without this the starfield ends in a hard clipped line against the next
+       section. */
+    mask-image:linear-gradient(to bottom, #000 0%, #000 72%, transparent 98%);
+    -webkit-mask-image:linear-gradient(to bottom, #000 0%, #000 72%, transparent 98%);
   }
   .summon-canvas.ready { opacity:1; }
   .hero-accent {
@@ -1733,54 +1738,117 @@ const CSS = `
      once the server-curated (or seeded-fallback) pair has resolved, so it
      fades in on mount rather than riding the scroll-reveal IO (that observer
      only queries .reveal elements present at first paint). */
+  /* --- Today's debate — the live arena teaser --- */
   .debate-teaser { padding:72px 40px 96px; background:var(--bg); position:relative; }
-  .debate-inner {
-    max-width:640px; margin:0 auto; text-align:center;
-    animation:debateIn .7s var(--ease) both;
-  }
-  @keyframes debateIn {
-    from { opacity:0; transform:translateY(18px); }
+  .debate-inner { max-width:680px; margin:0 auto; text-align:center; }
+  .debate-inner .section-sub { margin:0 auto; }
+  /* Entrance choreography. Driven by a component-local IntersectionObserver
+     ('.in' on the section) — the global reveal observer only registers
+     elements present at first paint, and this section mounts after today's
+     pair resolves. */
+  .debate-eyebrow, .debate-heading, .debate-sub, .debate-side, .debate-seam, .debate-coin { opacity:0; }
+  .debate-teaser.in .debate-eyebrow { animation:debateRise .7s var(--ease) both; }
+  .debate-teaser.in .debate-heading { animation:debateRise .7s var(--ease) .08s both; }
+  .debate-teaser.in .debate-sub { animation:debateRise .7s var(--ease) .16s both; }
+  @keyframes debateRise {
+    from { opacity:0; transform:translateY(16px); }
     to { opacity:1; transform:none; }
   }
-  .debate-inner .section-sub { margin:0 auto; }
-  .debate-card {
-    margin-top:40px; background:var(--card); border:1px solid var(--border);
-    border-radius:var(--radius); padding:32px 28px 28px;
-    box-shadow:0 24px 70px rgba(0,0,0,0.4);
-  }
-  .debate-portraits {
-    display:flex; align-items:center; justify-content:center; gap:20px;
-  }
-  .debate-portrait {
-    width:96px; height:96px; border-radius:50%; overflow:hidden; flex-shrink:0;
-    background:var(--surface); border:2px solid var(--border);
-  }
-  .debate-portrait.l { border-color:rgba(231,115,51,0.55); }
-  .debate-portrait.r { border-color:rgba(21,161,171,0.55); }
-  .debate-portrait img { width:100%; height:100%; object-fit:cover; object-position:top; display:block; }
-  .debate-portrait-fallback {
-    width:100%; height:100%; display:flex; align-items:center; justify-content:center;
-    font-family:'Righteous',sans-serif; font-size:32px; color:var(--muted);
-  }
-  .debate-vs {
-    font-family:'Righteous',sans-serif; font-size:14px; color:var(--muted);
-    letter-spacing:1px; flex-shrink:0;
-  }
   .debate-vs-text { color:var(--muted); font-size:0.6em; vertical-align:middle; }
-  .debate-split { margin-top:26px; }
+
+  /* The stage: two fighters filling their halves, each lit in their side's
+     colour, split by a skewed gold seam with the VS coin on it — the arena's
+     clash-card language, not a widget. */
+  .debate-stage {
+    position:relative; margin-top:44px; height:250px;
+    border-radius:20px; overflow:hidden;
+    border:1px solid var(--border); background:var(--card);
+    box-shadow:0 30px 80px rgba(0,0,0,0.5);
+    display:flex;
+  }
+  .debate-side { position:relative; flex:1; overflow:hidden; }
+  .debate-teaser.in .debate-side.l { animation:debateSlideL .8s var(--ease) .2s both; }
+  .debate-teaser.in .debate-side.r { animation:debateSlideR .8s var(--ease) .2s both; }
+  @keyframes debateSlideL {
+    from { opacity:0; transform:translateX(-36px); }
+    to { opacity:1; transform:none; }
+  }
+  @keyframes debateSlideR {
+    from { opacity:0; transform:translateX(36px); }
+    to { opacity:1; transform:none; }
+  }
+  .debate-side img {
+    position:absolute; inset:0; width:100%; height:100%;
+    object-fit:cover; object-position:top;
+  }
+  .debate-side-fallback {
+    position:absolute; inset:0; display:flex; align-items:center; justify-content:center;
+    font-family:'Righteous',sans-serif; font-size:64px; color:var(--muted);
+    background:var(--surface);
+  }
+  /* Side-colour washes + a floor fade that keeps the names legible. */
+  .debate-side.l::after {
+    content:''; position:absolute; inset:0;
+    background:linear-gradient(115deg, rgba(231,115,51,0.30) 0%, transparent 55%),
+               linear-gradient(to top, rgba(11,24,32,0.88) 0%, transparent 58%);
+  }
+  .debate-side.r::after {
+    content:''; position:absolute; inset:0;
+    background:linear-gradient(245deg, rgba(21,161,171,0.30) 0%, transparent 55%),
+               linear-gradient(to top, rgba(11,24,32,0.88) 0%, transparent 58%);
+  }
+  .debate-name {
+    position:absolute; bottom:14px; z-index:2;
+    font-family:'Righteous',sans-serif; font-size:17px; color:var(--beige);
+    letter-spacing:0.3px; text-shadow:0 2px 12px rgba(0,0,0,0.8);
+  }
+  .debate-side.l .debate-name { left:16px; }
+  .debate-side.r .debate-name { right:16px; }
+  .debate-seam {
+    position:absolute; top:-10%; bottom:-10%; left:50%; width:3px; z-index:2;
+    transform:translateX(-50%) rotate(9deg); transform-origin:center;
+    background:linear-gradient(to bottom, transparent, var(--yellow) 30%, var(--orange) 70%, transparent);
+    box-shadow:0 0 18px rgba(249,178,34,0.45);
+  }
+  .debate-teaser.in .debate-seam { animation:debateSeam .6s var(--ease) .5s both; }
+  @keyframes debateSeam {
+    from { opacity:0; transform:translateX(-50%) rotate(9deg) scaleY(0.3); }
+    to { opacity:1; transform:translateX(-50%) rotate(9deg) scaleY(1); }
+  }
+  .debate-coin {
+    position:absolute; top:50%; left:50%; z-index:3;
+    width:54px; height:54px; border-radius:50%;
+    display:flex; align-items:center; justify-content:center;
+    background:#0e1c26; border:2px solid var(--yellow);
+    font-family:'Righteous',sans-serif; font-size:16px; color:var(--yellow); letter-spacing:1px;
+    box-shadow:0 0 34px rgba(249,178,34,0.35), 0 10px 30px rgba(0,0,0,0.6);
+  }
+  .debate-teaser.in .debate-coin { animation:debateCoin .55s cubic-bezier(.2,1.6,.4,1) .62s both; }
+  @keyframes debateCoin {
+    from { opacity:0; transform:translate(-50%,-50%) scale(0.3) rotate(-14deg); }
+    to { opacity:1; transform:translate(-50%,-50%) scale(1) rotate(0deg); }
+  }
+
+  /* Live crowd split — fills from 50/50 to the real tally once revealed. */
+  .debate-split { margin-top:22px; }
   .debate-split-bar {
     display:flex; height:10px; border-radius:6px; overflow:hidden; background:var(--surface);
   }
-  .debate-split-fill { height:100%; transition:width .8s var(--ease); }
+  .debate-split-fill { height:100%; transition:width .9s var(--ease); }
   .debate-split-fill.l { background:linear-gradient(90deg,#c85f2a,var(--orange)); }
   .debate-split-fill.r { background:linear-gradient(90deg,var(--teal),#0f7f88); }
   .debate-split-labels {
-    display:flex; justify-content:space-between; margin-top:8px;
+    display:flex; justify-content:space-between; margin-top:9px;
     font-size:12px; font-weight:600; letter-spacing:0.5px; color:var(--muted);
   }
   .debate-split-labels .l { color:var(--orange); }
   .debate-split-labels .r { color:var(--teal); }
   .debate-teaser .btn-primary { margin-top:32px; }
+  @media (prefers-reduced-motion:reduce) {
+    .debate-eyebrow,.debate-heading,.debate-sub,.debate-side,.debate-seam,.debate-coin {
+      opacity:1 !important; animation:none !important;
+    }
+  }
 
   footer {
     /* Bottom clearance = the iOS toolbar/home-indicator zone, so the page closes
@@ -1864,13 +1932,14 @@ const CSS = `
 
     /* Sections */
     .section,.screenshots,.showcase,.cta-section,.debate-teaser { padding:64px 20px; }
+    .debate-stage { height:200px; }
+    .debate-name { font-size:14px; }
+    .debate-coin { width:46px; height:46px; font-size:14px; }
     .section-heading { font-size:clamp(24px,6vw,34px); margin-bottom:16px; }
     .section-sub { font-size:15px; }
 
     /* Daily debate teaser — smaller portraits, tighter card */
     .debate-card { padding:24px 18px 20px; }
-    .debate-portrait { width:76px; height:76px; }
-    .debate-portraits { gap:14px; }
 
     /* Features — grid layout: icon left, title+desc right */
     .features-grid { grid-template-columns:1fr; gap:10px; margin-top:36px; }
@@ -2075,17 +2144,18 @@ function firstSentence(text: string): string | null {
   return match ? match[0].trim() : trimmed;
 }
 
-function DebatePortrait({ hero, side }: { hero: MatchupHero; side: 'l' | 'r' }) {
+function DebateSide({ hero, side }: { hero: MatchupHero; side: 'l' | 'r' }) {
   const src = hero.portrait_url ?? hero.image_url ?? null;
   return (
-    <div className={`debate-portrait ${side}`}>
+    <div className={`debate-side ${side}`}>
       {src ? (
         <img src={src} alt={hero.name} loading="lazy" />
       ) : (
-        <span className="debate-portrait-fallback" aria-hidden="true">
+        <span className="debate-side-fallback" aria-hidden="true">
           {hero.name.charAt(0)}
         </span>
       )}
+      <span className="debate-name">{hero.name}</span>
     </div>
   );
 }
@@ -2093,17 +2163,48 @@ function DebatePortrait({ hero, side }: { hero: MatchupHero; side: 'l' | 'r' }) 
 // Teaser only — no inline voting. The split bar reads the live crowd tally
 // (useMatchupVote, same hook the Compare screen uses) and falls back to the
 // stat-round split until the tally loads or if it's empty, so the bar is
-// never a flat 50/50 by default.
+// never a flat 50/50 by default. The whole section choreographs in when it
+// scrolls into view (component-local IO — the global reveal observer only
+// registers first-paint elements, and this mounts after today's pair
+// resolves): copy rises, fighters slide in from their corners, the gold seam
+// strikes, the VS coin pops, and the split bar fills from 50/50 to the tally.
 function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText: string | null }) {
   const router = useRouter();
   const { heroA, heroB, winsA, winsB, verdict } = matchup;
   const { tally } = useMatchupVote(heroA.id, heroB.id);
+  const sectionRef = useRef<HTMLElement>(null);
+  const [seen, setSeen] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    if (!('IntersectionObserver' in window)) {
+      setSeen(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setSeen(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.3 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
 
   const haveTally = !!tally && tally.total > 0;
   const total = haveTally ? tally.total : winsA + winsB;
   const votesA = haveTally ? tally.votesA : winsA;
   const pctA = total > 0 ? Math.round((votesA / total) * 100) : 50;
   const pctB = 100 - pctA;
+  // Bar geometry: hold 50/50 until revealed (the CSS width transition then
+  // animates to the real split), and never let a side collapse to nothing —
+  // a 0/100 tally renders 7/93 visually while the labels stay honest.
+  const clampW = (n: number) => Math.min(93, Math.max(7, n));
+  const wA = seen ? clampW(pctA) : 50;
   const line =
     hookText ?? firstSentence(verdict) ?? `${heroA.name} or ${heroB.name} — who actually wins?`;
 
@@ -2111,32 +2212,31 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
     router.push(`/compare/${heroA.id}/${heroB.id}` as Parameters<typeof router.push>[0]);
 
   return (
-    <section className="debate-teaser">
+    <section className={`debate-teaser${seen ? ' in' : ''}`} ref={sectionRef}>
       <div className="debate-inner">
-        <p className="section-eyebrow">Today&apos;s debate</p>
-        <h2 className="section-heading">
+        <p className="section-eyebrow debate-eyebrow">Today&apos;s debate</p>
+        <h2 className="section-heading debate-heading">
           {heroA.name} <span className="debate-vs-text">vs</span> {heroB.name}
         </h2>
-        <p className="section-sub">{line}</p>
+        <p className="section-sub debate-sub">{line}</p>
 
-        <div className="debate-card">
-          <div className="debate-portraits">
-            <DebatePortrait hero={heroA} side="l" />
-            <span className="debate-vs" aria-hidden="true">
-              VS
-            </span>
-            <DebatePortrait hero={heroB} side="r" />
+        <div className="debate-stage">
+          <DebateSide hero={heroA} side="l" />
+          <DebateSide hero={heroB} side="r" />
+          <div className="debate-seam" aria-hidden="true" />
+          <span className="debate-coin" aria-hidden="true">
+            VS
+          </span>
+        </div>
+
+        <div className="debate-split" aria-hidden="true">
+          <div className="debate-split-bar">
+            <div className="debate-split-fill l" style={{ width: `${wA}%` }} />
+            <div className="debate-split-fill r" style={{ width: `${100 - wA}%` }} />
           </div>
-
-          <div className="debate-split" aria-hidden="true">
-            <div className="debate-split-bar">
-              <div className="debate-split-fill l" style={{ width: `${pctA}%` }} />
-              <div className="debate-split-fill r" style={{ width: `${pctB}%` }} />
-            </div>
-            <div className="debate-split-labels">
-              <span className="l">{pctA}%</span>
-              <span className="r">{pctB}%</span>
-            </div>
+          <div className="debate-split-labels">
+            <span className="l">{pctA}%</span>
+            <span className="r">{pctB}%</span>
           </div>
         </div>
 

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1739,18 +1739,15 @@ const CSS = `
      once the server-curated (or seeded-fallback) pair has resolved, so it
      fades in on mount rather than riding the scroll-reveal IO (that observer
      only queries .reveal elements present at first paint). */
-  /* --- Today's debate — the live crossfire ---
-     The section's job is DEBATE, not the fight (the "Who'd actually win?"
-     section further down owns that): the space between the two camps is a
-     live comment war — real takes popping in as side-tinted speech bubbles
-     over the fighters squaring off below. */
+  /* --- Today's debate — the live thread ---
+     The debate rendered as what it IS: a conversation. Real takes as
+     avatar-attached chat bubbles between the two camps, in normal flow
+     directly on the page ink (no stage card behind them — seamless), popping
+     in on a chat cadence, with the tug-of-war tally underneath. */
   .debate-teaser { padding:72px 40px 96px; background:var(--bg); position:relative; }
-  .debate-inner { max-width:680px; margin:0 auto; text-align:center; }
+  .debate-inner { max-width:640px; margin:0 auto; text-align:center; }
   .debate-inner .section-sub { margin:0 auto; }
-  /* Entrance choreography — component-local IO ('.in'): the global reveal
-     observer only registers first-paint elements and this mounts after
-     today's pair resolves. */
-  .debate-eyebrow, .debate-heading, .debate-sub, .debate-bubble { opacity:0; }
+  .debate-eyebrow, .debate-heading, .debate-sub { opacity:0; }
   .debate-teaser.in .debate-eyebrow { animation:debateRise .7s var(--ease) both; }
   .debate-teaser.in .debate-heading { animation:debateRise .7s var(--ease) .08s both; }
   .debate-teaser.in .debate-sub { animation:debateRise .7s var(--ease) .16s both; }
@@ -1775,106 +1772,51 @@ const CSS = `
     50% { opacity:0.45; transform:scale(0.75); }
   }
 
-  /* The stage: fighters square off from the bottom corners (side B mirrored so
-     they FACE each other), the crossfire of takes filling the air between. */
-  .debate-stage {
-    position:relative; margin-top:44px;
-    border-radius:20px; overflow:hidden;
-    border:1px solid var(--border);
-    background:
-      radial-gradient(90% 70% at 12% 100%, rgba(231,115,51,0.13) 0%, transparent 60%),
-      radial-gradient(90% 70% at 88% 100%, rgba(21,161,171,0.13) 0%, transparent 60%),
-      var(--card);
-    box-shadow:0 30px 80px rgba(0,0,0,0.5);
+  .debate-thread { margin-top:44px; display:flex; flex-direction:column; gap:20px; }
+  .debate-row { display:flex; align-items:flex-end; gap:12px; opacity:0; }
+  .debate-row.b { flex-direction:row-reverse; }
+  .debate-teaser.in .debate-row.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .5s both; }
+  .debate-teaser.in .debate-row.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.15s both; }
+  .debate-teaser.in .debate-row.slot3 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.8s both; }
+  @keyframes debateBubble {
+    from { opacity:0; transform:translateY(14px) scale(0.9); }
+    to { opacity:1; transform:none; }
   }
-  /* The air above the face-off — where the argument happens. */
-  .debate-air { position:relative; height:236px; }
-  /* The face-off row: two halves sized to the ART's aspect, so the FULL
-     portrait always renders — nothing crops, at any viewport width. */
-  .debate-faceoff { display:flex; }
-  .debate-side {
-    position:relative; width:50%; aspect-ratio:1/1;
-    overflow:hidden;
+  /* Camp avatars — the portraits live here, as chat identities. A circular
+     face crop is their natural shape: nothing reads as cut off. */
+  .debate-avatar {
+    position:relative; width:54px; height:54px; border-radius:50%; overflow:hidden;
+    flex-shrink:0; border:2px solid var(--border); background:var(--surface);
   }
-  /* Duotone: grayscale art washed in the camp colour (mix-blend color keeps
-     luminance, swaps hue — the montage "ghost gallery" trick), so any source
-     art harmonises with the section instead of shouting its own palette. */
-  .debate-side img { filter:grayscale(1) contrast(1.06); }
-  .debate-side::before {
-    content:''; position:absolute; inset:0; z-index:1; mix-blend-mode:color;
-  }
-  .debate-side.l::before { background:var(--orange); opacity:0.9; }
-  .debate-side.r::before { background:var(--teal); opacity:0.9; }
-  /* Gold hairline where the camps meet — the debate line. */
-  .debate-faceoff-seam {
-    position:absolute; top:0; bottom:0; left:50%; width:1px; z-index:2;
-    transform:translateX(-50%) scaleY(0); transform-origin:top;
-    background:linear-gradient(to bottom, transparent, rgba(249,178,34,0.35) 30%, rgba(249,178,34,0.9));
-    box-shadow:0 0 14px rgba(249,178,34,0.5);
-  }
-  /* Busts + seam are SCROLL-DRIVEN (imperative transforms from the section's
-     viewport progress): the camps converge toward the debate line as you
-     scroll the stage in — the reader causes the confrontation. Transforms are
-     cleared once landed so no composited layer outlives the motion. */
-  .debate-side img {
-    position:absolute; inset:0; width:100%; height:100%;
-    object-fit:cover; object-position:top;
-  }
-  /* Face each other: mirror side B (portrait art overwhelmingly faces right). */
-  .debate-side.r img { transform:scaleX(-1); }
-  .debate-side-fallback {
+  .debate-row.a .debate-avatar { border-color:rgba(231,115,51,0.75); box-shadow:0 0 20px rgba(231,115,51,0.25); }
+  .debate-row.b .debate-avatar { border-color:rgba(21,161,171,0.75); box-shadow:0 0 20px rgba(21,161,171,0.25); }
+  .debate-avatar img { width:100%; height:100%; object-fit:cover; object-position:top; display:block; }
+  .debate-avatar-fallback {
     position:absolute; inset:0; display:flex; align-items:center; justify-content:center;
-    font-family:'Righteous',sans-serif; font-size:56px; color:var(--muted);
-    background:var(--surface);
+    font-family:'Righteous',sans-serif; font-size:22px; color:var(--muted);
   }
-  /* Side-colour rim light from each camp's corner + a floor fade. */
-  .debate-side.l::after {
-    content:''; position:absolute; inset:0; z-index:2;
-    background:linear-gradient(115deg, rgba(231,115,51,0.22) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.78) 0%, transparent 40%),
-               linear-gradient(to bottom, rgba(11,24,32,0.55) 0%, transparent 30%);
+  .debate-msg {
+    max-width:min(78%, 440px); padding:12px 16px 11px; text-align:left;
+    font-size:14.5px; line-height:1.5; color:var(--beige);
+    background:var(--card); border:1px solid rgba(231,115,51,0.4);
+    border-radius:16px 16px 16px 4px;
+    box-shadow:0 14px 40px rgba(0,0,0,0.35);
   }
-  .debate-side.r::after {
-    content:''; position:absolute; inset:0; z-index:2;
-    background:linear-gradient(245deg, rgba(21,161,171,0.22) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.78) 0%, transparent 40%),
-               linear-gradient(to bottom, rgba(11,24,32,0.55) 0%, transparent 30%);
+  .debate-row.b .debate-msg {
+    border-color:rgba(21,161,171,0.4);
+    border-radius:16px 16px 4px 16px; text-align:right;
   }
-
-  /* The crossfire: takes as side-tinted chat bubbles, popped in on a real
-     conversation cadence, tails aimed at their camp. */
-  .debate-bubble {
-    position:absolute; z-index:3; max-width:62%;
-    text-align:left;
-    font-size:15px; line-height:1.5; color:var(--beige);
-    text-shadow:0 2px 16px rgba(0,0,0,0.85);
-  }
-  .debate-bubble .debate-bubble-author {
+  .debate-msg-author {
     display:block; margin-top:6px;
     font-size:10.5px; font-weight:700; letter-spacing:1.2px; text-transform:uppercase;
   }
-  .debate-bubble.b { text-align:right; }
-  .debate-bubble.a .debate-bubble-author { color:var(--orange); }
-  .debate-bubble.b .debate-bubble-author { color:var(--teal); }
-  .debate-bubble.slot1 { top:26px; left:20px; }
-  .debate-bubble.slot2 { top:104px; right:20px; }
-  .debate-bubble.slot3 { top:182px; left:50%; transform:translateX(-50%); max-width:70%; text-align:center; }
-  .debate-teaser.in .debate-bubble.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .55s both; }
-  .debate-teaser.in .debate-bubble.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.2s both; }
-  .debate-teaser.in .debate-bubble.slot3 { animation:debateBubbleC .5s cubic-bezier(.2,1.4,.4,1) 1.9s both; }
-  @keyframes debateBubble {
-    from { opacity:0; transform:translateY(14px) scale(0.86); }
-    to { opacity:1; transform:none; }
-  }
-  @keyframes debateBubbleC {
-    from { opacity:0; transform:translateX(-50%) translateY(14px) scale(0.86); }
-    to { opacity:1; transform:translateX(-50%); }
-  }
+  .debate-row.a .debate-msg-author { color:var(--orange); }
+  .debate-row.b .debate-msg-author { color:var(--teal); }
 
   /* Live crowd split — a tug-of-war rope that fills from 50/50 to the real
      tally once revealed, with a glowing KNOT at the contested boundary that
      strains side to side: the argument, visualised as live tension. */
-  .debate-split { margin-top:24px; }
+  .debate-split { margin-top:30px; }
   .debate-split-bar {
     position:relative; display:flex; height:14px; border-radius:999px;
     overflow:visible; background:var(--surface);
@@ -1919,12 +1861,9 @@ const CSS = `
   }
   .debate-teaser .btn-primary { margin-top:30px; }
   @media (prefers-reduced-motion:reduce) {
-    .debate-eyebrow,.debate-heading,.debate-sub,.debate-bubble {
+    .debate-eyebrow,.debate-heading,.debate-sub,.debate-row {
       opacity:1 !important; animation:none !important;
     }
-    .debate-bubble.slot3 { transform:translateX(-50%) !important; }
-    .debate-side { transform:none !important; opacity:1 !important; }
-    .debate-faceoff-seam { transform:translateX(-50%) scaleY(1) !important; }
     .debate-live-dot, .debate-knot-core { animation:none !important; }
   }
 
@@ -2010,11 +1949,8 @@ const CSS = `
 
     /* Sections */
     .section,.screenshots,.showcase,.cta-section,.debate-teaser { padding:64px 20px; }
-    .debate-air { height:212px; }
-    .debate-bubble { font-size:13.5px; max-width:74%; }
-    .debate-bubble.slot1 { top:16px; }
-    .debate-bubble.slot2 { top:88px; }
-    .debate-bubble.slot3 { top:158px; max-width:80%; }
+    .debate-msg { font-size:13.5px; max-width:82%; }
+    .debate-avatar { width:46px; height:46px; }
     .section-heading { font-size:clamp(24px,6vw,34px); margin-bottom:16px; }
     .section-sub { font-size:15px; }
 
@@ -2224,14 +2160,14 @@ function firstSentence(text: string): string | null {
   return match ? match[0].trim() : trimmed;
 }
 
-function DebateSide({ hero, side }: { hero: MatchupHero; side: 'l' | 'r' }) {
+function DebateAvatar({ hero }: { hero: MatchupHero }) {
   const src = hero.portrait_url ?? hero.image_url ?? null;
   return (
-    <div className={`debate-side ${side}`}>
+    <div className="debate-avatar">
       {src ? (
         <img src={src} alt={hero.name} loading="lazy" />
       ) : (
-        <span className="debate-side-fallback" aria-hidden="true">
+        <span className="debate-avatar-fallback" aria-hidden="true">
           {hero.name.charAt(0)}
         </span>
       )}
@@ -2246,26 +2182,24 @@ interface DebateBubble {
 }
 
 // Teaser only — no inline voting. This section sells the DEBATE (the "Who'd
-// actually win?" section further down owns the fight) as a scroll-told story:
-// (1) the question — camp-tinted names; (2) the camps form — the busts
-// converge toward the gold debate line, DRIVEN BY SCROLL, so the reader causes
-// the confrontation; (3) the argument erupts — real takes fire in on a chat
-// cadence; (4) the line moves — the knot slides to the live tally while the
-// percentages count up from 50/50.
+// actually win?" section further down owns the fight) as what it is: a live
+// conversation. Real takes render as avatar-attached chat rows between the
+// two camps, in normal document flow directly on the page ink, popping in on
+// a chat cadence; the tug-of-war tally (with its straining knot) sits under
+// the thread, and the percentages count up from 50/50 on reveal.
 function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText: string | null }) {
   const router = useRouter();
   const { heroA, heroB, winsA, winsB, verdict } = matchup;
   const { tally } = useMatchupVote(heroA.id, heroB.id);
   const sectionRef = useRef<HTMLElement>(null);
-  const stageRef = useRef<HTMLDivElement>(null);
   const [seen, setSeen] = useState(false);
   const [takes, setTakes] = useState<Take[]>([]);
   // Displayed (counting) percentage — starts balanced, counts to the tally.
   const [shownPctA, setShownPctA] = useState(50);
 
-  // Copy reveal + argument cadence trigger (component-local IO — the global
-  // reveal observer only registers first-paint elements, and this section
-  // mounts after today's pair resolves).
+  // Reveal choreography trigger (component-local IO — the global reveal
+  // observer only registers first-paint elements, and this section mounts
+  // after today's pair resolves).
   useEffect(() => {
     const el = sectionRef.current;
     if (!el) return;
@@ -2280,66 +2214,13 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
           io.disconnect();
         }
       },
-      { threshold: 0.3 },
+      { threshold: 0.25 },
     );
     io.observe(el);
     return () => io.disconnect();
   }, []);
 
-  // Beat 2 — the camps form. Scroll-coupled: progress of the stage through the
-  // lower half of the viewport drives the busts' convergence and the debate
-  // line drawing itself down. Transforms are cleared once landed so no
-  // composited layer outlives the motion (the iOS toolbar-band lesson).
-  useEffect(() => {
-    const stage = stageRef.current;
-    if (!stage || typeof window === 'undefined') return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    const sideL = stage.querySelector<HTMLElement>('.debate-side.l');
-    const sideR = stage.querySelector<HTMLElement>('.debate-side.r');
-    const seam = stage.querySelector<HTMLElement>('.debate-faceoff-seam');
-    if (!sideL || !sideR || !seam) return;
-    let raf = 0;
-    let done = false;
-    const place = () => {
-      raf = 0;
-      if (done) return;
-      const r = stage.getBoundingClientRect();
-      const vh = window.innerHeight;
-      // 0 when the stage top crosses the viewport bottom → 1 when it reaches ~52% up.
-      const pRaw = (vh - r.top) / (vh * 0.48);
-      const p = Math.min(1, Math.max(0, pRaw));
-      const e = 1 - (1 - p) ** 3; // easeOutCubic
-      if (p >= 1) {
-        // Landed: release the transforms entirely.
-        sideL.style.transform = '';
-        sideR.style.transform = '';
-        sideL.style.opacity = '';
-        sideR.style.opacity = '';
-        seam.style.transform = 'translateX(-50%) scaleY(1)';
-        done = true;
-        window.removeEventListener('scroll', onScroll, true);
-        return;
-      }
-      const shift = (1 - e) * 34; // % of own width still away from the line
-      sideL.style.transform = `translateX(${-shift}%)`;
-      sideR.style.transform = `translateX(${shift}%)`;
-      const fade = String(Math.min(1, 0.25 + e));
-      sideL.style.opacity = fade;
-      sideR.style.opacity = fade;
-      seam.style.transform = `translateX(-50%) scaleY(${e})`;
-    };
-    const onScroll = () => {
-      if (!raf) raf = window.requestAnimationFrame(place);
-    };
-    place();
-    window.addEventListener('scroll', onScroll, true);
-    return () => {
-      window.removeEventListener('scroll', onScroll, true);
-      if (raf) window.cancelAnimationFrame(raf);
-    };
-  }, []);
-
-  // Today's real hot takes power the crossfire bubbles.
+  // Today's real hot takes power the thread.
   useEffect(() => {
     let active = true;
     getTakes(heroA.id, heroB.id)
@@ -2357,8 +2238,8 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
   const votesA = haveTally ? tally.votesA : winsA;
   const pctA = total > 0 ? Math.round((votesA / total) * 100) : 50;
 
-  // Beat 4 — the line moves: percentages count from 50/50 to the tally in step
-  // with the knot's slide once the section has revealed.
+  // The line moves: percentages count from 50/50 to the tally in step with
+  // the knot's slide once the section has revealed.
   useEffect(() => {
     if (!seen) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
@@ -2380,8 +2261,8 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seen, pctA]);
 
-  // Top takes by agreement, one slot each; editorial camp slogans keep the
-  // crossfire alive on days the takes haven't landed yet.
+  // Top takes by agreement, one row each; editorial camp slogans keep the
+  // thread alive on days the takes haven't landed yet.
   const bubbles: DebateBubble[] = [...takes]
     .sort((x, y) => y.agreeCount - x.agreeCount)
     .slice(0, 3)
@@ -2432,20 +2313,16 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
         </h2>
         <p className="section-sub debate-sub">{line}</p>
 
-        <div className="debate-stage" ref={stageRef}>
-          <div className="debate-air">
-            {bubbles.map((bubble, idx) => (
-              <div key={idx} className={`debate-bubble ${bubble.side} slot${idx + 1}`}>
+        <div className="debate-thread">
+          {bubbles.map((bubble, idx) => (
+            <div key={idx} className={`debate-row ${bubble.side} slot${idx + 1}`}>
+              <DebateAvatar hero={bubble.side === 'a' ? heroA : heroB} />
+              <div className="debate-msg">
                 {bubble.body}
-                <span className="debate-bubble-author">{bubble.author}</span>
+                <span className="debate-msg-author">{bubble.author}</span>
               </div>
-            ))}
-          </div>
-          <div className="debate-faceoff">
-            <DebateSide hero={heroA} side="l" />
-            <DebateSide hero={heroB} side="r" />
-          </div>
-          <div className="debate-faceoff-seam" aria-hidden="true" />
+            </div>
+          ))}
         </div>
 
         <div className="debate-split">

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -6,6 +6,7 @@ import * as THREE from 'three';
 import { LOGO_MASK_PATH as LOGO_PATH } from '../../constants/logo';
 import { getTodaysMatchup, type MatchupHero, type TodaysMatchup } from '../../lib/matchup';
 import { getDailyDebate, todayIso } from '../../lib/db/dailyDebate';
+import { getTakes, type Take } from '../../lib/db/takes';
 import { useMatchupVote } from '../../hooks/useMatchupVote';
 
 const screenshotDesktop = require('../../../assets/images/screenshots/desktop-explore.png');
@@ -1738,15 +1739,18 @@ const CSS = `
      once the server-curated (or seeded-fallback) pair has resolved, so it
      fades in on mount rather than riding the scroll-reveal IO (that observer
      only queries .reveal elements present at first paint). */
-  /* --- Today's debate — the live arena teaser --- */
+  /* --- Today's debate — the live crossfire ---
+     The section's job is DEBATE, not the fight (the "Who'd actually win?"
+     section further down owns that): the space between the two camps is a
+     live comment war — real takes popping in as side-tinted speech bubbles
+     over the fighters squaring off below. */
   .debate-teaser { padding:72px 40px 96px; background:var(--bg); position:relative; }
   .debate-inner { max-width:680px; margin:0 auto; text-align:center; }
   .debate-inner .section-sub { margin:0 auto; }
-  /* Entrance choreography. Driven by a component-local IntersectionObserver
-     ('.in' on the section) — the global reveal observer only registers
-     elements present at first paint, and this section mounts after today's
-     pair resolves. */
-  .debate-eyebrow, .debate-heading, .debate-sub, .debate-side, .debate-seam, .debate-coin { opacity:0; }
+  /* Entrance choreography — component-local IO ('.in'): the global reveal
+     observer only registers first-paint elements and this mounts after
+     today's pair resolves. */
+  .debate-eyebrow, .debate-heading, .debate-sub, .debate-side, .debate-bubble { opacity:0; }
   .debate-teaser.in .debate-eyebrow { animation:debateRise .7s var(--ease) both; }
   .debate-teaser.in .debate-heading { animation:debateRise .7s var(--ease) .08s both; }
   .debate-teaser.in .debate-sub { animation:debateRise .7s var(--ease) .16s both; }
@@ -1755,18 +1759,38 @@ const CSS = `
     to { opacity:1; transform:none; }
   }
   .debate-vs-text { color:var(--muted); font-size:0.6em; vertical-align:middle; }
-
-  /* The stage: two fighters filling their halves, each lit in their side's
-     colour, split by a skewed gold seam with the VS coin on it — the arena's
-     clash-card language, not a widget. */
-  .debate-stage {
-    position:relative; margin-top:44px; height:250px;
-    border-radius:20px; overflow:hidden;
-    border:1px solid var(--border); background:var(--card);
-    box-shadow:0 30px 80px rgba(0,0,0,0.5);
-    display:flex;
+  .debate-live {
+    display:inline-flex; align-items:center; gap:7px; margin-left:12px;
+    font-size:11px; letter-spacing:2px; color:#ff6b6b; vertical-align:middle;
   }
-  .debate-side { position:relative; flex:1; overflow:hidden; }
+  .debate-live-dot {
+    width:7px; height:7px; border-radius:50%; background:#ff5d5d;
+    box-shadow:0 0 10px rgba(255,93,93,0.8);
+    animation:debateLivePulse 1.6s ease-in-out infinite;
+  }
+  @keyframes debateLivePulse {
+    0%,100% { opacity:1; transform:scale(1); }
+    50% { opacity:0.45; transform:scale(0.75); }
+  }
+
+  /* The stage: fighters square off from the bottom corners (side B mirrored so
+     they FACE each other), the crossfire of takes filling the air between. */
+  .debate-stage {
+    position:relative; margin-top:44px; height:380px;
+    border-radius:20px; overflow:hidden;
+    border:1px solid var(--border);
+    background:
+      radial-gradient(90% 70% at 12% 100%, rgba(231,115,51,0.13) 0%, transparent 60%),
+      radial-gradient(90% 70% at 88% 100%, rgba(21,161,171,0.13) 0%, transparent 60%),
+      var(--card);
+    box-shadow:0 30px 80px rgba(0,0,0,0.5);
+  }
+  .debate-side {
+    position:absolute; bottom:0; width:44%; height:52%;
+    overflow:hidden;
+  }
+  .debate-side.l { left:0; border-top-right-radius:18px; }
+  .debate-side.r { right:0; border-top-left-radius:18px; }
   .debate-teaser.in .debate-side.l { animation:debateSlideL .8s var(--ease) .2s both; }
   .debate-teaser.in .debate-side.r { animation:debateSlideR .8s var(--ease) .2s both; }
   @keyframes debateSlideL {
@@ -1781,73 +1805,85 @@ const CSS = `
     position:absolute; inset:0; width:100%; height:100%;
     object-fit:cover; object-position:top;
   }
+  /* Face each other: mirror side B (portrait art overwhelmingly faces right). */
+  .debate-side.r img { transform:scaleX(-1); }
   .debate-side-fallback {
     position:absolute; inset:0; display:flex; align-items:center; justify-content:center;
-    font-family:'Righteous',sans-serif; font-size:64px; color:var(--muted);
+    font-family:'Righteous',sans-serif; font-size:56px; color:var(--muted);
     background:var(--surface);
   }
-  /* Side-colour washes + a floor fade that keeps the names legible. */
+  /* Side-colour rim light from each camp's corner + a floor fade. */
   .debate-side.l::after {
     content:''; position:absolute; inset:0;
     background:linear-gradient(115deg, rgba(231,115,51,0.30) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.88) 0%, transparent 58%);
+               linear-gradient(to top, rgba(11,24,32,0.72) 0%, transparent 45%);
   }
   .debate-side.r::after {
     content:''; position:absolute; inset:0;
     background:linear-gradient(245deg, rgba(21,161,171,0.30) 0%, transparent 55%),
-               linear-gradient(to top, rgba(11,24,32,0.88) 0%, transparent 58%);
-  }
-  .debate-name {
-    position:absolute; bottom:14px; z-index:2;
-    font-family:'Righteous',sans-serif; font-size:17px; color:var(--beige);
-    letter-spacing:0.3px; text-shadow:0 2px 12px rgba(0,0,0,0.8);
-  }
-  .debate-side.l .debate-name { left:16px; }
-  .debate-side.r .debate-name { right:16px; }
-  .debate-seam {
-    position:absolute; top:-10%; bottom:-10%; left:50%; width:3px; z-index:2;
-    transform:translateX(-50%) rotate(9deg); transform-origin:center;
-    background:linear-gradient(to bottom, transparent, var(--yellow) 30%, var(--orange) 70%, transparent);
-    box-shadow:0 0 18px rgba(249,178,34,0.45);
-  }
-  .debate-teaser.in .debate-seam { animation:debateSeam .6s var(--ease) .5s both; }
-  @keyframes debateSeam {
-    from { opacity:0; transform:translateX(-50%) rotate(9deg) scaleY(0.3); }
-    to { opacity:1; transform:translateX(-50%) rotate(9deg) scaleY(1); }
-  }
-  .debate-coin {
-    position:absolute; top:50%; left:50%; z-index:3;
-    width:54px; height:54px; border-radius:50%;
-    display:flex; align-items:center; justify-content:center;
-    background:#0e1c26; border:2px solid var(--yellow);
-    font-family:'Righteous',sans-serif; font-size:16px; color:var(--yellow); letter-spacing:1px;
-    box-shadow:0 0 34px rgba(249,178,34,0.35), 0 10px 30px rgba(0,0,0,0.6);
-  }
-  .debate-teaser.in .debate-coin { animation:debateCoin .55s cubic-bezier(.2,1.6,.4,1) .62s both; }
-  @keyframes debateCoin {
-    from { opacity:0; transform:translate(-50%,-50%) scale(0.3) rotate(-14deg); }
-    to { opacity:1; transform:translate(-50%,-50%) scale(1) rotate(0deg); }
+               linear-gradient(to top, rgba(11,24,32,0.72) 0%, transparent 45%);
   }
 
-  /* Live crowd split — fills from 50/50 to the real tally once revealed. */
+  /* The crossfire: takes as side-tinted chat bubbles, popped in on a real
+     conversation cadence, tails aimed at their camp. */
+  .debate-bubble {
+    position:absolute; z-index:3; max-width:62%;
+    padding:11px 14px 12px; border-radius:14px; text-align:left;
+    font-size:13.5px; line-height:1.45; color:var(--beige);
+    background:rgba(20,33,48,0.92);
+    -webkit-backdrop-filter:blur(8px); backdrop-filter:blur(8px);
+    border:1px solid var(--border);
+    box-shadow:0 14px 40px rgba(0,0,0,0.45);
+  }
+  .debate-bubble .debate-bubble-author {
+    display:block; margin-top:6px;
+    font-size:10.5px; font-weight:700; letter-spacing:1.2px; text-transform:uppercase;
+  }
+  .debate-bubble.a { border-color:rgba(231,115,51,0.45); border-bottom-left-radius:4px; }
+  .debate-bubble.b { border-color:rgba(21,161,171,0.45); border-bottom-right-radius:4px; }
+  .debate-bubble.a .debate-bubble-author { color:var(--orange); }
+  .debate-bubble.b .debate-bubble-author { color:var(--teal); }
+  .debate-bubble.slot1 { top:22px; left:16px; }
+  .debate-bubble.slot2 { top:104px; right:16px; }
+  .debate-bubble.slot3 { top:196px; left:50%; transform:translateX(-50%); max-width:66%; }
+  .debate-teaser.in .debate-bubble.slot1 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) .65s both; }
+  .debate-teaser.in .debate-bubble.slot2 { animation:debateBubble .5s cubic-bezier(.2,1.4,.4,1) 1.25s both; }
+  .debate-teaser.in .debate-bubble.slot3 { animation:debateBubbleC .5s cubic-bezier(.2,1.4,.4,1) 1.85s both; }
+  @keyframes debateBubble {
+    from { opacity:0; transform:translateY(14px) scale(0.86); }
+    to { opacity:1; transform:none; }
+  }
+  @keyframes debateBubbleC {
+    from { opacity:0; transform:translateX(-50%) translateY(14px) scale(0.86); }
+    to { opacity:1; transform:translateX(-50%); }
+  }
+
+  /* Live crowd split — a tug-of-war that fills from 50/50 to the real tally
+     once revealed; the contested boundary carries a small glow. */
   .debate-split { margin-top:22px; }
   .debate-split-bar {
     display:flex; height:10px; border-radius:6px; overflow:hidden; background:var(--surface);
   }
   .debate-split-fill { height:100%; transition:width .9s var(--ease); }
-  .debate-split-fill.l { background:linear-gradient(90deg,#c85f2a,var(--orange)); }
+  .debate-split-fill.l {
+    background:linear-gradient(90deg,#c85f2a,var(--orange));
+    box-shadow:6px 0 14px rgba(231,115,51,0.55);
+  }
   .debate-split-fill.r { background:linear-gradient(90deg,var(--teal),#0f7f88); }
   .debate-split-labels {
-    display:flex; justify-content:space-between; margin-top:9px;
+    display:flex; justify-content:space-between; align-items:baseline; gap:10px; margin-top:9px;
     font-size:12px; font-weight:600; letter-spacing:0.5px; color:var(--muted);
   }
   .debate-split-labels .l { color:var(--orange); }
   .debate-split-labels .r { color:var(--teal); }
-  .debate-teaser .btn-primary { margin-top:32px; }
+  .debate-split-labels .mid { font-weight:500; letter-spacing:0.3px; }
+  .debate-teaser .btn-primary { margin-top:30px; }
   @media (prefers-reduced-motion:reduce) {
-    .debate-eyebrow,.debate-heading,.debate-sub,.debate-side,.debate-seam,.debate-coin {
+    .debate-eyebrow,.debate-heading,.debate-sub,.debate-side,.debate-bubble {
       opacity:1 !important; animation:none !important;
     }
+    .debate-bubble.slot3 { transform:translateX(-50%) !important; }
+    .debate-live-dot { animation:none !important; }
   }
 
   footer {
@@ -1932,9 +1968,11 @@ const CSS = `
 
     /* Sections */
     .section,.screenshots,.showcase,.cta-section,.debate-teaser { padding:64px 20px; }
-    .debate-stage { height:200px; }
-    .debate-name { font-size:14px; }
-    .debate-coin { width:46px; height:46px; font-size:14px; }
+    .debate-stage { height:340px; }
+    .debate-bubble { font-size:12.5px; max-width:72%; }
+    .debate-bubble.slot2 { top:96px; }
+    .debate-bubble.slot3 { top:184px; max-width:76%; }
+    .debate-side { width:46%; height:46%; }
     .section-heading { font-size:clamp(24px,6vw,34px); margin-bottom:16px; }
     .section-sub { font-size:15px; }
 
@@ -2155,26 +2193,34 @@ function DebateSide({ hero, side }: { hero: MatchupHero; side: 'l' | 'r' }) {
           {hero.name.charAt(0)}
         </span>
       )}
-      <span className="debate-name">{hero.name}</span>
     </div>
   );
 }
 
-// Teaser only — no inline voting. The split bar reads the live crowd tally
-// (useMatchupVote, same hook the Compare screen uses) and falls back to the
-// stat-round split until the tally loads or if it's empty, so the bar is
-// never a flat 50/50 by default. The whole section choreographs in when it
-// scrolls into view (component-local IO — the global reveal observer only
-// registers first-paint elements, and this mounts after today's pair
-// resolves): copy rises, fighters slide in from their corners, the gold seam
-// strikes, the VS coin pops, and the split bar fills from 50/50 to the tally.
+interface DebateBubble {
+  body: string;
+  side: 'a' | 'b';
+  author: string;
+}
+
+// Teaser only — no inline voting. This section sells the DEBATE (the "Who'd
+// actually win?" section further down owns the fight): the air between the
+// two camps is a live crossfire of real community takes, popped in on a chat
+// cadence, with the tug-of-war tally underneath. The split bar reads the live
+// crowd tally (useMatchupVote, same hook the Compare screen uses) and falls
+// back to the stat-round split until the tally loads, so it's never a flat
+// 50/50 by default.
 function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText: string | null }) {
   const router = useRouter();
   const { heroA, heroB, winsA, winsB, verdict } = matchup;
   const { tally } = useMatchupVote(heroA.id, heroB.id);
   const sectionRef = useRef<HTMLElement>(null);
   const [seen, setSeen] = useState(false);
+  const [takes, setTakes] = useState<Take[]>([]);
 
+  // Choreograph in when scrolled into view (component-local IO — the global
+  // reveal observer only registers first-paint elements, and this section
+  // mounts after today's pair resolves).
   useEffect(() => {
     const el = sectionRef.current;
     if (!el) return;
@@ -2195,6 +2241,40 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
     return () => io.disconnect();
   }, []);
 
+  // Today's real hot takes power the crossfire bubbles.
+  useEffect(() => {
+    let active = true;
+    getTakes(heroA.id, heroB.id)
+      .then((rows) => {
+        if (active) setTakes(rows);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [heroA.id, heroB.id]);
+
+  // Top takes by agreement, one slot each; editorial camp slogans keep the
+  // crossfire alive on days the takes haven't landed yet.
+  const bubbles: DebateBubble[] = [...takes]
+    .sort((x, y) => y.agreeCount - x.agreeCount)
+    .slice(0, 3)
+    .map((t) => ({
+      body: t.body,
+      side: t.pickedId === heroA.id ? ('a' as const) : ('b' as const),
+      author: t.displayName ?? 'a fan',
+    }));
+  if (bubbles.length < 2) {
+    const seeds: DebateBubble[] = [
+      { body: `${heroA.name} takes this — and it isn't close.`, side: 'a', author: `Team ${heroA.name}` },
+      { body: `${heroB.name} wins it nine times out of ten.`, side: 'b', author: `Team ${heroB.name}` },
+    ];
+    for (const s of seeds) {
+      if (bubbles.length >= 2) break;
+      if (!bubbles.some((o) => o.side === s.side)) bubbles.push(s);
+    }
+  }
+
   const haveTally = !!tally && tally.total > 0;
   const total = haveTally ? tally.total : winsA + winsB;
   const votesA = haveTally ? tally.votesA : winsA;
@@ -2205,6 +2285,9 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
   // a 0/100 tally renders 7/93 visually while the labels stay honest.
   const clampW = (n: number) => Math.min(93, Math.max(7, n));
   const wA = seen ? clampW(pctA) : 50;
+  const voteWord = haveTally
+    ? `${tally.total.toLocaleString()} ${tally.total === 1 ? 'vote' : 'votes'} in`
+    : 'the crowd is deciding';
   const line =
     hookText ?? firstSentence(verdict) ?? `${heroA.name} or ${heroB.name} — who actually wins?`;
 
@@ -2214,7 +2297,13 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
   return (
     <section className={`debate-teaser${seen ? ' in' : ''}`} ref={sectionRef}>
       <div className="debate-inner">
-        <p className="section-eyebrow debate-eyebrow">Today&apos;s debate</p>
+        <p className="section-eyebrow debate-eyebrow">
+          Today&apos;s debate
+          <span className="debate-live" aria-hidden="true">
+            <span className="debate-live-dot" />
+            LIVE
+          </span>
+        </p>
         <h2 className="section-heading debate-heading">
           {heroA.name} <span className="debate-vs-text">vs</span> {heroB.name}
         </h2>
@@ -2223,19 +2312,22 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
         <div className="debate-stage">
           <DebateSide hero={heroA} side="l" />
           <DebateSide hero={heroB} side="r" />
-          <div className="debate-seam" aria-hidden="true" />
-          <span className="debate-coin" aria-hidden="true">
-            VS
-          </span>
+          {bubbles.map((bubble, idx) => (
+            <div key={idx} className={`debate-bubble ${bubble.side} slot${idx + 1}`}>
+              {bubble.body}
+              <span className="debate-bubble-author">{bubble.author}</span>
+            </div>
+          ))}
         </div>
 
-        <div className="debate-split" aria-hidden="true">
-          <div className="debate-split-bar">
+        <div className="debate-split">
+          <div className="debate-split-bar" aria-hidden="true">
             <div className="debate-split-fill l" style={{ width: `${wA}%` }} />
             <div className="debate-split-fill r" style={{ width: `${100 - wA}%` }} />
           </div>
           <div className="debate-split-labels">
             <span className="l">{pctA}%</span>
+            <span className="mid">{voteWord}</span>
             <span className="r">{pctB}%</span>
           </div>
         </div>
@@ -2253,13 +2345,9 @@ function DebateTeaser({ matchup, hookText }: { matchup: TodaysMatchup; hookText:
             strokeLinejoin="round"
             aria-hidden="true"
           >
-            <path d="M14.5 17.5 3 6V3h3l11.5 11.5" />
-            <path d="m13 19 6-6" />
-            <path d="m16 16 4 4" />
-            <path d="M14.5 6.5 18 3h3v3l-3.5 3.5" />
-            <path d="m5 14 4 4" />
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
           </svg>
-          Cast your vote
+          Join the debate
         </button>
       </div>
     </section>

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -2213,6 +2213,13 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
   // first paint). Instead: inject a real <link> (fetch starts immediately,
   // preconnected), wait for its CSS to parse, then wait for the actual display
   // faces before revealing.
+  //
+  // Choreography: the reveal ALSO waits for the visual viewport to settle.
+  // iOS Safari collapses its URL bar on its own clock shortly after load —
+  // fading the splash while the toolbar is mid-collapse reads as two unrelated
+  // animations fighting. The collapse fires visualViewport resize events, so
+  // hold the fade until the viewport has been still for a beat and the reveal
+  // always lands on a settled stage.
   useEffect(() => {
     let done = false;
     const ready = () => {
@@ -2242,17 +2249,42 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
           link!.addEventListener('load', res, { once: true });
           link!.addEventListener('error', res, { once: true });
         });
-    cssReady
-      .then(() =>
-        Promise.all([
-          document.fonts.load("400 24px 'Righteous'"),
-          document.fonts.load("400 16px 'Poppins'"),
-          document.fonts.load("600 16px 'Poppins'"),
-        ]),
-      )
-      .then(ready, ready);
+    const fontsP = cssReady.then(() =>
+      Promise.all([
+        document.fonts.load("400 24px 'Righteous'"),
+        document.fonts.load("400 16px 'Poppins'"),
+        document.fonts.load("600 16px 'Poppins'"),
+      ]),
+    );
+
+    // Viewport-settle: resolves once visualViewport has fired no resize for
+    // 260ms (the toolbar collapse is a burst of resizes). Immediately settled
+    // where visualViewport is unsupported.
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    let removeSettle: (() => void) | null = null;
+    const viewportP = new Promise<void>((res) => {
+      const vv = window.visualViewport;
+      if (!vv) return res();
+      const fin = () => {
+        removeSettle?.();
+        res();
+      };
+      const arm = () => {
+        if (settleTimer) clearTimeout(settleTimer);
+        settleTimer = setTimeout(fin, 260);
+      };
+      vv.addEventListener('resize', arm);
+      removeSettle = () => vv.removeEventListener('resize', arm);
+      arm();
+    });
+
+    Promise.all([fontsP, viewportP]).then(ready, ready);
     const fallback = setTimeout(ready, 3000); // never leave the hero hidden
-    return () => clearTimeout(fallback);
+    return () => {
+      clearTimeout(fallback);
+      if (settleTimer) clearTimeout(settleTimer);
+      removeSettle?.();
+    };
   }, []);
 
   // The Summoning — three.js lifecycle

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1158,16 +1158,10 @@ const CSS = `
     position: fixed; top:0; left:0; right:0; z-index:100;
     display:flex; align-items:center; justify-content:space-between;
     padding:20px 40px;
-    background:linear-gradient(to bottom,rgba(11,24,32,0.95) 0%,transparent 100%);
-    border-bottom:1px solid transparent;
-    transition:border-color .35s ease, padding .3s ease, background-color .35s ease;
-  }
-  nav.nav-solid {
-    background:rgba(11,24,32,0.78);
-    -webkit-backdrop-filter:blur(16px) saturate(1.2);
-    backdrop-filter:blur(16px) saturate(1.2);
-    border-bottom-color:rgba(37,61,80,0.7);
-    padding-top:14px; padding-bottom:14px;
+    /* One consistent gradient scrim at every scroll position — the same
+       ink fade the app TopBar carries (near-solid over the logo row, easing
+       to transparent), so the nav never restyles mid-scroll. */
+    background:linear-gradient(to bottom, rgba(11,24,32,1) 0%, rgba(11,24,32,0.85) 30%, rgba(11,24,32,0.45) 62%, rgba(11,24,32,0.14) 84%, transparent 100%);
   }
   .nav-brand { display:flex; align-items:center; gap:10px; }
   .nav-logo { height:32px; width:32px; }
@@ -2291,16 +2285,6 @@ export default function LandingPage({ dom: _dom }: { dom?: import('expo/dom').DO
       engineRef.current = null;
     };
   }, [mode, fallBack]);
-
-  // Nav turns glass once the page scrolls
-  useEffect(() => {
-    const nav = document.querySelector('nav');
-    if (!nav) return;
-    const onScroll = () => nav.classList.toggle('nav-solid', window.scrollY > 40);
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   // Stats count up the first time the band scrolls into view
   useEffect(() => {

--- a/src/components/landing/LandingPage.dom.tsx
+++ b/src/components/landing/LandingPage.dom.tsx
@@ -1144,7 +1144,6 @@ const CSS = `
     --ease:cubic-bezier(.16,1,.3,1); /* expo-out — the page's one easing voice */
   }
   html {
-    scroll-behavior: smooth;
     background: var(--bg); /* iOS Safari overscroll top area */
   }
   body {
@@ -1174,7 +1173,7 @@ const CSS = `
   .nav-cta:hover { background:#f2813e; transform:translateY(-1px); }
 
   .hero {
-    position:relative; min-height:100dvh;
+    position:relative; min-height:100svh;
     display:flex; flex-direction:column; align-items:center; justify-content:center;
     text-align:center; padding:120px 24px 80px; overflow:hidden;
   }
@@ -1207,7 +1206,7 @@ const CSS = `
     display:grid; grid-template-columns:minmax(380px,0.95fr) minmax(0,1.3fr);
     gap:0; align-items:center;
     width:100%; max-width:1220px; margin:0 auto;
-    min-height:calc(100dvh - 190px);
+    min-height:calc(100svh - 190px);
   }
   /* No container — the copy sits directly in the starfield; a soft local
      darkening behind it keeps the type readable without drawing a box */
@@ -1828,7 +1827,7 @@ const CSS = `
 
     /* Hero — tighter, no min-height */
     .hero { padding:88px 20px 52px; min-height:auto; }
-    .hero--3d { min-height:100dvh; padding:88px 16px 36px; }
+    .hero--3d { min-height:100svh; padding:88px 16px 36px; }
     .hc1,.hc2,.hc3,.hc4,.hc5,.hc6,.hc7,.hc8,.hc9,.hc10 { display:none; }
     .scroll-hint { display:none; }
     .plate-name { font-size:19px; }

--- a/src/components/ui/LogoLoader.web.tsx
+++ b/src/components/ui/LogoLoader.web.tsx
@@ -53,13 +53,16 @@ export function LogoLoader() {
 }
 
 const styles = StyleSheet.create({
-  // The document default background is deep-navy (see app/+html.tsx), so the
-  // status-bar and toolbar safe areas behind this box are already ink — the
-  // loader only needs to fill the app box.
+  // minHeight 100lvh: span the LARGE viewport so ink content physically sits
+  // under the iOS Safari bottom toolbar during the boot/lazy-chunk phase. At
+  // exactly 100dvh nothing extends into the toolbar band, so the glass frosts
+  // the flat canvas and reads as a solid navy slab — with the bleed it stays
+  // translucent edge-to-edge, exactly like a loaded page.
   container: {
     flex: 1,
+    minHeight: '100lvh' as unknown as number,
     backgroundColor: COLORS.deepNavy,
     alignItems: 'center',
     justifyContent: 'center',
-  },
+  } as object,
 });

--- a/src/hooks/useCachedAdminFlag.ts
+++ b/src/hooks/useCachedAdminFlag.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+const KEY = 'mythique.is_admin';
+
+/**
+ * The admin flag, backed by the last-known value (localStorage) so admin-only
+ * UI — the settings "Admin" section, command-center entry points — renders on
+ * FIRST paint for a returning admin instead of popping in when the profile
+ * query resolves.
+ *
+ * Safe to be optimistic: every admin surface re-verifies server-side (RLS'd
+ * RPCs; /admin/health bounces non-admins), so a stale `true` shows a dead
+ * entry at worst, and the cache corrects itself the moment the profile lands.
+ * Non-admins never have the cached flag, so they never see a flash.
+ */
+export function useCachedAdminFlag(
+  profile: { is_admin?: boolean | null } | null | undefined,
+): boolean {
+  // Read once on mount — localStorage doesn't exist on native, where the
+  // profile query result is the only source.
+  const [cached] = useState(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem(KEY) === '1',
+  );
+  useEffect(() => {
+    if (!profile || typeof localStorage === 'undefined') return;
+    localStorage.setItem(KEY, profile.is_admin ? '1' : '0');
+  }, [profile]);
+  return profile ? !!profile.is_admin : cached;
+}

--- a/src/hooks/useDiscoveryRows.ts
+++ b/src/hooks/useDiscoveryRows.ts
@@ -10,15 +10,18 @@ import {
 } from '../lib/discovery';
 
 /** The Battle Discovery feed's rows, derived from data the hub already fetches
- *  (rivalries + iconic pool + featured teams). Each list degrades to []. */
+ *  (rivalries + iconic pool + featured teams). Each list degrades to [].
+ *  `settled` = every source has resolved — gate the whole feed on it so the
+ *  sections reveal as one snapshot instead of popping in one at a time. */
 export function useDiscoveryRows(): {
   rivalries: Matchup[];
   dream: Matchup[];
   goliath: Matchup[];
   teams: TeamMatchup[];
+  settled: boolean;
 } {
-  const { rivalries, iconicPool } = useVersusHub();
-  const { teams } = usePresetTeams();
+  const { rivalries, iconicPool, feedSettled } = useVersusHub();
+  const { teams, loading: teamsLoading } = usePresetTeams();
 
   return useMemo(
     () => ({
@@ -26,8 +29,9 @@ export function useDiscoveryRows(): {
       dream: uniquePairs(buildDreamMatches(iconicPool, 8)),
       goliath: uniquePairs(buildGoliathMatches(iconicPool, 8)),
       teams: uniquePairs(buildTeamMatches(teams, 6)),
+      settled: feedSettled && !teamsLoading,
     }),
-    [rivalries, iconicPool, teams],
+    [rivalries, iconicPool, teams, feedSettled, teamsLoading],
   );
 }
 

--- a/src/hooks/useProfileData.ts
+++ b/src/hooks/useProfileData.ts
@@ -20,8 +20,9 @@ export interface ProfileData {
    *  not `loading` — to gate anything that reads the full picture (e.g. the fan
    *  tier / milestone detector), so it never runs on a partially-loaded snapshot. */
   settled: boolean;
-  /** Re-fetch all profile data. Resolves when the favourites fetch settles, so
-   *  callers can drive their own pull-to-refresh spinner off the promise. */
+  /** Re-fetch all profile data. Resolves when the full snapshot has been
+   *  applied (all five sources settled), so callers can drive their own
+   *  pull-to-refresh spinner off the promise. */
   refetch: () => Promise<void>;
 }
 
@@ -45,26 +46,33 @@ export function useProfileData(userId: string | undefined): ProfileData {
 
   const refetch = useCallback((): Promise<void> => {
     if (!userId) return Promise.resolve();
-    const battleP = getBattleRecord()
-      .then(setBattle)
-      .catch(() => {});
-    const tasteP = getTasteProfile()
-      .then(setTaste)
-      .catch(() => {});
-    const contribP = getMyContributions()
-      .then(setContributions)
-      .catch(() => {});
-    const takesP = getMyTakes(userId)
-      .then(setTakes)
-      .catch(() => setTakes([]));
-    const favP = getUserFavouriteHeroes(userId)
-      .then(setFavourites)
-      .catch(() => setFavourites([]))
-      .finally(() => setLoading(false));
-    // `settled` flips only once every source has resolved, so consumers can gate
-    // full-picture logic (fan tier / milestone nudge) on a complete snapshot.
-    void Promise.allSettled([battleP, tasteP, contribP, takesP, favP]).then(() => setSettled(true));
-    return favP;
+    // Fetch all five sources in parallel but apply them as ONE snapshot once
+    // every request has settled. Applying each as it landed made the profile
+    // sections mount one after another during the initial load (contributions
+    // popping in, then takes, …) — a visible layout stagger. One snapshot =
+    // one reveal; on refetch the previous data stays up until the new
+    // snapshot swaps in, so there's no flicker either.
+    const done: Promise<void> = Promise.allSettled([
+      getBattleRecord(),
+      getTasteProfile(),
+      getMyContributions(),
+      getMyTakes(userId),
+      getUserFavouriteHeroes(userId),
+    ]).then(([battleR, tasteR, contribR, takesR, favR]) => {
+      // React batches these into a single render. Rejected sources keep their
+      // previous value (initial load: the empty default).
+      if (battleR.status === 'fulfilled') setBattle(battleR.value);
+      if (tasteR.status === 'fulfilled') setTaste(tasteR.value);
+      if (contribR.status === 'fulfilled') setContributions(contribR.value);
+      setTakes(takesR.status === 'fulfilled' ? takesR.value : []);
+      setFavourites(favR.status === 'fulfilled' ? favR.value : []);
+      setLoading(false);
+      // `settled` flips only once every source has resolved, so consumers can
+      // gate full-picture logic (fan tier / milestone nudge) on a complete
+      // snapshot.
+      setSettled(true);
+    });
+    return done;
   }, [userId]);
 
   return {

--- a/src/hooks/useVersusHub.ts
+++ b/src/hooks/useVersusHub.ts
@@ -147,6 +147,21 @@ export function useVersusHub() {
         }
       : null;
 
+  // The discovery feed below the showdown renders from FIVE independent
+  // queries. Revealing each section as its query lands makes them pop in one
+  // after another (the stagger useProfileData had); `feedSettled` flips once
+  // every feed source has resolved so the view can reveal the whole feed as
+  // one snapshot. yesterdayHeroesQ is a dependent query — while disabled with
+  // no data it stays 'pending', so it only counts when its parent produced a
+  // result to resolve names for.
+  const feedSettled =
+    !yesterdayResultQ.isPending &&
+    (!yesterdayResult || !yesterdayHeroesQ.isPending) &&
+    !rivalriesQ.isPending &&
+    !iconicQ.isPending &&
+    !teamBattleQ.isPending &&
+    !mostFearedQ.isPending;
+
   return {
     matchup,
     hookText: debateHookQ.data ?? null,
@@ -155,6 +170,7 @@ export function useVersusHub() {
     rivalries: rivalriesQ.data ?? [],
     iconicPool: iconicQ.data ?? [],
     loading: matchupQ.isPending || rivalriesQ.isPending || iconicQ.isPending,
+    feedSettled,
     teamBattle: teamBattleQ.data ?? null,
     mostFeared: mostFearedQ.data ?? [],
   };


### PR DESCRIPTION
Three progressive-render glitches, one root-cause fix each:

## 1. Landing — "half-baked" first paint
The display fonts (Righteous/Poppins) loaded via a **CSS `@import` inside the component's injected `<style>`** — the fetch only began after JS mounted, and `document.fonts.ready` resolved *before* those faces were registered. So the splash loader faded out over fallback-font text, which then visibly snapped into the real fonts.
**Fix:** inject a real `<link rel="stylesheet">` (with preconnects) on mount, wait for its CSS to parse, then wait for the actual display faces (`document.fonts.load(...)`) before revealing. Fallback timer 2s → 3s.

## 2. Profile — sections mounting one by one
`useProfileData` fired five parallel fetches (favourites, battle, contributions, taste, takes) that each `setState` **as they landed** — sections popped in arrival order.
**Fix:** apply all five as **one snapshot** when every source settles (single batched render). Refetches keep old data visible until the new snapshot swaps in. Shared hook → native profile improves too.

## 3. Settings — admin "Catalog Health" appearing late
The Admin section rendered only after the async profile query resolved.
**Fix:** new `useCachedAdminFlag` — last-known admin state in localStorage, so a returning admin sees the section on first paint. Optimism is safe: every admin surface re-verifies server-side (RLS'd RPCs, /admin/health bounces non-admins), and non-admins never have the flag cached.

## Check on device
- Landing fresh load (hard refresh): loader holds until fonts are real, hero reveals fully styled.
- Profile: sections appear together in one reveal.
- Settings (as admin): Admin section present immediately on repeat visits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)