### PR TITLE
feat(admin): TikTok analytics scaffolding (Phase 1, dormant until connected) + multi-platform Insights

### DIFF
--- a/docs/tiktok-integration.md
+++ b/docs/tiktok-integration.md
@@ -1,0 +1,56 @@
+# TikTok integration
+
+Mirrors the Instagram insights pipeline (`ig-sync` → `social_post_results` →
+Publish › Insights). **Phase 1 (analytics) is built and deployed** but dormant
+until the one-time connect below is done — the `tiktok-sync` function returns
+`{ error: "TikTok not connected" }` and the "Pull TikTok" button surfaces that.
+
+## The hard reality (why comments aren't auto-replied)
+
+TikTok exposes **no reply-to-comments write API** to third-party apps. Reading
+comment threads requires the Research API (gated to approved academic
+researchers). So the roadmap is:
+
+- **Phase 1 — analytics (DONE, dormant):** pull your videos' views / likes /
+  comments / shares via the Display API into `social_post_results`. Feeds the
+  Insights tab's per-platform split, best-format, top-posts.
+- **Phase 2 — comment triage (planned):** an inbox that lists comments needing
+  a reply and **deep-links into the TikTok app** to post the reply. Compliant,
+  no account risk. Not auto-reply.
+- **Phase 3 — viral-gap explorer (spike):** trending sounds/hashtags cross-
+  referenced against the catalog. Trending data is gated/limited — a research
+  spike, not a commitment.
+
+## One-time connect (unblocks Phase 1) — you must do this
+
+1. **Register an app** at <https://developers.tiktok.com> (Manage apps → Connect
+   an app). Product: **Login Kit** + **Display API**. Request scopes
+   `user.info.basic` and `video.list`.
+2. **Submit for review.** Provide the app URL, a demo covering each scope, and a
+   privacy policy. Approval is typically **1–2 weeks** (first-pass audits are
+   clean if every requested scope is demoed and correspondence is answered).
+3. **Complete OAuth once** for the Mythique TikTok creator account (any minimal
+   OAuth helper works — the redirect returns `access_token`, `refresh_token`,
+   `open_id`, `expires_in`).
+4. **Store the credential** — insert one row:
+   ```sql
+   insert into platform_credentials (platform, access_token, refresh_token, external_id, expires_at)
+   values ('tiktok', '<access_token>', '<refresh_token>', '<open_id>',
+           now() + interval '24 hours');
+   ```
+5. **Set function secrets** (for the 24h token auto-refresh):
+   `supabase secrets set TIKTOK_CLIENT_KEY=… TIKTOK_CLIENT_SECRET=…`
+
+Then "Pull TikTok" in Publish › Insights works exactly like "Pull Instagram" —
+and captions are matched the same way (we already generate distinctive captions
+you paste verbatim, so no manual linking).
+
+## What's in the repo
+
+- `supabase/functions/tiktok-sync/index.ts` — Display API `video.list` +
+  token refresh → `social_post_results` (platform=`tiktok`). Deployed (v1).
+- `src/lib/db/socialPosts.ts` → `syncTiktok()`.
+- `SocialInsightsDomain` — "Pull TikTok" button; the per-platform split already
+  renders any `platform` value generically.
+- Migration `…_platform_credentials_refresh_token` — adds `refresh_token`
+  (TikTok tokens expire ~24h; Instagram's never needed it).

--- a/src/components/admin/health/domains/SocialInsightsDomain.tsx
+++ b/src/components/admin/health/domains/SocialInsightsDomain.tsx
@@ -100,16 +100,15 @@ export function SocialInsightsDomain() {
     setTimeout(() => setSyncMsg(null), 4000);
   };
 
-  const SyncButton = ({
-    platform,
-    icon,
-    label,
-  }: {
-    platform: 'instagram' | 'tiktok';
-    icon: 'logo-instagram' | 'logo-tiktok';
-    label: string;
-  }) => (
+  // Plain render helper (not a component) so its identity is stable across
+  // renders — eslint's "no components during render" rule.
+  const renderSyncButton = (
+    platform: 'instagram' | 'tiktok',
+    icon: 'logo-instagram' | 'logo-tiktok',
+    label: string,
+  ) => (
     <Pressable
+      key={platform}
       style={styles.syncBtn}
       onPress={() => runSync(platform)}
       disabled={syncing !== null}
@@ -127,8 +126,8 @@ export function SocialInsightsDomain() {
   const syncBtn = (
     <View style={styles.syncRow}>
       {syncMsg ? <Text style={styles.syncMsg}>{syncMsg}</Text> : null}
-      <SyncButton platform="instagram" icon="logo-instagram" label="Pull Instagram" />
-      <SyncButton platform="tiktok" icon="logo-tiktok" label="Pull TikTok" />
+      {renderSyncButton('instagram', 'logo-instagram', 'Pull Instagram')}
+      {renderSyncButton('tiktok', 'logo-tiktok', 'Pull TikTok')}
     </View>
   );
 

--- a/src/components/admin/health/domains/SocialInsightsDomain.tsx
+++ b/src/components/admin/health/domains/SocialInsightsDomain.tsx
@@ -59,6 +59,22 @@ const angleLabel = (p: SocialPost) => {
   return a.charAt(0).toUpperCase() + a.slice(1);
 };
 
+// Per-platform display: proper label + brand icon (data carries the raw
+// platform key). Unknown platforms fall back to a capitalised label + globe.
+const PLATFORM_META: Record<
+  string,
+  { label: string; icon: 'logo-instagram' | 'logo-tiktok' | 'logo-reddit' | 'globe-outline' }
+> = {
+  instagram: { label: 'Instagram', icon: 'logo-instagram' },
+  tiktok: { label: 'TikTok', icon: 'logo-tiktok' },
+  reddit: { label: 'Reddit', icon: 'logo-reddit' },
+};
+const platformMeta = (p: string) =>
+  PLATFORM_META[p] ?? {
+    label: p.charAt(0).toUpperCase() + p.slice(1),
+    icon: 'globe-outline' as const,
+  };
+
 export function SocialInsightsDomain() {
   const qc = useQueryClient();
   const postsQ = useQuery({ queryKey: ['socialPosts'], queryFn: listSocialPosts });
@@ -299,7 +315,10 @@ export function SocialInsightsDomain() {
         >
           {platformRows.map((p) => (
             <View key={p.platform} style={styles.platRow}>
-              <Text style={styles.platName}>{p.platform}</Text>
+              <View style={styles.platNameRow}>
+                <Ionicons name={platformMeta(p.platform).icon} size={13} color={COLORS.navy} />
+                <Text style={styles.platName}>{platformMeta(p.platform).label}</Text>
+              </View>
               <View style={styles.platNums}>
                 <Text style={styles.platViews}>
                   {p.views ? (
@@ -345,7 +364,7 @@ export function SocialInsightsDomain() {
                 <Text style={styles.topAngle}>{angleLabel(t.post)}</Text>
                 {[...new Set(t.platforms)].map((pf) => (
                   <Text key={pf} style={styles.topPlatform}>
-                    {pf}
+                    {platformMeta(pf).label}
                   </Text>
                 ))}
               </View>
@@ -366,6 +385,7 @@ export function SocialInsightsDomain() {
 
 const styles = StyleSheet.create({
   syncRow: { flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  platNameRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   syncMsg: { fontFamily: 'Nunito_700Bold', fontSize: 11, color: COLORS.navy, opacity: 0.7 },
   wrap: { gap: 12, width: '100%' },
   syncBtn: {

--- a/src/components/admin/health/domains/SocialInsightsDomain.tsx
+++ b/src/components/admin/health/domains/SocialInsightsDomain.tsx
@@ -24,6 +24,7 @@ import {
   listSocialPosts,
   listPostResults,
   syncInstagram,
+  syncTiktok,
   type SocialPost,
   type SocialPostResult,
 } from '../../../../lib/db/socialPosts';
@@ -63,31 +64,56 @@ export function SocialInsightsDomain() {
   const postsQ = useQuery({ queryKey: ['socialPosts'], queryFn: listSocialPosts });
   const resultsQ = useQuery({ queryKey: ['socialPostResults'], queryFn: listPostResults });
   const narrow = useWindowDimensions().width < 640;
-  const [syncing, setSyncing] = useState(false);
+  // One control per connected platform — pulls that platform's post metrics
+  // into social_post_results. TikTok is read-only analytics (no reply API).
+  const [syncing, setSyncing] = useState<'instagram' | 'tiktok' | null>(null);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
 
-  const runSync = async () => {
-    setSyncing(true);
+  const runSync = async (platform: 'instagram' | 'tiktok') => {
+    setSyncing(platform);
     setSyncMsg(null);
+    const label = platform === 'tiktok' ? 'TikTok' : 'Instagram';
     try {
-      const r = await syncInstagram();
-      setSyncMsg(`Synced ${r.matched} Instagram post${r.matched === 1 ? '' : 's'}`);
+      const r = platform === 'tiktok' ? await syncTiktok() : await syncInstagram();
+      setSyncMsg(`Synced ${r.matched} ${label} post${r.matched === 1 ? '' : 's'}`);
       qc.invalidateQueries({ queryKey: ['socialPostResults'] });
     } catch (e) {
-      setSyncMsg(e instanceof Error ? e.message : 'Sync failed');
+      setSyncMsg(e instanceof Error ? e.message : `${label} sync failed`);
     }
-    setSyncing(false);
+    setSyncing(null);
     setTimeout(() => setSyncMsg(null), 4000);
   };
-  const syncBtn = (
-    <Pressable style={styles.syncBtn} onPress={runSync} disabled={syncing} hitSlop={6}>
-      {syncing ? (
+
+  const SyncButton = ({
+    platform,
+    icon,
+    label,
+  }: {
+    platform: 'instagram' | 'tiktok';
+    icon: 'logo-instagram' | 'logo-tiktok';
+    label: string;
+  }) => (
+    <Pressable
+      style={styles.syncBtn}
+      onPress={() => runSync(platform)}
+      disabled={syncing !== null}
+      hitSlop={6}
+    >
+      {syncing === platform ? (
         <ActivityIndicator size="small" color={GOLD} />
       ) : (
-        <Ionicons name="logo-instagram" size={14} color={COLORS.navy} />
+        <Ionicons name={icon} size={14} color={COLORS.navy} />
       )}
-      <Text style={styles.syncBtnText}>{syncing ? 'Syncing…' : (syncMsg ?? 'Sync Instagram')}</Text>
+      <Text style={styles.syncBtnText}>{syncing === platform ? 'Syncing…' : label}</Text>
     </Pressable>
+  );
+
+  const syncBtn = (
+    <View style={styles.syncRow}>
+      {syncMsg ? <Text style={styles.syncMsg}>{syncMsg}</Text> : null}
+      <SyncButton platform="instagram" icon="logo-instagram" label="Pull Instagram" />
+      <SyncButton platform="tiktok" icon="logo-tiktok" label="Pull TikTok" />
+    </View>
   );
 
   if (postsQ.isLoading || resultsQ.isLoading) {
@@ -105,7 +131,7 @@ export function SocialInsightsDomain() {
   if (latest.length === 0) {
     return (
       <Panel title="Insights" hint="Numbers appear here as results come in" action={syncBtn}>
-        <EmptyState text="No results yet — hit Sync Instagram to pull your posts, or log numbers from Post today › Posted (reddit & instagram refresh nightly)." />
+        <EmptyState text="No results yet — hit Pull Instagram / Pull TikTok to import your posts, or log numbers from Post today › Posted (reddit & instagram refresh nightly)." />
       </Panel>
     );
   }
@@ -339,6 +365,8 @@ export function SocialInsightsDomain() {
 }
 
 const styles = StyleSheet.create({
+  syncRow: { flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  syncMsg: { fontFamily: 'Nunito_700Bold', fontSize: 11, color: COLORS.navy, opacity: 0.7 },
   wrap: { gap: 12, width: '100%' },
   syncBtn: {
     flexDirection: 'row',

--- a/src/lib/db/socialPosts.ts
+++ b/src/lib/db/socialPosts.ts
@@ -68,3 +68,20 @@ export async function syncInstagram(): Promise<{
   if (error) throw new Error(error.message);
   return data ?? { scanned: 0, matched: 0, unmatched: 0 };
 }
+
+/** Trigger the TikTok sync edge function — matches recent TikTok videos to
+ *  queue posts by caption and writes fresh result snapshots (platform=tiktok).
+ *  Read-only analytics; TikTok has no reply-to-comments write API. */
+export async function syncTiktok(): Promise<{
+  scanned: number;
+  matched: number;
+  unmatched: number;
+}> {
+  const { data, error } = await supabase.functions.invoke<{
+    scanned: number;
+    matched: number;
+    unmatched: number;
+  }>('tiktok-sync', { body: {} });
+  if (error) throw new Error(error.message);
+  return data ?? { scanned: 0, matched: 0, unmatched: 0 };
+}

--- a/supabase/functions/tiktok-sync/index.ts
+++ b/supabase/functions/tiktok-sync/index.ts
@@ -1,0 +1,162 @@
+// On-demand TikTok sync: lists your recent videos + their public metrics via
+// the TikTok Display API and auto-matches each to a queue post BY CAPTION (the
+// same caption-key match ig-sync uses), then writes social_post_results rows
+// with platform='tiktok'. Pressing "Pull TikTok content" in the Insights tab
+// is enough — no manual linking.
+//
+// PREREQUISITE (one-time, on the TikTok developer portal — cannot be done from
+// here): an APPROVED TikTok app with Login Kit + the `video.list` and
+// `user.info.basic` scopes, then a completed OAuth so a row exists in
+// platform_credentials with platform='tiktok' (access_token, refresh_token,
+// external_id = open_id). Set TIKTOK_CLIENT_KEY + TIKTOK_CLIENT_SECRET as
+// function secrets for the token refresh below. Until then this returns
+// { error: 'TikTok not connected' } — same graceful shape as ig-sync.
+//
+// SCOPE: read-only analytics. TikTok has NO official reply-to-comments write
+// API for third-party apps — comment reply is a separate, triage-only feature.
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+);
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+
+// Same caption normalisation ig-sync uses: lowercase, letters+digits only,
+// first 40 chars — robust to emoji, punctuation, trailing hashtags.
+const capKey = (s: string | null | undefined) =>
+  (s ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .slice(0, 40);
+
+// TikTok access tokens live ~24h; refresh in place (refresh token lasts ~1yr)
+// and persist the new pair so subsequent syncs keep working unattended.
+async function freshToken(cred: {
+  access_token: string;
+  refresh_token: string | null;
+  expires_at: string | null;
+}): Promise<string> {
+  const notExpired = cred.expires_at && new Date(cred.expires_at).getTime() > Date.now() + 60_000;
+  if (notExpired || !cred.refresh_token) return cred.access_token;
+
+  const res = await fetch('https://open.tiktokapis.com/v2/oauth/token/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_key: Deno.env.get('TIKTOK_CLIENT_KEY') ?? '',
+      client_secret: Deno.env.get('TIKTOK_CLIENT_SECRET') ?? '',
+      grant_type: 'refresh_token',
+      refresh_token: cred.refresh_token,
+    }),
+  });
+  const body = await res.json();
+  if (!res.ok || !body.access_token) return cred.access_token; // fall back; the list call will surface the auth error
+  await supabase
+    .from('platform_credentials')
+    .update({
+      access_token: body.access_token,
+      refresh_token: body.refresh_token ?? cred.refresh_token,
+      expires_at: new Date(Date.now() + (body.expires_in ?? 86_400) * 1000).toISOString(),
+    })
+    .eq('platform', 'tiktok');
+  return body.access_token;
+}
+
+interface TikTokVideo {
+  id: string;
+  title?: string;
+  video_description?: string;
+  view_count?: number;
+  like_count?: number;
+  comment_count?: number;
+  share_count?: number;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+  try {
+    const { data: cred } = await supabase
+      .from('platform_credentials')
+      .select('access_token, refresh_token, expires_at, external_id')
+      .eq('platform', 'tiktok')
+      .maybeSingle();
+    if (!cred) return json({ error: 'TikTok not connected' }, 400);
+
+    const token = await freshToken(cred);
+
+    // Queue posts keyed by caption prefix (only those with a caption).
+    const { data: posts } = await supabase.from('social_posts').select('id, caption');
+    const byCap = new Map<string, string>();
+    for (const p of posts ?? []) {
+      const k = capKey(p.caption);
+      if (k.length >= 12 && !byCap.has(k)) byCap.set(k, p.id);
+    }
+
+    // Display API: list recent videos with their public metrics. Fields go in
+    // the query string; pagination via cursor in the JSON body (two pages).
+    const FIELDS =
+      'id,title,video_description,view_count,like_count,comment_count,share_count';
+    const videos: TikTokVideo[] = [];
+    let cursor: number | undefined;
+    for (let page = 0; page < 2; page++) {
+      const res = await fetch(
+        `https://open.tiktokapis.com/v2/video/list/?fields=${FIELDS}`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ max_count: 20, ...(cursor ? { cursor } : {}) }),
+        },
+      );
+      const body = await res.json();
+      if (!res.ok || body.error?.code !== 'ok') {
+        return json({ error: `TikTok video.list: ${body.error?.message ?? res.status}` }, 502);
+      }
+      videos.push(...(body.data?.videos ?? []));
+      if (!body.data?.has_more) break;
+      cursor = body.data?.cursor;
+    }
+
+    let matched = 0;
+    const unmatched: string[] = [];
+    const failures: string[] = [];
+    for (const v of videos) {
+      const caption = v.title || v.video_description;
+      const postId = byCap.get(capKey(caption));
+      const permalink = `https://www.tiktok.com/@${cred.external_id ?? 'me'}/video/${v.id}`;
+      if (!postId) {
+        unmatched.push(permalink);
+        continue;
+      }
+      try {
+        const { error } = await supabase.from('social_post_results').insert({
+          post_id: postId,
+          platform: 'tiktok',
+          views: v.view_count ?? null,
+          likes: v.like_count ?? null,
+          comments: v.comment_count ?? null,
+          post_url: permalink,
+          source: 'auto',
+          note: v.share_count != null ? `${v.share_count} shares` : null,
+        });
+        if (error) throw new Error(error.message);
+        matched++;
+      } catch (e) {
+        failures.push(`${permalink}: ${e instanceof Error ? e.message : e}`);
+      }
+    }
+
+    return json({ scanned: videos.length, matched, unmatched: unmatched.length, failures });
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : 'tiktok-sync failed' }, 500);
+  }
+});

--- a/supabase/migrations/20260715120000_platform_credentials_refresh_token.sql
+++ b/supabase/migrations/20260715120000_platform_credentials_refresh_token.sql
@@ -1,0 +1,4 @@
+-- TikTok access tokens expire ~24h and must be refreshed with a refresh_token
+-- (~1yr). Instagram's long-lived token never needed one, so the column didn't
+-- exist. Additive + nullable — no impact on the existing instagram row.
+alter table public.platform_credentials add column if not exists refresh_token text;


### PR DESCRIPTION
Direction chosen: compliant comment triage + analytics-first. This is **Phase 1 (analytics)** — built, deployed, and dormant until the one-time TikTok app approval + OAuth (`docs/tiktok-integration.md`).

## The hard reality (documented)
TikTok exposes **no reply-to-comments write API** to third-party apps. So: Phase 1 = analytics (this PR), Phase 2 = comment triage that deep-links into the app (planned), Phase 3 = viral-gap spike.

## What's here
- **`tiktok-sync` edge function** — Display API `video.list` (views/likes/comments/shares) + 24h token auto-refresh → `social_post_results` (platform=`tiktok`), matched to queue posts by caption like `ig-sync`. CORS/OPTIONS/try-catch from the start. **Deployed v1**, returns `{error:'TikTok not connected'}` until setup — no error before then.
- **Migration** `platform_credentials_refresh_token` (applied) — TikTok tokens expire ~24h; IG's long-lived one never needed it.
- **`syncTiktok()`** client + **"Pull Instagram" / "Pull TikTok"** buttons in Insights.
- **Multi-platform Insights display** — `PLATFORM_META` (label + brand icon) so the per-platform split and top-post chips render TikTok/Reddit/IG properly instead of the raw key.
- **`docs/tiktok-integration.md`** — the 3-phase roadmap + the one-time connect steps (register app → review ~1–2 wks → OAuth → store token + secrets).

## To activate (you, when at a PC)
Register the TikTok app (Login Kit + Display API, scopes `video.list` + `user.info.basic`), complete OAuth once, drop the token in `platform_credentials`, set `TIKTOK_CLIENT_KEY`/`SECRET` secrets. Then "Pull TikTok" works like "Pull Instagram". I'll do the one live-API test pass + build Phase 2 once connected.

684 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)