### PR TITLE
fix: squash browse-filter, timezone & nav dead-end bugs

### DIFF
--- a/__tests__/lib/db/heroes.tagFilter.test.ts
+++ b/__tests__/lib/db/heroes.tagFilter.test.ts
@@ -33,10 +33,37 @@ describe('getCategoryPage tag filter', () => {
     expect(selectArg).not.toContain('hero_tags');
   });
 
-  it('inner-joins hero_tags and filters by each selected tag', async () => {
+  it('aliases the hero_tags inner join and filters the alias', async () => {
     await getCategoryPage('popular', { ...DEFAULT_FILTERS, tags: ['anti-hero'], page: 0 });
     const selectArg = (chain.select as jest.Mock).mock.calls[0][0] as string;
-    expect(selectArg).toContain('hero_tags!inner');
-    expect(chain.eq).toHaveBeenCalledWith('hero_tags.tag', 'anti-hero');
+    expect(selectArg).toContain('t0:hero_tags!inner(tag)');
+    expect(chain.eq).toHaveBeenCalledWith('t0.tag', 'anti-hero');
+  });
+
+  it('gives each tag its OWN aliased join so multiple tags AND (not an impossible single-row match)', async () => {
+    await getCategoryPage('popular', {
+      ...DEFAULT_FILTERS,
+      tags: ['comic-relief', 'wholesome'],
+      page: 0,
+    });
+    const selectArg = (chain.select as jest.Mock).mock.calls[0][0] as string;
+    // Two distinct aliased joins, not one shared embed.
+    expect(selectArg).toContain('t0:hero_tags!inner(tag)');
+    expect(selectArg).toContain('t1:hero_tags!inner(tag)');
+    // Each tag filters its own alias — never two .eq on the same key.
+    expect(chain.eq).toHaveBeenCalledWith('t0.tag', 'comic-relief');
+    expect(chain.eq).toHaveBeenCalledWith('t1.tag', 'wholesome');
+  });
+
+  it('double-quotes the search value so commas/parens do not break the .or() filter', async () => {
+    await getCategoryPage('popular', {
+      ...DEFAULT_FILTERS,
+      search: 'Spider-Man (2099)',
+      page: 0,
+    });
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toBe(
+      'name.ilike."%Spider-Man (2099)%",full_name.ilike."%Spider-Man (2099)%"',
+    );
   });
 });

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -862,7 +862,7 @@ export default function CharacterScreen() {
         <LoadErrorView
           actions={[
             { label: 'Retry', primary: true, onPress: retryLoad },
-            { label: 'Go back', onPress: () => router.back() },
+            { label: 'Go back', onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) },
           ]}
         />
       </View>

--- a/app/compare/[hero]/[opponent].tsx
+++ b/app/compare/[hero]/[opponent].tsx
@@ -92,7 +92,11 @@ export default function NativeCompareScreen() {
         <Stack.Screen options={headerBase} />
         <StatusBar style="light" />
         <Text style={styles.errorText}>{error}</Text>
-        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7} style={styles.retryBtn}>
+        <TouchableOpacity
+          onPress={() => (router.canGoBack() ? router.back() : router.replace(`/character/${hero}`))}
+          activeOpacity={0.7}
+          style={styles.retryBtn}
+        >
           <Text style={styles.retryText}>Go back</Text>
         </TouchableOpacity>
       </View>

--- a/app/issue/[id].tsx
+++ b/app/issue/[id].tsx
@@ -362,7 +362,7 @@ export default function IssueScreen() {
           subline="Check your connection and try again."
           actions={[
             { label: 'Retry', primary: true, onPress: () => issueQuery.refetch() },
-            { label: 'Go back', onPress: () => router.back() },
+            { label: 'Go back', onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) },
           ]}
         />
       </View>
@@ -388,7 +388,7 @@ export default function IssueScreen() {
           icon="book-outline"
           headline="Issue not found"
           subline="We don't have this issue in the archive yet."
-          actions={[{ label: 'Go back', primary: true, onPress: () => router.back() }]}
+          actions={[{ label: 'Go back', primary: true, onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) }]}
         />
       </View>
     );

--- a/app/title/[id].tsx
+++ b/app/title/[id].tsx
@@ -101,7 +101,7 @@ export default function TitleScreen() {
             subline="Check your connection and try again."
             actions={[
               { label: 'Retry', primary: true, onPress: () => titleQuery.refetch() },
-              { label: 'Go back', onPress: () => router.back() },
+              { label: 'Go back', onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) },
             ]}
           />
         </View>
@@ -125,7 +125,7 @@ export default function TitleScreen() {
           icon="film-outline"
           headline="Title not found"
           subline="We don't have this title in the archive yet."
-          actions={[{ label: 'Go back', primary: true, onPress: () => router.back() }]}
+          actions={[{ label: 'Go back', primary: true, onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) }]}
         />
       </View>
     );
@@ -306,7 +306,7 @@ export default function TitleScreen() {
     return (
       <View style={styles.webPage}>
         <Stack.Screen options={{ headerShown: false }} />
-        <FilmBackdropHeader film={film} onBack={() => router.back()} />
+        <FilmBackdropHeader film={film} onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))} />
         {/* Header is real (seeded stub or live row); the body waits on all its
             data and dissolves in over a body skeleton — so it never shifts. */}
         <View style={styles.bodyRegion}>
@@ -378,7 +378,7 @@ export default function TitleScreen() {
         contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 40 }]}
         showsVerticalScrollIndicator={false}
       >
-        <FilmBackdropHeader film={film} onBack={() => router.back()} />
+        <FilmBackdropHeader film={film} onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))} />
 
         {/* Header is real (seeded stub or live row); the body waits on all its
             data, then swaps in (gated → in place, no shift). */}

--- a/src/hooks/useMatchupVote.ts
+++ b/src/hooks/useMatchupVote.ts
@@ -37,6 +37,13 @@ export function useMatchupVote(heroAId: string, heroBId: string): MatchupVoteSta
 
   useEffect(() => {
     let active = true;
+    // Reset before the fetch so an in-place pair swap (same mounted instance)
+    // can't render the new matchup as already-revealed with the prior pair's
+    // pick/tally carried over. All current callers mount fresh per pair, but the
+    // hook must be correct on its own contract.
+    setPickedId(null);
+    setTally(null);
+    setLoaded(false);
     getVoterKey()
       .then((vk) => getMatchupTallyV2(heroAId, heroBId, vk))
       .then(async (t) => {

--- a/src/lib/db/heroes/categories.ts
+++ b/src/lib/db/heroes/categories.ts
@@ -237,6 +237,28 @@ export async function getAllHeroesBySlug(slug: CategorySlug): Promise<Hero[]> {
 const CATEGORY_LIST_COLUMNS =
   'id, name, image_url, image_md_url, portrait_url, portrait_blurhash, publisher, issue_count';
 
+// Select columns plus one ALIASED inner-join per tag (t0, t1, …). Each tag must
+// be its own join: a single `hero_tags!inner(tag)` embed filtered by two
+// `.eq('hero_tags.tag', …)` requires ONE junction row to equal both tags —
+// impossible — so the inner join keeps zero rows and the grid comes back empty
+// (worse: on large tables the planner times out). Independent aliased joins give
+// the correct "has ALL of these tags" semantics. See applyListFacets.
+function tagJoinSelect(tagList: string[]): string {
+  if (!tagList.length) return CATEGORY_LIST_COLUMNS;
+  const joins = tagList.map((_, i) => `t${i}:hero_tags!inner(tag)`).join(', ');
+  return `${CATEGORY_LIST_COLUMNS}, ${joins}`;
+}
+
+// A user's raw search text becomes an `.or()` filter value; PostgREST parses `,`
+// as its OR-term delimiter and `()` as grouping, so a query like `Rocket, Groot`
+// or `Spider-Man (2099)` produces a malformed logic tree → 400 → the whole grid
+// errors. Double-quoting the value makes those chars literal; we escape only the
+// `\` and `"` that would end the quoted string.
+function ilikeSearchOr(search: string): string {
+  const q = search.trim().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `name.ilike."%${q}%",full_name.ilike."%${q}%"`;
+}
+
 export async function getCategoryPage(
   slug: CategorySlug,
   options: { page: number; pageSize?: number; withCount?: boolean } & CategoryFilters,
@@ -261,9 +283,7 @@ export async function getCategoryPage(
   const to = from + pageSize - 1;
 
   // Inner-join hero_tags only when filtering by tag, so the base query is unchanged.
-  const selectCols = tagList.length
-    ? `${CATEGORY_LIST_COLUMNS}, hero_tags!inner(tag)`
-    : CATEGORY_LIST_COLUMNS;
+  const selectCols = tagJoinSelect(tagList);
 
   let q: any = supabase
     .from('heroes')
@@ -349,9 +369,12 @@ function applyListFacets(
 
   if (hasStats) q = q.gte('powerstats_total', 1);
 
-  for (const tag of tagList) q = q.eq('hero_tags.tag', tag);
+  // Aliased inner joins (t0, t1, …) so multiple tags AND correctly — see tagJoinSelect.
+  tagList.forEach((tag, i) => {
+    q = q.eq(`t${i}.tag`, tag);
+  });
 
-  if (search.trim()) q = q.or(`name.ilike.%${search.trim()}%,full_name.ilike.%${search.trim()}%`);
+  if (search.trim()) q = q.or(ilikeSearchOr(search));
 
   if (sort === 'az') q = q.order('name');
   else if (sort === 'power')
@@ -386,9 +409,7 @@ export async function getUniversePage(
   const from = page * pageSize;
   const to = from + pageSize - 1;
 
-  const selectCols = tagList.length
-    ? `${CATEGORY_LIST_COLUMNS}, hero_tags!inner(tag)`
-    : CATEGORY_LIST_COLUMNS;
+  const selectCols = tagJoinSelect(tagList);
 
   let q: any = supabase
     .from('heroes')
@@ -426,9 +447,7 @@ export async function getFranchisePage(
   const from = page * pageSize;
   const to = from + pageSize - 1;
 
-  const selectCols = tagList.length
-    ? `${CATEGORY_LIST_COLUMNS}, hero_tags!inner(tag)`
-    : CATEGORY_LIST_COLUMNS;
+  const selectCols = tagJoinSelect(tagList);
 
   let q: any = supabase
     .from('heroes')
@@ -562,9 +581,7 @@ export async function getTeamPage(
   const from = page * pageSize;
   const to = from + pageSize - 1;
 
-  const selectCols = tagList.length
-    ? `${CATEGORY_LIST_COLUMNS}, hero_tags!inner(tag)`
-    : CATEGORY_LIST_COLUMNS;
+  const selectCols = tagJoinSelect(tagList);
 
   let q: any = supabase
     .from('heroes')

--- a/src/lib/db/teams.ts
+++ b/src/lib/db/teams.ts
@@ -19,9 +19,12 @@ export interface TeamTally {
   myPick: string | null;
 }
 
-// Same daily-seed convention as src/lib/matchup.ts: same pair all day, new tomorrow.
+// Same daily-seed convention as src/lib/matchup.ts: same pair all day, new
+// tomorrow. UTC on purpose — the daily matchup/debate roll on the server's UTC
+// calendar (todayIso/dayStamp), so the team battle must too or "today"
+// disagrees across timezones around midnight.
 function dailySeed(d = new Date()): number {
-  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+  return d.getUTCFullYear() * 10000 + (d.getUTCMonth() + 1) * 100 + d.getUTCDate();
 }
 
 /** Deterministically pick two distinct featured teams for a day. Pure + tested. */

--- a/src/lib/db/trending.ts
+++ b/src/lib/db/trending.ts
@@ -398,9 +398,9 @@ export function trendingTitleMeta(t: TrendingTitle): string | null {
     const d = new Date(t.release_date);
     if (Number.isNaN(d.getTime())) return null;
     if (d.getTime() > Date.now()) {
-      return `Coming ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+      return `Coming ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}`;
     }
-    return String(d.getFullYear());
+    return String(d.getUTCFullYear());
   }
   return null;
 }
@@ -442,7 +442,7 @@ export function trendingBadge(
     if (!Number.isNaN(d.getTime()) && d.getTime() > Date.now()) {
       return {
         tone: 'coming',
-        label: `Coming ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`,
+        label: `Coming ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}`,
       };
     }
   }


### PR DESCRIPTION
Repo-wide bug hunt (four parallel audits: logic, data-layer/edge, hooks/effects, auth/nav). Only **confirmed, reproduced** bugs are here — each verified against the live PostgREST API or the test suite.

## 🔴 Data layer — both silently broke all four browse surfaces (category / universe / franchise / team)
`src/lib/db/heroes/categories.ts`

**1. Selecting 2+ tags returned an empty grid — actually a statement _timeout_.**
Two `.eq('hero_tags.tag', …)` against a single `hero_tags!inner(tag)` embed require **one** junction row to equal **both** tags — impossible. The inner join keeps zero rows; on the 34k-row table the planner times out, so the grid errors. Reachable from the tag chips, and worse on Anime/Video-games/Horror where an implicit media tag is folded in — so even **one** user tag = 2 filters = broken.
→ Fixed with one **aliased** inner join per tag (`t0`, `t1`, …) → correct "has ALL tags" AND semantics.
Verified live: `comic-relief ∩ wholesome` = **332** heroes (was 0/timeout).

**2. Search text with `,` `(` `)` errored the whole grid.**
Raw text interpolated into `.or()`; PostgREST reads `,` as its term delimiter and `()` as grouping. `Spider-Man (2099)` → malformed logic tree → **400**.
→ Value is now double-quoted (`\`/`"` escaped) so those chars are literal. Verified live (400 → 200).

## 🟠 Timezone — same class as the earlier daily-debate UTC fix
`src/lib/db/teams.ts`, `src/lib/db/trending.ts` — the daily team-battle seed and trending date/year badges used **device-local** date components, diverging from the server's UTC daily calendar in negative-UTC zones (wrong day/year, wrong daily matchup at midnight). Now UTC throughout.

## 🟠 Nav dead-ends — the most shareable/indexed surfaces
`app/title`, `app/issue`, `app/character`, `app/compare` — unguarded `router.back()` dead-ended (or threw `GO_BACK not handled`) when a shared/indexed link opens with an empty history stack. Primary back + sole-action error buttons now use the codebase's established `canGoBack() ? back() : replace(fallback)` guard.

## 🟢 Hardening
`src/hooks/useMatchupVote.ts` — reset pick/tally/loaded before the fetch so an in-place hero-pair swap can't render a new matchup as already-voted. Latent (all callers mount fresh), fixed for contract correctness.

## Tests
Adds tag-AND + search-escaping regression tests. `tsc` clean, **686** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)