### PR TITLE
docs: execution-ready specs for the 4-item hardening batch

### DIFF
--- a/docs/superpowers/specs/2026-07-15-auth-returnto-design.md
+++ b/docs/superpowers/specs/2026-07-15-auth-returnto-design.md
@@ -1,0 +1,173 @@
+# Auth returnTo — preserve location through sign-in
+
+**Status:** spec, ready to execute
+**Priority:** 3 of 4 in the 2026-07-15 hardening batch (see `2026-07-15-hardening-execution-plan.md`)
+**Size:** small (1 PR)
+
+## Problem
+
+A logged-out user who taps an auth-gated action (vote on a team battle, post a
+take, contribute, report) is `router.push`ed to `/(auth)/login` — and after
+signing in lands on `/explore`. The character/matchup they were on and the
+action they intended are both lost.
+
+The redirect to `/explore` is hardcoded in **three** places:
+
+1. `app/(auth)/login.tsx:64` — `router.replace('/explore')` after email sign-in
+2. `app/(auth)/login.web.tsx:58` — same, web
+3. `app/_layout.tsx:66` — the **AuthGate**: when `user && segments[0] === '(auth)'`
+   (or native root), it `router.replace('/explore')`
+
+Web OAuth is the only path that returns correctly today, via
+`redirectTo: window.location.href` in `useAuth.ts:139-149/170-180` — but even
+that captures the *login page's* URL, not the origin page, so it only works if
+the login URL itself carries the origin (which this spec makes true).
+
+## The critical gotcha (why the naive fix fails)
+
+You cannot just change the login handlers to `router.replace(target)`. The
+AuthGate effect (`app/_layout.tsx:57-73`, deps `[user, loading, segments, router]`)
+fires when `user` flips truthy **while the user is still on the `(auth)` screen**
+— `segments[0] === '(auth)'` is still true at that instant — so the gate's own
+`router.replace('/explore')` races and clobbers the intended target.
+
+**The fix must go through the gate:** the AuthGate itself must honor `returnTo`.
+This also makes OAuth work for free — OAuth never navigates from the login
+screen (native: ID-token flow + `onAuthStateChange`; web: full-page redirect
+back to the login URL), so the AuthGate is the *only* component positioned to
+redirect after OAuth, and it must know the target.
+
+## Design
+
+A `returnTo` query param on the login route, sanitized before use.
+
+```
+/(auth)/login?returnTo=%2Fversus%2Fteam%2Fabc123
+```
+
+### New module: `src/lib/loginRedirect.ts`
+
+```ts
+import type { Href } from 'expo-router';
+
+/**
+ * Validates a raw returnTo param into a safe internal path, or null.
+ * Rejects anything that isn't a same-app absolute path: external URLs,
+ * protocol-relative ('//evil.com'), auth-group paths (redirect loops),
+ * and the root ('/' is the landing page — an authed user belongs on /explore).
+ */
+export function sanitizeReturnTo(raw: string | string[] | undefined): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (!v || typeof v !== 'string') return null;
+  if (!v.startsWith('/') || v.startsWith('//')) return null;
+  if (v === '/' || v.startsWith('/(auth)')) return null;
+  return v;
+}
+
+/** Href for the login screen, carrying the page to return to after sign-in. */
+export function loginHref(returnTo?: string | null): Href {
+  const clean = sanitizeReturnTo(returnTo ?? undefined);
+  return clean
+    ? { pathname: '/(auth)/login', params: { returnTo: clean } }
+    : '/(auth)/login';
+}
+```
+
+(Match house style: TypeScript, no `any`; keep the comment tone.)
+
+### Change 1 — AuthGate honors returnTo (`app/_layout.tsx:57-73`)
+
+In `AuthGate`, read the param with `useGlobalSearchParams()` (global, not local
+— AuthGate is not the route component) and use it as the redirect target:
+
+```ts
+const params = useGlobalSearchParams<{ returnTo?: string | string[] }>();
+// inside the effect:
+if (user && (inAuthGroup || atRoot)) {
+  router.replace(sanitizeReturnTo(params.returnTo) ?? '/explore');
+}
+```
+
+Add `params.returnTo` to the effect deps. **Do not** change any other gate
+logic (the `settled` mechanism, loading guard, native `atRoot` all stay).
+
+Check whether `app/_layout.web.tsx` has its own gate with the same hardcoded
+`/explore` — if so, apply the identical change there.
+
+### Change 2 — login email handlers (`login.tsx:56-66`, `login.web.tsx:49-60`)
+
+```ts
+const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
+// on success:
+router.replace(sanitizeReturnTo(returnTo) ?? '/explore');
+```
+
+Belt-and-braces with Change 1 (whichever fires first wins; both compute the
+same target). "Browse without signing in" (`login.tsx:230`) stays `/explore`.
+
+### Change 3 — thread returnTo through the auth group's internal links
+
+- login ↔ signup switch links (`login` bottom row, `signup.tsx:127/260`,
+  `signup.web.tsx:73/201`): pass the current `returnTo` param along so the
+  param survives switching forms. Signup itself does **not** redirect (it parks
+  on the email-confirmation card — `signup.tsx:63`); if the user then goes
+  "Back to Sign In", the param is still there. That's the graceful degradation:
+  a confirmation-link round-trip through the user's inbox does not preserve
+  returnTo, and that's acceptable (non-goal).
+- forgot-password links: pass it through the same way only if trivially easy;
+  otherwise skip (out of scope).
+
+### Change 4 — the 13 gate call sites pass their location
+
+Each caller adds `usePathname()` (from `expo-router`) and replaces
+`router.push('/(auth)/login')` with `router.push(loginHref(pathname))`:
+
+| Site | Action |
+| --- | --- |
+| `app/character/[id].tsx:1685`, `:1705` | Contribute / Report |
+| `app/character/[id].web.tsx:2394`, `:2408` | Contribute / Report |
+| `app/versus/team/[battleId].tsx:21`, `.web.tsx:20` | Team-battle vote |
+| `src/components/takes/TakesSection.tsx:179` (`goToLogin`, used at `:182/:271/:292`) | Take submit / CTA / report |
+| `app/(tabs)/explore.web.tsx:1505` | Favourites invite |
+| `app/(tabs)/profile.tsx:225`, `profile.web.tsx:100` | Guest profile sign-in |
+| `src/components/web/TopBar.tsx:393` | Top-bar sign-in |
+| `src/components/landing/LandingPage.dom.tsx:2771` | Landing sign-in — pathname is `/`, which `sanitizeReturnTo` rejects → plain `/(auth)/login`. Correct; leave it using `loginHref(pathname)` anyway for uniformity. |
+
+Line numbers are as of commit `d4b653e4` — re-locate by grepping
+`(auth)/login` if drifted.
+
+### Why web OAuth now works end-to-end
+
+The user is on `/login?returnTo=%2Fversus%2Fteam%2Fabc` when they tap Google.
+`useAuth` sends `redirectTo: window.location.href` — which now *includes* the
+returnTo param. After the OAuth round-trip the browser lands back on that same
+login URL with a session; the AuthGate fires (`user && inAuthGroup`) and
+replaces to the sanitized returnTo. No changes to `useAuth.ts` needed.
+
+## Non-goals
+
+- **Intent resume** (auto-reopening the contribute sheet / re-casting the vote
+  after login). Location-only. An `intent` param can layer on later.
+- Preserving returnTo across the signup email-confirmation round-trip.
+- Any visual change. The login/signup screens change zero pixels.
+
+## Tests
+
+New `__tests__/lib/loginRedirect.test.ts` (pure logic — no mocks needed):
+
+- accepts `/character/123`, `/versus/team/abc?x=y`
+- rejects: `undefined`, `''`, `https://evil.com`, `//evil.com`, `/`,
+  `/(auth)/login`, array input takes first element
+- `loginHref(null)` → `'/(auth)/login'`; `loginHref('/character/9')` → object
+  with params
+
+## Acceptance criteria
+
+1. Logged out, on `/versus/team/<id>`, tap vote → login screen → email sign-in
+   → back on `/versus/team/<id>`.
+2. Same flow via Google OAuth on web → back on the team battle page.
+3. Sign in from the top bar while browsing `/character/123` → return to it.
+4. Sign in with no returnTo (direct visit to /login) → `/explore` (unchanged).
+5. `yarn test:ci` green; `npx tsc --noEmit` clean.
+6. A crafted `/login?returnTo=https://evil.com` (or `//evil.com`) lands on
+   `/explore`, never off-site.

--- a/docs/superpowers/specs/2026-07-15-comicvine-collision-gate-design.md
+++ b/docs/superpowers/specs/2026-07-15-comicvine-collision-gate-design.md
@@ -1,0 +1,187 @@
+# ComicVine collision gate — publisher plausibility check (#65)
+
+**Status:** spec, ready to execute
+**Priority:** 4 of 4 in the 2026-07-15 hardening batch (see `2026-07-15-hardening-execution-plan.md`)
+**Closes:** [#65](https://github.com/ginoleeswan/hero/issues/65)
+**Size:** medium-large (1 PR: two edge functions + migration + admin queue panel)
+
+## Problem (from #65, confirmed in code)
+
+`enrich-comicvine-batch` matches heroes to ComicVine by **exact lowercased name
+only** and takes the most-published hit — no franchise/publisher plausibility
+check. Observed 2026-07-13: hand-curated **Aragorn** (publisher
+`'J. R. R. Tolkien'`) was matched to ComicVine id 6810 — a **Marvel winged
+horse** — which overwrote `publisher, summary, image_url, powers, description,
+origin, issue_count, creators, enemies, friends, movies, teams, first_issue_*`
+and reported `comicvine_status='done'`. A wrong match is indistinguishable from
+a right one; nothing flags it.
+
+Not actively spreading (pending queue is currently drained), but every future
+ingestion batch re-arms it, and there is **static historical debt** (~80
+suspicious rows by the smell test below).
+
+## The exact bug locus (two hand-duplicated "drift-twins" — keep in sync)
+
+1. `supabase/functions/enrich-comicvine-batch/index.ts:148-165` (the 6-hourly
+   cron drain; batch selection at `:380-386` pulls
+   `comicvine_status='pending'` ordered by `issue_count`).
+2. `supabase/functions/get-comicvine-hero/index.ts:157-178` (live per-view
+   fallback — byte-identical decision block).
+
+Both do: filter results to exact name equality (fallback: name-before-`(`
+equality) → sort by `count_of_issue_appearances` desc → take `[0]` →
+unconditionally `'done'`. The search `field_list` is only
+`id,name,count_of_issue_appearances` — **publisher isn't even fetched at
+decision time** (it arrives on the later detail call, after commit:
+`enrich-comicvine-batch:178`, `get-comicvine-hero:200`).
+
+## Design
+
+### 1. Shared matcher: `supabase/functions/_shared/comicvineMatch.ts` (NEW)
+
+Kill the drift-twin problem: extract ONE matcher both functions import
+(`_shared/` already exists). Signature:
+
+```ts
+export type MatchDecision =
+  | { kind: 'match'; cvId: string }
+  | { kind: 'needs_review'; reason: string }
+  | { kind: 'unmatched' };
+
+export function pickComicvineMatch(
+  results: Array<Record<string, unknown>>, // CV /characters list results
+  hero: { name: string; publisher: string | null },
+): MatchDecision;
+```
+
+Both call sites change their list-call `field_list` to
+`id,name,count_of_issue_appearances,publisher` (CV returns publisher as an
+object with `.name` — same shape already read post-detail at
+`enrich-comicvine-batch:178`).
+
+Decision rules (in order):
+
+1. Exact-name filter (existing logic: trim/lowercase equality, else
+   base-before-`(` equality). Empty → `unmatched` (unchanged).
+2. **Publisher gate.** Normalize both sides with a small
+   `normalizePublisher()`: lowercase, strip punctuation, and collapse known
+   aliases — at minimum `marvel*→marvel`, `dc*→dc`, `dark horse*→dark horse`,
+   `image*→image`. Comparison = normalized equality OR one side containing the
+   other (`'marvel'` vs `'marvel comics'`).
+   - Hero has a publisher AND ≥1 candidate agrees → keep only agreeing
+     candidates, sort by popularity, `match` on `[0]`.
+   - Hero has a publisher AND **no** candidate agrees → `needs_review`
+     (reason: `publisher mismatch: hero=<p> cv=<top candidate p>`). **Never**
+     auto-apply a disagreeing match — this is the Aragorn case.
+   - Hero has NO publisher (null / `'Company-Licensed'` / `'Creator-Owned'` —
+     the unbranded sentinels from `20260714143052_index_unbranded_worklist.sql`):
+     single exact candidate → `match`; multiple candidates with **different**
+     normalized publishers → `needs_review` (reason: `ambiguous: N same-name
+     candidates`); multiple with the same publisher → `match` on most popular.
+3. When `hero.comicvine_id` is already set (the `if (cvId)` branch), the gate
+   does not run — an explicit id is trusted (that's how admin resolution works,
+   see §4).
+
+### 2. New status: `needs_review`
+
+- Migration: extend the `heroes_comicvine_status_check` CHECK constraint
+  (introduced `20260612130000`, last widened `20260618120000`) to
+  `('pending','done','empty','failed','unmatched','needs_review')`. Add a
+  partial index matching the house pattern
+  (`20260713140000_index_heroes_comicvine_status_pending.sql`):
+  `create index … on heroes (comicvine_status) where comicvine_status = 'needs_review';`
+- `enrich-comicvine-batch`: add `'needs_review'` to `EnrichOutcome`
+  (`index.ts:76`), update the status-semantics comment block (`:66-75`), and on
+  that outcome write `comicvine_status='needs_review'` **without touching any
+  other column**. Count it in the `enrichment_runs` live counters the way
+  `unmatched` is counted today.
+- `get-comicvine-hero` (live path): on `needs_review`, set the status (so the
+  admin queue sees it) and return `NULL_RESPONSE` exactly like `markUnmatched()`
+  does — the character page renders un-enriched, no user-visible error.
+- Rows in `needs_review` must NOT be re-picked by the drain (batch selection
+  only pulls `pending`/`failed` — already true; verify).
+
+Apply via `mcp__supabase__apply_migration`; regenerate
+`src/types/database.generated.ts` after.
+
+### 3. Admin review queue — the human decision surface
+
+Reuse the **NeedsYou pattern**
+(`src/components/admin/health/domains/NeedsYou.tsx` — the wikidata ambiguous
+resolver: candidate rows with inline accept + manual-ID escape hatch). New
+panel `ComicvineReview` in the same domain area (wire it wherever the
+enrichment pipeline panels live — `PipelinesDomain.tsx` — matching how
+NeedsYou/DuplicatesPanel are surfaced).
+
+- List: heroes with `comicvine_status='needs_review'` (id, name, publisher,
+  portrait via `HeroThumb` from `atoms.tsx`).
+- Candidates: fetch live via the existing `cv-search` edge function (no new
+  candidates table — same approach as NeedsYou's live `fetchWikidataEntities`).
+  Show name, publisher, issue count, deck.
+- Actions per hero:
+  - **Accept candidate** → set `comicvine_id=<picked>`,
+    `comicvine_status='pending'` → the drain enriches it by explicit id on its
+    next pass (trusted-id branch, no gate).
+  - **Manual ID** input → same write.
+  - **Not on ComicVine** → `comicvine_status='unmatched'` (terminal; the
+    interim guardrail already uses this for hand-curated rows).
+- Writes go through `src/lib/db/` (new module or extend the existing admin
+  catalog-health module — follow how `NeedsYou` persists its resolution), and
+  must be admin-gated the same way (`is_admin` RPC pattern per
+  `ReviewDomain.tsx`).
+
+### 4. One-time audit of historical debt
+
+In the same migration (or a follow-up SQL via MCP), flag the smell-test rows
+for human review in the new queue instead of a spreadsheet:
+
+```sql
+update heroes set comicvine_status = 'needs_review'
+where comicvine_status = 'done'
+  and id not like 'cv-%'
+  and publisher in ('Marvel Comics', 'DC Comics')   -- adjust to actual values: check `select distinct publisher` first
+  and franchise is not null;
+```
+
+**Before running:** verify the predicate against prod (`select count(*)` ≈ 80
+per #65) and eyeball 5 rows. This does NOT revert their data — it just surfaces
+them in the queue; the human either re-accepts (status back to `done` via
+accept → pending → drain re-enriches from the confirmed id) or corrects. Rows
+the admin confirms wrong get the Aragorn treatment (accept correct id, or
+`unmatched` + manual data repair — data repair itself is out of scope here).
+
+## Non-goals
+
+- Fixing CV-sourced *content* pollution on correct matches (Gandalf's
+  friends-array crossover noise) — that's CV's data, different problem.
+- A confidence-score model. Publisher agreement is the 95% gate; the queue
+  catches the rest.
+- Reverting/repairing historical wrong rows automatically.
+
+## Tests
+
+The matcher is now a pure importable function — unit-test it in Deno or port a
+mirror to jest if edge-function testing is awkward; minimum coverage:
+
+- Aragorn case: hero publisher `J. R. R. Tolkien`, single Marvel candidate →
+  `needs_review` (NOT match).
+- Agreement: hero `Marvel Comics` + candidates from Marvel and DC → picks the
+  Marvel one even if the DC one is more published.
+- Alias: hero `Marvel` vs CV `Marvel Comics` → agree.
+- No-publisher hero + single candidate → match; + multi-publisher candidates →
+  `needs_review`; + same-publisher candidates → most popular.
+- No exact hit → `unmatched`.
+
+## Acceptance criteria
+
+1. Re-running the Aragorn scenario yields `needs_review`, zero columns written.
+2. A normal unambiguous hero (e.g. a Marvel hero with one CV hit) still
+   enriches `done` in one drain pass — throughput unharmed.
+3. The admin queue lists `needs_review` rows with live CV candidates; accepting
+   one leads (after the next drain pass) to `done` with the chosen id.
+4. `get-comicvine-hero` on a mismatch: character page loads un-enriched, row
+   flagged `needs_review`, no error surfaced to the user.
+5. Historical smell-test rows appear in the queue (count sanity ≈ 80).
+6. Both functions import the shared matcher — the duplicated decision blocks
+   are deleted. Deployed via `mcp__supabase__deploy_edge_function`.
+7. Migration applied via MCP + types regenerated; `yarn test:ci` green.

--- a/docs/superpowers/specs/2026-07-15-hardening-execution-plan.md
+++ b/docs/superpowers/specs/2026-07-15-hardening-execution-plan.md
@@ -1,0 +1,97 @@
+# Hardening batch — execution plan (2026-07-15)
+
+Four specs, four PRs, executed **in this order**. Each spec is self-contained
+with exact file:line anchors (as of commit `d4b653e4`), decided trade-offs, and
+acceptance criteria — **do not relitigate scope decisions**; they were made
+deliberately with the owner.
+
+| # | Spec | Size | Blocking owner action |
+| --- | --- | --- | --- |
+| 1 | [`2026-07-15-auth-returnto-design.md`](2026-07-15-auth-returnto-design.md) | S | none |
+| 2 | [`2026-07-15-sentry-observability-design.md`](2026-07-15-sentry-observability-design.md) | M | Sentry DSN + auth token |
+| 3 | [`2026-07-15-comicvine-collision-gate-design.md`](2026-07-15-comicvine-collision-gate-design.md) | M-L | none |
+| 4 | [`2026-07-15-web-push-daily-design.md`](2026-07-15-web-push-daily-design.md) | L | VAPID keys + secrets |
+
+**Why this order:** returnTo is small and self-contained (warm-up, instant user
+value). Sentry next so the two bigger features ship with observability. The
+ComicVine gate before push because it has no owner dependency. Push last — it
+has the most moving parts (SW + migration + cron + edge function + UI) and its
+failures should land in an already-working Sentry.
+
+Each PR: branch off `main` → PR → owner merges. Never commit to `main`.
+
+## Hard rules (violating any of these is a defect)
+
+1. **yarn only** — never npm/bun. Expo-managed packages via `yarn expo install`.
+2. **Migrations** via `mcp__supabase__apply_migration` with a matching file in
+   `supabase/migrations/YYYYMMDDHHMMSS_description.sql`; regenerate
+   `src/types/database.generated.ts` (`mcp__supabase__generate_typescript_types`)
+   after every migration. Never edit the generated file by hand.
+3. **Edge functions** deployed via `mcp__supabase__deploy_edge_function`.
+4. Screens never import `supabase` directly — all DB access through
+   `src/lib/db/` (or `src/lib/` for non-table concerns like push).
+5. TypeScript strict habits: no `any`, `unknown` for caught errors; functional
+   components; `StyleSheet.create`; fonts `Flame-Bold`/`FlameSans-Regular`/
+   `Nunito_*`; clamped Flame text needs `lineHeight ≥ 1.22× fontSize`.
+6. Platform-split screens (`foo.tsx` + `foo.web.tsx`): shared logic lives in a
+   platform-neutral hook/lib — never duplicate effects across the pair.
+7. Before finishing any PR: `npx tsc --noEmit` clean AND `yarn test:ci` green
+   (baseline: 686 passing). New logic gets unit tests per each spec's Tests
+   section.
+8. Any new SQL touching user-facing reads: benchmark as the **anon role**
+   (`set local role anon`), not postgres — see the RLS planner-shackle lesson.
+9. Commit trailer: `Co-Authored-By:` the executing model, per repo convention.
+10. Line-number anchors in the specs may drift — re-locate by grepping the
+    quoted code, don't trust offsets blindly.
+
+## Owner setup (can happen in parallel, blocks only the marked step)
+
+- **Sentry (blocks PR 2 going live, not the code):** create org/project →
+  `EXPO_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` into Vercel env and EAS
+  secrets. The code must no-op gracefully without them, so the PR can merge
+  first.
+- **VAPID (blocks PR 4's send path):** `npx web-push generate-vapid-keys` →
+  public key to Vercel env as `EXPO_PUBLIC_VAPID_PUBLIC_KEY`; both keys to
+  Supabase function secrets (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`).
+
+## Verification gate per PR (in addition to each spec's acceptance criteria)
+
+```
+npx tsc --noEmit
+yarn test:ci
+yarn expo export -p web        # PRs 2 and 4 only (metro/SW changes) — must succeed
+```
+
+For PR 3 additionally: run the matcher unit tests, and verify against prod (via
+MCP `execute_sql`) that the smell-test predicate count ≈ 80 BEFORE running the
+audit UPDATE.
+
+## Context you'd otherwise have to rediscover
+
+- The AuthGate (`app/_layout.tsx:57-73`) is a second redirect that races any
+  post-login navigation — spec 1's design routes returnTo THROUGH the gate.
+  Both root layouts exist (`_layout.tsx` native, `_layout.web.tsx` web); check
+  both for gate logic.
+- The repo already has self-hosted error reporting
+  (`src/lib/db/clientErrors.ts` + web ErrorBoundary in `_layout.web.tsx:29-49`)
+  — Sentry goes BESIDE it, never replaces it. Native has no boundary at all.
+- `metro.config.js` has a custom SVG transformer + web-stub resolver that must
+  survive the `getSentryExpoConfig` wrap.
+- `daily_debate` (UTC-keyed, cron-guaranteed) is the ONLY server-authoritative
+  daily surface; the team battle is client-computed — that's why push v1 is
+  debate-only.
+- The ComicVine matcher exists in TWO byte-identical copies (`enrich-comicvine-batch`
+  and `get-comicvine-hero`) — spec 3 extracts it to
+  `supabase/functions/_shared/`; never fix one copy alone.
+- The cron + `net.http_post` + hardcoded anon-bearer pattern:
+  `supabase/migrations/20260712100000_schedule_pull_social_stats.sql` is the
+  canonical template.
+- Admin review-queue UI precedent: `NeedsYou.tsx` (candidates + inline accept +
+  manual-ID escape hatch), `ReviewDomain.tsx` (approve/reject + admin RPC),
+  `DuplicatesPanel.tsx` (same-name disambiguation).
+
+## Issue hygiene
+
+- PR 3 closes #65 (`Closes #65` in the PR body).
+- After all four merge: update `docs/ROADMAP.md` (add a "Hardening" shipped
+  bullet; move #65 out of Data quality).

--- a/docs/superpowers/specs/2026-07-15-sentry-observability-design.md
+++ b/docs/superpowers/specs/2026-07-15-sentry-observability-design.md
@@ -1,0 +1,163 @@
+# Production error reporting — Sentry + native ErrorBoundary
+
+**Status:** spec, ready to execute
+**Priority:** 1 of 4 in the 2026-07-15 hardening batch (see `2026-07-15-hardening-execution-plan.md`)
+**Size:** medium (1 PR + owner setup)
+
+## What exists today (do not duplicate it)
+
+The repo already has a **self-hosted** error feed — keep it, Sentry slots
+*alongside*:
+
+- `src/lib/db/clientErrors.ts` — `recordClientError(kind, message, opts)`
+  inserts into the Supabase `client_errors` table (deduped via a `seen` Set,
+  throttled `MAX_PER_LOAD = 25`); `installGlobalErrorCapture()` attaches
+  `window` `error` + `unhandledrejection` listeners (**web only** — no-op on
+  native). Feeds the command-center Errors domain via
+  `admin_recent_client_errors` RPC.
+- `app/_layout.web.tsx:29-49` — a real `ErrorBoundary` export (expo-router
+  route boundary): on-brand crash screen (`#0b1820` bg, `Flame-Regular` title
+  "Something went wrong", `Nunito_400Regular` body, orange "Try again" →
+  `retry`), logs via `recordClientError('boundary', …)`. Styles at `:51-85`.
+- `installGlobalErrorCapture()` is called from `_layout.web.tsx:201` (cleanup
+  `:205`).
+
+**The actual gaps:**
+1. **Native has nothing** — no ErrorBoundary export in `app/_layout.tsx`, no
+   global JS error handler (`ErrorUtils` never touched). A native render crash
+   is a silent white screen.
+2. No aggregation/alerting/release-tagging — `client_errors` is a raw feed you
+   must remember to read; minified web stacks are unreadable (no source maps).
+
+## Design
+
+### Package + config
+
+- `yarn expo install @sentry/react-native` (the deprecated `sentry-expo` is NOT
+  used; note `package.json` `transformIgnorePatterns` already whitelists
+  `sentry-expo` — leftover template naming, harmless, leave it, but add
+  `@sentry/react-native` to that allowlist).
+- `app.config.ts` plugins array (`:52-105`): add
+  `['@sentry/react-native/expo', { organization: '<org>', project: 'mythique' }]`.
+- `metro.config.js`: wrap with `getSentryExpoConfig` from
+  `@sentry/react-native/metro` **carefully** — this file has a custom SVG
+  transformer (`react-native-svg-transformer/expo`), custom
+  `sourceExts`/`assetExts` moves, and a custom `resolver.resolveRequest`
+  (`:23-28`) aliasing native-only modules to `src/web-stubs/*` on web.
+  `getSentryExpoConfig(__dirname)` replaces `getDefaultConfig`; re-apply every
+  customization on top of it. **Verify after: `yarn expo export -p web`
+  succeeds and `src/web-stubs` aliasing still works (spot-check the export has
+  no native module in the bundle).**
+
+### Init: new `src/lib/sentry.ts`
+
+```ts
+import * as Sentry from '@sentry/react-native';
+
+const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+// No-op without a DSN (local dev, tests, forks) — same fail-soft posture as
+// the sitemap generator. Errors-only: tracing/replay off to protect the
+// hard-won landing bundle size (three.js split saved 911 KB; don't give it
+// back to an APM bundle).
+export function initSentry(): void {
+  if (!dsn || process.env.NODE_ENV === 'test') return;
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 0,
+    enableAutoPerformanceTracing: false,
+    sendDefaultPii: false,
+  });
+}
+
+export { Sentry };
+```
+
+Call `initSentry()` at module scope (top, before component definitions) in
+**both** `app/_layout.tsx` and `app/_layout.web.tsx`.
+
+Env: add `EXPO_PUBLIC_SENTRY_DSN=` to `.env.example`; test value in
+`jest.setup.env.js` is NOT needed (init guards on NODE_ENV).
+
+### Native ErrorBoundary (the real gap): `app/_layout.tsx`
+
+Add an `export function ErrorBoundary({ error, retry }: ErrorBoundaryProps)`
+mirroring the web one at `_layout.web.tsx:29-49` — same visual (port the `eb`
+styles), same `recordClientError('boundary', …)` call, plus
+`Sentry.captureException(error)`. Note `recordClientError` is currently
+web-gated internally? — check: the *install* function is web-only but
+`recordClientError` itself inserts via supabase-js and works on native; if it
+has a Platform guard, remove it for the insert path.
+
+### Wire Sentry beside the existing hooks (never instead of)
+
+- `_layout.web.tsx` ErrorBoundary: add `Sentry.captureException(error)` next to
+  the existing `recordClientError` call.
+- `src/lib/db/clientErrors.ts`: in `recordClientError`, after the dedupe/
+  throttle checks pass, also `Sentry.captureMessage`/`captureException` — this
+  gives Sentry the same deduped stream the self-hosted feed gets, including the
+  web global handlers, with zero new listeners. (Import from `src/lib/sentry`
+  so the no-DSN guard applies.)
+- Native global fatal-error coverage comes free from `Sentry.init` (it installs
+  the `ErrorUtils` handler). Do NOT add a hand-rolled native handler.
+- Optionally tag the route: in `AnalyticsProvider` (`src/components/Analytics.tsx`
+  + `.web.tsx`), `Sentry.setTag('route', route)` inside the existing page-view
+  effect. Cheap, high-value for triage.
+
+### Source maps (web) — fail-soft, same posture as the sitemap
+
+`vercel.json` buildCommand becomes:
+
+```
+yarn expo export -p web && node scripts/generate-sitemap.mjs && node scripts/upload-sourcemaps.mjs
+```
+
+New `scripts/upload-sourcemaps.mjs`: if `SENTRY_AUTH_TOKEN` is absent, log and
+`exit 0` (never break a deploy). Otherwise run `npx sentry-cli sourcemaps
+inject dist && npx sentry-cli sourcemaps upload dist --org <org> --project
+mythique --release <version>` using `version` from `app.config.ts` (`1.0.0`) +
+the Vercel commit SHA (`process.env.VERCEL_GIT_COMMIT_SHA`). `sentry-cli` as a
+devDependency.
+
+Native source maps (EAS builds) come via the config plugin automatically when
+`SENTRY_AUTH_TOKEN` is present at build time — no extra work; note it in the
+owner checklist.
+
+### Jest
+
+`__mocks__/@sentry/react-native.js` following the repo's plain-CommonJS mock
+style (see `__mocks__/svgMock.js`): no-op `init`, `captureException`,
+`captureMessage`, `setTag`, `wrap: (x) => x`. Wire via `moduleNameMapper` in
+`package.json` jest block (`:127-132`).
+
+## Owner actions (blocking, ~10 min)
+
+1. Create a Sentry org/project (platform: React Native) → copy the **DSN**.
+2. Vercel env: `EXPO_PUBLIC_SENTRY_DSN` (all envs), `SENTRY_AUTH_TOKEN`
+   (build). EAS secrets: same two, for native builds.
+3. `.env.local`: add the DSN (optional for local dev).
+
+## Non-goals
+
+- Performance tracing, session replay, profiling (all off — bundle discipline).
+- Replacing `client_errors` / the admin Errors domain (it stays the in-app feed).
+- Alert-rule configuration inside Sentry (owner can do it in the UI later).
+
+## Tests / verification
+
+- `yarn test:ci` green with the mock; `npx tsc --noEmit` clean.
+- `yarn expo export -p web` succeeds; bundle diff sanity: main entry chunk
+  growth < ~40 KB gzip (errors-only SDK). If it's way more, tracing got
+  enabled — fix the init.
+- Manual: with DSN set, throw from a dev screen → event in Sentry with the
+  `route` tag; boundary screens still render on both platforms.
+
+## Acceptance criteria
+
+1. Native root exports an ErrorBoundary visually matching the web one; a thrown
+   render error on native shows the branded screen (not a white screen).
+2. With no DSN configured, the app behaves exactly as today (init no-ops, zero
+   network calls to Sentry).
+3. With DSN: web boundary errors, web global errors/rejections, and native
+   fatal JS errors all arrive in Sentry; `client_errors` rows still written.
+4. A deploy without `SENTRY_AUTH_TOKEN` still succeeds (fail-soft upload step).

--- a/docs/superpowers/specs/2026-07-15-web-push-daily-design.md
+++ b/docs/superpowers/specs/2026-07-15-web-push-daily-design.md
@@ -1,0 +1,221 @@
+# Web push — daily-debate re-engagement channel
+
+**Status:** spec, ready to execute
+**Priority:** 2 of 4 in the 2026-07-15 hardening batch (see `2026-07-15-hardening-execution-plan.md`)
+**Size:** large (1 PR + owner setup). Execute AFTER the Sentry PR (push failures should be observable).
+
+## Problem
+
+All of Mythique's retention mechanics are daily — daily debate/matchup, daily
+team battle — but there is **no re-engagement channel**: no push (no
+`expo-notifications`, no service worker), no email. Nothing brings a user back
+tomorrow.
+
+## Scope decisions (made deliberately — don't relitigate during execution)
+
+- **Web push only, v1.** Mobile-web is the product surface; native push needs
+  `expo-notifications` + store-build round-trips — later phase.
+- **Signed-in subscribers only, v1.** The opt-in lives in Settings (already
+  auth-gated: `settings.web.tsx:144` redirects guests). This keeps the table on
+  the standard RLS owner pattern and enables personalization. Anonymous
+  subscriptions (the `voter_key` pattern) are a later phase.
+- **Daily debate only, v1.** It is the one daily surface that is
+  server-authoritative (`daily_debate` table, row guaranteed by the
+  `daily-debate-roll` cron at 00:05 UTC). The daily team battle is client-only
+  (in-JS `dailySeed()` over featured teams — `src/lib/db/teams.ts`) and is
+  excluded until it gets a server-side pick.
+- **One send per day at 15:00 UTC** (morning US / evening EU), well after the
+  00:05 UTC roll. Cron name: `send-daily-push`.
+
+## Known platform facts (from research; verified 2026-07-15)
+
+- `public/manifest.json` is already a valid standalone PWA manifest with
+  192/512 icons — copied to `dist/`. No `gcm_sender_id` needed (VAPID).
+- **No service worker exists anywhere**; Expo static export does not emit one.
+- `app/+html.tsx` is the document shell (Expo `output: 'static'`) — already
+  injects the manifest link; inline scripts use `dangerouslySetInnerHTML`
+  (see its existing `rootStyle` pattern). This is where SW registration goes.
+- `vercel.json`: real files in `dist/` are served ahead of the SPA catch-all
+  rewrite, so `public/sw.js` → `dist/sw.js` → served at `/sw.js` correctly.
+  The `Permissions-Policy` header does NOT restrict push/notifications — no
+  header change needed.
+- Cron pattern (canonical example
+  `supabase/migrations/20260712100000_schedule_pull_social_stats.sql`):
+  `cron.schedule(name, sched, $$ select net.http_post(url := '<fn url>',
+  headers := …anon bearer…, body := …) $$)`. Functions do privileged work via
+  their own `SUPABASE_SERVICE_ROLE_KEY`; browser-facing functions need the
+  CORS pattern from `ig-sync/index.ts`, cron-only ones don't.
+- iOS Safari limitation: web push requires the PWA to be installed to the home
+  screen (iOS 16.4+). Accept it; the settings row copy should not promise
+  more than the platform can deliver.
+
+## Design
+
+### 1. Migration: `push_subscriptions` (+ cron)
+
+New migration (via `mcp__supabase__apply_migration`, then regenerate
+`database.generated.ts`):
+
+```sql
+create table public.push_subscriptions (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users (id) on delete cascade,
+  endpoint    text not null unique,
+  p256dh      text not null,
+  auth        text not null,
+  created_at  timestamptz not null default now(),
+  last_ok_at  timestamptz,          -- stamped by the sender on success
+  failed_at   timestamptz           -- stamped on transient failure; 404/410 rows are DELETED
+);
+alter table public.push_subscriptions enable row level security;
+-- Owner pattern, same as user_favourites (20260404000000_create_heroes_favourites_profiles.sql):
+create policy "push_select" on public.push_subscriptions
+  for select to authenticated using (auth.uid() = user_id);
+create policy "push_insert" on public.push_subscriptions
+  for insert to authenticated with check (auth.uid() = user_id);
+create policy "push_delete" on public.push_subscriptions
+  for delete to authenticated using (auth.uid() = user_id);
+create index push_subscriptions_user_idx on public.push_subscriptions (user_id);
+```
+
+Same migration schedules the cron (mirror the pull-social-stats file verbatim,
+new name/url/time):
+
+```sql
+select cron.schedule('send-daily-push', '0 15 * * *', $cron$ … net.http_post to
+  https://rpvgqfaeiowisdubgxkg.supabase.co/functions/v1/send-daily-push … $cron$);
+```
+
+(Copy the anon-bearer header block exactly from the pull-social-stats
+migration — same key, same shape.)
+
+### 2. Service worker: `public/sw.js`
+
+Plain JS (it's served verbatim, not bundled):
+
+```js
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() ?? {};
+  event.waitUntil(
+    self.registration.showNotification(data.title ?? 'Mythique', {
+      body: data.body ?? '',
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      data: { url: data.url ?? '/versus' },
+    }),
+  );
+});
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? '/';
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((tabs) => {
+      const existing = tabs.find((t) => 'focus' in t);
+      return existing ? (existing.navigate(url), existing.focus()) : clients.openWindow(url);
+    }),
+  );
+});
+```
+
+No fetch handler, no caching — this SW exists solely for push (don't
+accidentally become an offline cache with stale-bundle problems).
+
+### 3. Registration in `app/+html.tsx`
+
+Inline script via `dangerouslySetInnerHTML` (same pattern as `rootStyle`):
+`if ('serviceWorker' in navigator) navigator.serviceWorker.register('/sw.js')`
+wrapped in a `load` listener. Registration alone shows no prompt — permission
+is only requested from the settings toggle.
+
+### 4. Client: `src/lib/push.ts` (platform-neutral API, web implementation)
+
+```
+isPushSupported(): boolean            // 'serviceWorker' in navigator && 'PushManager' in window
+getSubscriptionState(): Promise<'subscribed' | 'unsubscribed' | 'denied' | 'unsupported'>
+subscribeToPush(userId: string): Promise<{ error: string | null }>
+unsubscribeFromPush(): Promise<{ error: string | null }>
+```
+
+`subscribeToPush`: `Notification.requestPermission()` →
+`registration.pushManager.subscribe({ userVisibleOnly: true,
+applicationServerKey: urlBase64ToUint8Array(process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY!) })`
+→ upsert `{ user_id, endpoint, p256dh, auth }` into `push_subscriptions`
+**directly via supabase-js** (RLS owner policy — no edge function needed for
+subscribe; screens-never-import-supabase rule satisfied because this is
+`src/lib/`). `unsubscribeFromPush`: `subscription.unsubscribe()` + delete the
+row by endpoint. Include the standard `urlBase64ToUint8Array` helper. Guard
+every browser API behind `isPushSupported()`; on native the module's functions
+return `'unsupported'`/no-op (keep the file platform-neutral — no `.web.tsx`
+split needed since it's a lib, not a view).
+
+### 5. Settings UI
+
+`app/settings.web.tsx` (sections at `:150-218`): new **Notifications**
+`SectionShell` between Account and Support, one row: "Daily matchup alert" with
+a `Switch` (RN's `Switch` works on web). `SettingRow` currently has no toggle
+variant — add an optional `toggle`/`onToggle` prop pair to it rather than a new
+component. States: unsupported → row hidden; permission denied → row disabled
+with sub-copy "Notifications are blocked in your browser settings"; otherwise
+reflect `getSubscriptionState()` (fetch in an effect with a cancelled flag —
+house style). `app/settings.tsx` (native): hide the section entirely
+(`isPushSupported()` false).
+
+### 6. Edge function: `supabase/functions/send-daily-push/index.ts`
+
+Cron-invoked (no CORS — mirror `pull-social-stats`); service-role client at
+module scope (mirror `ig-sync`). Uses `npm:web-push` (Supabase Deno runtime
+supports npm specifiers) with `Deno.env.get('VAPID_PUBLIC_KEY')`,
+`VAPID_PRIVATE_KEY`, subject `mailto:ginoswanepoel@gmail.com`.
+
+Flow:
+1. `select hero_a_id, hero_b_id, hook_text from daily_debate where debate_date = current_date`
+   — if absent (shouldn't be; the roll guarantees it), return
+   `{ skipped: 'no debate row' }`.
+2. Join `heroes` for the two names.
+3. Personalization: `select uf.user_id from user_favourites uf where uf.hero_id
+   in (a, b)` → a Set. Favourite-holders get title
+   `"<FavName> is in today's matchup"`, everyone else
+   `"Today's matchup: <A> vs <B>"`; body = `hook_text ?? 'Cast your vote'`;
+   `url: '/versus'`.
+4. Load all `push_subscriptions`; send each with `webpush.sendNotification`.
+   On success stamp `last_ok_at`; on **404/410 delete the row** (endpoint
+   gone); other errors stamp `failed_at` and count.
+5. Return `{ sent, pruned, failed }` (the cron log line).
+
+Deploy via `mcp__supabase__deploy_edge_function`.
+
+### 7. Env / secrets
+
+- Generate VAPID keys once: `npx web-push generate-vapid-keys`.
+- Public key → `EXPO_PUBLIC_VAPID_PUBLIC_KEY` (Vercel env + `.env.example` +
+  `.env.local`).
+- Private + public → Supabase function secrets:
+  `supabase secrets set VAPID_PUBLIC_KEY=… VAPID_PRIVATE_KEY=…` (or via
+  dashboard). **Owner action.**
+
+## Non-goals (v1)
+
+- Native push (expo-notifications), anonymous subscribers, per-user send-time
+  preferences, notification categories/preferences beyond the single toggle,
+  team-battle notifications, any offline caching in the SW.
+
+## Tests
+
+- `__tests__/lib/push.test.ts`: `urlBase64ToUint8Array` round-trip;
+  `getSubscriptionState()` returns `'unsupported'` when `navigator.serviceWorker`
+  is absent (jsdom default); subscribe short-circuits on denied permission.
+  Mock the supabase module as other db tests do.
+- The edge function is exercised by a manual invoke (below), not jest.
+
+## Acceptance criteria
+
+1. Chrome desktop/Android: toggle on in Settings → permission prompt → row in
+   `push_subscriptions`; toggle off → row gone + browser subscription gone.
+2. Manual invoke of `send-daily-push` (curl with anon bearer) → notification
+   arrives; clicking it opens/focuses `/versus`; response counts match.
+3. A favourite-holder of a debated hero receives the personalized title.
+4. Deleting the subscription in the browser then invoking → row pruned (410).
+5. Settings on native and on unsupported browsers: no Notifications section.
+6. Existing pages unaffected: `yarn expo export -p web` output serves `/sw.js`;
+   `yarn test:ci` green; tsc clean.
+7. Cron visible in `select * from cron.job` and fires at 15:00 UTC.


### PR DESCRIPTION
Five documents in `docs/superpowers/specs/`, written so a separate (Opus) session can execute without rediscovery. Grounded by four parallel code audits — every file:line anchor, platform fact, and gotcha below was verified against the repo at `d4b653e4`.

## The specs (execution order)

| # | Spec | The one thing that would have been missed |
| --- | --- | --- |
| 1 | **auth-returnto** | The AuthGate (`_layout.tsx:66`) is a *second* redirect that races and clobbers any post-login navigation — the fix must route returnTo **through** the gate, which also makes OAuth work for free. All 13 login call sites enumerated. |
| 2 | **sentry-observability** | The repo already has self-hosted error reporting (`client_errors` + web ErrorBoundary) — Sentry goes *beside* it; **native** is the real gap (no boundary, no global handler). Errors-only config to protect the landing bundle; fail-soft sourcemaps. |
| 3 | **comicvine-collision-gate** (#65) | The buggy matcher exists in TWO byte-identical copies; the disambiguating publisher field isn't even fetched at decision time. Spec extracts one `_shared/` matcher, adds `needs_review` + an admin queue on the NeedsYou pattern, audits the ~80 smell-test rows. |
| 4 | **web-push-daily** | Only the daily debate is server-authoritative (`daily_debate`, UTC, cron-guaranteed) — the team battle is client-computed, so push v1 is debate-only. Push-only SW (no cache), RLS-owner subscriptions, favourite-holder personalization, 410 pruning. |

Plus **hardening-execution-plan.md**: PR order + rationale, the hard rules (yarn only, MCP migrations + type regen, anon-role benchmarking), the owner-action checklist (Sentry DSN, VAPID keys — both fail-soft so PRs can merge before setup), and a rediscovery-context digest.

## Scope decisions already made (specs say "don't relitigate")
- returnTo is location-only (no intent resume) — v2 can layer an `intent` param.
- Sentry: no tracing/replay/profiling — bundle discipline.
- Push v1: web-only, signed-in only, debate-only, 15:00 UTC.
- CV gate: publisher agreement is the gate; no confidence-score model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)