### PR TITLE
feat(auth): preserve location through sign-in (returnTo)

### DIFF
--- a/__tests__/lib/loginRedirect.test.ts
+++ b/__tests__/lib/loginRedirect.test.ts
@@ -1,0 +1,51 @@
+import { sanitizeReturnTo, loginHref, signupHref } from '../../src/lib/loginRedirect';
+
+describe('sanitizeReturnTo', () => {
+  it('accepts same-app absolute paths', () => {
+    expect(sanitizeReturnTo('/character/123')).toBe('/character/123');
+    expect(sanitizeReturnTo('/versus/team/abc?x=y')).toBe('/versus/team/abc?x=y');
+  });
+
+  it('takes the first element of an array param', () => {
+    expect(sanitizeReturnTo(['/character/9', '/other'])).toBe('/character/9');
+  });
+
+  it('rejects empty / missing values', () => {
+    expect(sanitizeReturnTo(undefined)).toBeNull();
+    expect(sanitizeReturnTo('')).toBeNull();
+    expect(sanitizeReturnTo([])).toBeNull();
+  });
+
+  it('rejects external and protocol-relative URLs', () => {
+    expect(sanitizeReturnTo('https://evil.com')).toBeNull();
+    expect(sanitizeReturnTo('//evil.com')).toBeNull();
+    expect(sanitizeReturnTo('http://evil.com/path')).toBeNull();
+    expect(sanitizeReturnTo('javascript:alert(1)')).toBeNull();
+  });
+
+  it('rejects the root and the auth group (would loop / be pointless)', () => {
+    expect(sanitizeReturnTo('/')).toBeNull();
+    expect(sanitizeReturnTo('/(auth)/login')).toBeNull();
+    expect(sanitizeReturnTo('/(auth)/signup')).toBeNull();
+  });
+});
+
+describe('loginHref / signupHref', () => {
+  it('returns a bare route string when there is no safe returnTo', () => {
+    expect(loginHref(null)).toBe('/(auth)/login');
+    expect(loginHref('/')).toBe('/(auth)/login');
+    expect(loginHref('https://evil.com')).toBe('/(auth)/login');
+    expect(signupHref(undefined)).toBe('/(auth)/signup');
+  });
+
+  it('carries a sanitized returnTo as a param object', () => {
+    expect(loginHref('/character/9')).toEqual({
+      pathname: '/(auth)/login',
+      params: { returnTo: '/character/9' },
+    });
+    expect(signupHref('/versus/team/abc')).toEqual({
+      pathname: '/(auth)/signup',
+      params: { returnTo: '/versus/team/abc' },
+    });
+  });
+});

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -10,7 +10,7 @@ import {
   ScrollView,
   useWindowDimensions,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -24,6 +24,7 @@ import { AnimatedInput } from '../../src/components/ui/AnimatedInput';
 import { SocialDivider } from '../../src/components/ui/SocialDivider';
 import { GoogleSignInButton } from '../../src/components/ui/GoogleSignInButton';
 import { AppleSignInButton } from '../../src/components/ui/AppleSignInButton';
+import { postAuthTarget, signupHref } from '../../src/lib/loginRedirect';
 
 // Google Sign-In requires the OAuth URL scheme registered at native build time.
 // Expo Go / dev client builds don't have it — hide the button in those environments.
@@ -34,6 +35,7 @@ const LOGIN_HERO = require('../../assets/images/login-hero.webp');
 export default function LoginScreen() {
   const { signIn, signInWithGoogle, signInWithApple } = useAuth();
   const router = useRouter();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const insets = useSafeAreaInsets();
   const { height: screenHeight } = useWindowDimensions();
 
@@ -61,7 +63,9 @@ export default function LoginScreen() {
       setError(error.message);
       setLoading(false);
     } else {
-      router.replace('/explore');
+      // Return to the page the user was acting on (the AuthGate honors the same
+      // param and would otherwise win the race anyway — both compute this target).
+      router.replace(postAuthTarget(returnTo));
     }
   };
 
@@ -222,7 +226,7 @@ export default function LoginScreen() {
               )}
             </Pressable>
 
-            <Pressable onPress={() => router.push('/(auth)/signup')} style={styles.switchRow}>
+            <Pressable onPress={() => router.push(signupHref(returnTo))} style={styles.switchRow}>
               <Text style={styles.switchText}>Don’t have an account? </Text>
               <Text style={styles.switchLink}>Sign up</Text>
             </Pressable>

--- a/app/(auth)/login.web.tsx
+++ b/app/(auth)/login.web.tsx
@@ -8,7 +8,7 @@ import {
   ActivityIndicator,
   useWindowDimensions,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useScreenChrome } from '../../src/hooks/useScreenChrome';
 import { PageEndCap } from '../../src/components/web/PageEndCap';
@@ -19,6 +19,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { SocialDivider } from '../../src/components/ui/SocialDivider';
 import { GoogleSignInButton } from '../../src/components/ui/GoogleSignInButton';
 import { AppleSignInButton } from '../../src/components/ui/AppleSignInButton';
+import { postAuthTarget, signupHref } from '../../src/lib/loginRedirect';
 
 const LOGIN_HERO = require('../../assets/images/login-hero.webp');
 const HERO_ASPECT = LOGIN_HERO.width / LOGIN_HERO.height;
@@ -26,6 +27,7 @@ const HERO_ASPECT = LOGIN_HERO.width / LOGIN_HERO.height;
 export default function WebLoginScreen() {
   const { signIn, signInWithGoogle, signInWithApple } = useAuth();
   const router = useRouter();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 1024;
 
@@ -55,7 +57,8 @@ export default function WebLoginScreen() {
       setError(error.message);
       setLoading(false);
     } else {
-      router.replace('/explore');
+      // Return to the acting page (the AuthGate honors the same param post-OAuth).
+      router.replace(postAuthTarget(returnTo));
     }
   };
 
@@ -165,7 +168,7 @@ export default function WebLoginScreen() {
         )}
       </Pressable>
 
-      <Pressable onPress={() => router.push('/(auth)/signup')} style={styles.switchRow as object}>
+      <Pressable onPress={() => router.push(signupHref(returnTo))} style={styles.switchRow as object}>
         <Text style={styles.switchText}>Don’t have an account? </Text>
         <Text style={styles.switchLink}>Sign up</Text>
       </Pressable>

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -10,13 +10,14 @@ import {
   ScrollView,
   useWindowDimensions,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuth } from '../../src/hooks/useAuth';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { COLORS } from '../../src/constants/colors';
 import { HeroLogo } from '../../src/components/web/HeroLogo';
 import { DotGrid } from '../../src/components/ui/DotGrid';
@@ -34,6 +35,7 @@ const LOGIN_HERO = require('../../assets/images/login-hero.webp');
 export default function SignupScreen() {
   const { signUp, signInWithGoogle, signInWithApple } = useAuth();
   const router = useRouter();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const insets = useSafeAreaInsets();
   const { height: screenHeight } = useWindowDimensions();
 
@@ -124,7 +126,7 @@ export default function SignupScreen() {
                 <Text style={styles.pendingHint}>
                   Can’t find it? Check your Spam or Junk folder.
                 </Text>
-                <Pressable onPress={() => router.push('/(auth)/login')} style={styles.pendingCta}>
+                <Pressable onPress={() => router.push(loginHref(returnTo))} style={styles.pendingCta}>
                   <Text style={styles.pendingCtaText}>Back to Sign In</Text>
                 </Pressable>
                 <Pressable
@@ -257,7 +259,7 @@ export default function SignupScreen() {
                   .
                 </Text>
 
-                <Pressable onPress={() => router.push('/(auth)/login')} style={styles.switchRow}>
+                <Pressable onPress={() => router.push(loginHref(returnTo))} style={styles.switchRow}>
                   <Text style={styles.switchText}>Already have an account? </Text>
                   <Text style={styles.switchLink}>Sign in</Text>
                 </Pressable>

--- a/app/(auth)/signup.web.tsx
+++ b/app/(auth)/signup.web.tsx
@@ -8,8 +8,9 @@ import {
   ActivityIndicator,
   useWindowDimensions,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { useScreenChrome } from '../../src/hooks/useScreenChrome';
 import { PageEndCap } from '../../src/components/web/PageEndCap';
 import { COLORS, SURFACE, SURFACE_GRADIENT } from '../../src/constants/colors';
@@ -26,6 +27,7 @@ const HERO_ASPECT = LOGIN_HERO.width / LOGIN_HERO.height;
 export default function WebSignupScreen() {
   const { signUp, signInWithGoogle, signInWithApple } = useAuth();
   const router = useRouter();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 1024;
 
@@ -70,7 +72,7 @@ export default function WebSignupScreen() {
         <Text style={styles.pendingEmail}>{pendingEmail}</Text>
       </Text>
       <Text style={styles.pendingHint}>Can’t find it? Check your Spam or Junk folder.</Text>
-      <Pressable onPress={() => router.push('/(auth)/login')} style={styles.pendingCta as object}>
+      <Pressable onPress={() => router.push(loginHref(returnTo))} style={styles.pendingCta as object}>
         <Text style={styles.pendingCtaText}>Back to Sign In</Text>
       </Pressable>
       <Pressable
@@ -198,7 +200,7 @@ export default function WebSignupScreen() {
         .
       </Text>
 
-      <Pressable onPress={() => router.push('/(auth)/login')} style={styles.switchRow as object}>
+      <Pressable onPress={() => router.push(loginHref(returnTo))} style={styles.switchRow as object}>
         <Text style={styles.switchText}>Already have an account? </Text>
         <Text style={styles.switchLink}>Sign in</Text>
       </Pressable>

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { View, Text, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { useRouter, usePathname } from 'expo-router';
 import {
   COLORS,
   SURFACE,
@@ -21,6 +21,7 @@ import { Reveal } from '../../src/components/web/Reveal';
 import { HeroImage } from '../../src/components/HeroImage';
 import { WebHomeSkeleton } from '../../src/components/web/HomeSkeleton';
 import { type Hero } from '../../src/lib/db/heroes';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { RightNowBand } from '../../src/components/web/home/RightNowBand';
 import { useExploreData } from '../../src/lib/query/exploreQueries';
 import type { FavouriteHero } from '../../src/types';
@@ -1250,6 +1251,7 @@ const fi = StyleSheet.create({
 // ── Screen ────────────────────────────────────────────────────────────────────
 export default function WebHomeScreen() {
   const router = useRouter();
+  const pathname = usePathname();
   const { width } = useWindowDimensions();
   const isMobile = width < 640;
   const gutter = pageGutter(width);
@@ -1500,11 +1502,7 @@ export default function WebHomeScreen() {
                 <FavouritesInvite
                   gutter={gutter}
                   isAuthed={!!user}
-                  onCta={() =>
-                    router.push(
-                      (user ? '/search' : '/(auth)/login') as Parameters<typeof router.push>[0],
-                    )
-                  }
+                  onCta={() => router.push(user ? '/search' : loginHref(pathname))}
                 />
               )}
             </Reveal>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { queryClient } from '../../src/lib/query/queryClient';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { exploreKeys } from '../../src/lib/query/keys';
 import {
   View,
@@ -24,7 +25,7 @@ import { PressScale } from '../../src/components/ui/PressScale';
 import { Skeleton } from '../../src/components/ui/Skeleton';
 import { SkeletonProvider } from '../../src/components/ui/SkeletonProvider';
 import { Ionicons } from '@expo/vector-icons';
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useFocusEffect, useRouter, usePathname } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useProfile } from '../../src/hooks/useProfile';
 import { useProfileData } from '../../src/hooks/useProfileData';
@@ -142,6 +143,7 @@ const GUEST_BENEFITS = [
 
 function GuestProfileScreen() {
   const router = useRouter();
+  const pathname = usePathname();
   const insets = useSafeAreaInsets();
 
   return (
@@ -222,7 +224,7 @@ function GuestProfileScreen() {
           </TouchableOpacity>
 
           <TouchableOpacity
-            onPress={() => router.push('/(auth)/login')}
+            onPress={() => router.push(loginHref(pathname))}
             style={styles.guestSignUpBtn}
             activeOpacity={0.85}
           >

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { queryClient } from '../../src/lib/query/queryClient';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { exploreKeys } from '../../src/lib/query/keys';
 import {
   View,
@@ -23,7 +24,7 @@ import { LOGO_MASK_PATH as HERO_LOGO_PATH } from '../../src/constants/logo';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { useRouter, usePathname } from 'expo-router';
 import { useAuth } from '../../src/hooks/useAuth';
 import { useProfile } from '../../src/hooks/useProfile';
 import { useProfileData } from '../../src/hooks/useProfileData';
@@ -84,6 +85,7 @@ function username(email: string) {
 
 function GuestWebProfileScreen() {
   const router = useRouter();
+  const pathname = usePathname();
   const { width } = useWindowDimensions();
   const isMobile = width < SIDEBAR_BREAKPOINT;
 
@@ -97,7 +99,7 @@ function GuestWebProfileScreen() {
         Sign in to save your favourite heroes, customise your profile, and sync across devices.
       </Text>
       <Pressable
-        onPress={() => router.push('/(auth)/login')}
+        onPress={() => router.push(loginHref(pathname))}
         style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
           [guest.signInBtn, hovered && (guest.signInBtnHover as object)] as object
         }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@ import 'react-native-url-polyfill/auto';
 import { useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { Stack, useRouter, useSegments } from 'expo-router';
+import { Stack, useRouter, useSegments, useGlobalSearchParams } from 'expo-router';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -19,6 +19,7 @@ import { LogoLoader } from '../src/components/ui/LogoLoader';
 import AnalyticsProvider from '../src/components/Analytics';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '../src/lib/query/queryClient';
+import { postAuthTarget } from '../src/lib/loginRedirect';
 
 if (Platform.OS !== 'web') {
   const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID;
@@ -52,6 +53,9 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
   const { user, loading } = useAuth();
   const segments = useSegments();
   const router = useRouter();
+  // Global (not local) — AuthGate is not the route component, so it reads the
+  // login screen's ?returnTo from the app-wide param bag.
+  const { returnTo } = useGlobalSearchParams<{ returnTo?: string | string[] }>();
   const [settled, setSettled] = useState(false);
 
   useEffect(() => {
@@ -63,14 +67,17 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
     const atRoot = Platform.OS !== 'web' && (segments.length as number) === 0;
 
     if (user && (inAuthGroup || atRoot)) {
-      router.replace('/explore');
+      // Honor a sanitized returnTo so signing in returns the user to the page
+      // they were acting on. The gate MUST own this: it's a second redirect
+      // that would otherwise clobber any post-login navigation to /explore.
+      router.replace(postAuthTarget(returnTo));
     } else {
       // Auth gate resolved (no redirect needed) — reveal the app. Driven by
       // async session + route segments, so it belongs in an effect.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSettled(true);
     }
-  }, [user, loading, segments, router]);
+  }, [user, loading, segments, router, returnTo]);
 
   // Single boot gate: one LogoLoader spans the whole cold start (fonts + auth)
   // so the logo animation runs continuously instead of restarting at the

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { Stack, useRouter, useSegments, usePathname, type ErrorBoundaryProps } from 'expo-router';
+import {
+  Stack,
+  useRouter,
+  useSegments,
+  usePathname,
+  useGlobalSearchParams,
+  type ErrorBoundaryProps,
+} from 'expo-router';
 import { useFonts } from 'expo-font';
 import { StatusBar } from 'expo-status-bar';
 import {
@@ -21,6 +28,7 @@ import { WebChromeProvider, AdaptiveStatusBarCover } from '../src/contexts/WebCh
 import { CommandAlertsProvider } from '../src/contexts/CommandAlertsContext';
 import { queryClient } from '../src/lib/query/queryClient';
 import { COLORS } from '../src/constants/colors';
+import { postAuthTarget } from '../src/lib/loginRedirect';
 import AnalyticsProvider from '../src/components/Analytics';
 import { recordClientError, installGlobalErrorCapture } from '../src/lib/db/clientErrors';
 
@@ -96,6 +104,7 @@ function WebAuthGate({ fontsReady }: { fontsReady: boolean }) {
   const segments = useSegments();
   const router = useRouter();
   const pathname = usePathname();
+  const { returnTo } = useGlobalSearchParams<{ returnTo?: string | string[] }>();
   const [settled, setSettled] = useState(false);
 
   const segs = segments as string[];
@@ -106,14 +115,18 @@ function WebAuthGate({ fontsReady }: { fontsReady: boolean }) {
     const isRoot = segs.length === 0;
 
     if (user && (inAuthGroup || isRoot)) {
-      router.replace('/explore');
+      // Honor a sanitized returnTo (the login screen's ?returnTo). The gate owns
+      // this redirect — it would otherwise race/clobber any post-login nav. This
+      // is also the ONLY post-OAuth redirect on web (OAuth full-page-returns to
+      // the login URL, which now carries returnTo).
+      router.replace(postAuthTarget(returnTo));
     } else {
       // Auth gate resolved (no redirect needed) — reveal the app. Driven by
       // async session + route segments, so it belongs in an effect.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSettled(true);
     }
-  }, [user, loading, segs, inAuthGroup, router]);
+  }, [user, loading, segs, inAuthGroup, router, returnTo]);
 
   // Native document scroll for every route: content bleeds edge-to-edge under the
   // iOS Safari toolbar and the toolbar can collapse (it only minimizes on

--- a/app/character/[id].tsx
+++ b/app/character/[id].tsx
@@ -15,7 +15,7 @@ import {
   type NativeSyntheticEvent,
   type NativeScrollEvent,
 } from 'react-native';
-import { Stack, useLocalSearchParams, useRouter, Link } from 'expo-router';
+import { Stack, useLocalSearchParams, useRouter, usePathname, Link } from 'expo-router';
 import ReAnimated, {
   FadeIn,
   FadeOut,
@@ -33,6 +33,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import { NotFoundView, LoadErrorView } from '../../src/components/NotFoundView';
 import { heroRowToCharacterData } from '../../src/lib/db/heroes';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { FamilyCanvas } from '../../src/components/family/FamilyCanvas';
 import { groupTitlesByMedia } from '../../src/lib/db/titles';
 import { PortrayedBySection } from '../../src/components/PortrayedBySection';
@@ -592,6 +593,7 @@ export default function CharacterScreen() {
     imageUri?: string;
   }>();
   const router = useRouter();
+  const pathname = usePathname();
   const insets = useSafeAreaInsets();
   const compareStripStyle = [styles.compareStrip, { paddingBottom: insets.bottom || 16 }];
   const {
@@ -1682,7 +1684,7 @@ export default function CharacterScreen() {
           user={user}
           isAdmin={isAdmin}
           priorCount={0}
-          onRequestSignIn={() => router.push('/(auth)/login')}
+          onRequestSignIn={() => router.push(loginHref(pathname))}
           onSubmitted={async () => {
             // Admin edits apply immediately — pull the fresh row so the change
             // shows on the page without a manual reload.
@@ -1702,7 +1704,7 @@ export default function CharacterScreen() {
           imageUrl={reportCtx?.imageUrl ?? null}
           portraitUrl={heroPortraitUrl}
           user={user}
-          onRequestSignIn={() => router.push('/(auth)/login')}
+          onRequestSignIn={() => router.push(loginHref(pathname))}
         />
       ) : null}
 

--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState, Fragment, type ComponentProps } from 'react';
 import { View, Text, Pressable, StyleSheet, Animated, useWindowDimensions } from 'react-native';
 import { useSkeletonAnim, SkeletonBlock } from '../../src/components/web/Skeleton';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter, usePathname } from 'expo-router';
 import { Image } from 'expo-image';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { NotFoundView, LoadErrorView } from '../../src/components/NotFoundView';
 import { getHeroById, heroRowToCharacterData } from '../../src/lib/db/heroes';
+import { loginHref } from '../../src/lib/loginRedirect';
 import { FamilyCanvas } from '../../src/components/family/FamilyCanvas.web';
 import { groupPowers } from '../../src/constants/powerIcons';
 import { useHeroDetail } from '../../src/hooks/useHeroDetail';
@@ -506,6 +507,7 @@ function VitalCount({ value, style }: { value: number; style?: object }) {
 export default function WebCharacterScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const pathname = usePathname();
   const { width, height: winHeight } = useWindowDimensions();
   // Freeze at mount: winHeight changes as the iOS toolbar collapses, which
   // resized the hero mid-scroll and re-cropped the cover art (a "zoom" jitter).
@@ -2391,7 +2393,7 @@ export default function WebCharacterScreen() {
           user={user}
           isAdmin={isAdmin}
           priorCount={0}
-          onRequestSignIn={() => router.push('/(auth)/login')}
+          onRequestSignIn={() => router.push(loginHref(pathname))}
           onSubmitted={() => {
             if (isAdmin) reloadHero();
           }}
@@ -2405,7 +2407,7 @@ export default function WebCharacterScreen() {
           imageUrl={reportCtx?.imageUrl ?? null}
           portraitUrl={heroPortraitUrl}
           user={user}
-          onRequestSignIn={() => router.push('/(auth)/login')}
+          onRequestSignIn={() => router.push(loginHref(pathname))}
         />
         {/* end mobile */}
       </View>

--- a/app/versus/team/[battleId].tsx
+++ b/app/versus/team/[battleId].tsx
@@ -1,5 +1,5 @@
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import { useLocalSearchParams, useRouter, usePathname, Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
@@ -8,17 +8,19 @@ import { useTeamBattle } from '../../../src/hooks/useTeamBattle';
 import { useAuth } from '../../../src/hooks/useAuth';
 import { ClashArena } from '../../../src/components/versus/ClashArena';
 import { ClashSkeleton } from '../../../src/components/versus/ClashSkeleton';
+import { loginHref } from '../../../src/lib/loginRedirect';
 
 export default function TeamClashScreen() {
   const { battleId } = useLocalSearchParams<{ battleId: string }>();
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuth();
   const { loading, sideA, sideB, result, tally, vote } = useTeamBattle(battleId);
 
   const onVote = async (teamId: string) => {
     if (!user) {
-      router.push('/(auth)/login');
+      router.push(loginHref(pathname));
       return;
     }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);

--- a/app/versus/team/[battleId].web.tsx
+++ b/app/versus/team/[battleId].web.tsx
@@ -1,5 +1,5 @@
 import { View, StyleSheet } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter, usePathname } from 'expo-router';
 import { COLORS, SURFACE } from '../../../src/constants/colors';
 import { useTeamBattle } from '../../../src/hooks/useTeamBattle';
 import { useAuth } from '../../../src/hooks/useAuth';
@@ -7,17 +7,19 @@ import { useScreenChrome } from '../../../src/hooks/useScreenChrome';
 import { TOPBAR_HEIGHT } from '../../../src/components/web/TopBar';
 import { ClashArena } from '../../../src/components/versus/ClashArena';
 import { ClashSkeleton } from '../../../src/components/versus/ClashSkeleton';
+import { loginHref } from '../../../src/lib/loginRedirect';
 
 export default function TeamClashWeb() {
   useScreenChrome({ top: SURFACE.ink, canvas: SURFACE.ink });
   const { battleId } = useLocalSearchParams<{ battleId: string }>();
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuth();
   const { loading, sideA, sideB, result, tally, vote } = useTeamBattle(battleId);
 
   const onVote = (teamId: string) => {
     if (!user) {
-      router.push('/(auth)/login');
+      router.push(loginHref(pathname));
       return;
     }
     void vote(teamId);

--- a/src/components/takes/TakesSection.tsx
+++ b/src/components/takes/TakesSection.tsx
@@ -4,13 +4,14 @@
 // useMatchupTakes; report/delete lives behind a small per-card overflow menu.
 import { useEffect, useState } from 'react';
 import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, usePathname } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/colors';
 import { useAuth } from '../../hooks/useAuth';
 import { useMatchupVote } from '../../hooks/useMatchupVote';
 import { useMatchupTakes } from '../../hooks/useMatchupTakes';
 import { ReportSheet } from '../report/ReportSheet';
+import { loginHref } from '../../lib/loginRedirect';
 import type { Take } from '../../lib/db/takes';
 
 const MAX_LEN = 280;
@@ -155,6 +156,7 @@ function TakeCard({
 
 export function TakesSection({ heroA, heroB }: TakesSectionProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuth();
   const { pickedId: votePickedId } = useMatchupVote(heroA.id, heroB.id);
   const { takes, myTake, submit, remove, agree, agreedIds, error } = useMatchupTakes(
@@ -176,7 +178,7 @@ export function TakesSection({ heroA, heroB }: TakesSectionProps) {
     }
   }, [votePickedId, pick]);
 
-  const goToLogin = () => router.push('/(auth)/login');
+  const goToLogin = () => router.push(loginHref(pathname));
 
   const handleSubmit = async () => {
     if (!user) {

--- a/src/components/web/TopBar.tsx
+++ b/src/components/web/TopBar.tsx
@@ -5,6 +5,7 @@ import { Image } from 'expo-image';
 import { useRouter, usePathname } from 'expo-router';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/colors';
+import { loginHref } from '../../lib/loginRedirect';
 import { useAuth } from '../../hooks/useAuth';
 import { useProfile } from '../../hooks/useProfile';
 import { useSearch } from '../../contexts/SearchContext';
@@ -390,7 +391,7 @@ export function TopBar({ logoOnly = false }: { logoOnly?: boolean }) {
                 ref={(node) => {
                   if (node) (node as unknown as HTMLElement).title = 'Sign in';
                 }}
-                onPress={() => router.push('/(auth)/login')}
+                onPress={() => router.push(loginHref(pathname))}
                 style={({ hovered }: { pressed: boolean; hovered?: boolean }) =>
                   [c.item, hovered && hoverStyle] as object
                 }

--- a/src/lib/loginRedirect.ts
+++ b/src/lib/loginRedirect.ts
@@ -1,0 +1,53 @@
+import type { Href } from 'expo-router';
+
+/**
+ * Validates a raw `returnTo` query param into a safe internal path, or null.
+ *
+ * A logged-out user who taps an auth-gated action is sent to the login screen
+ * with `?returnTo=<their page>`; after signing in we route them back there. The
+ * value is attacker-controllable (it rides in the URL), so it's sanitized to a
+ * same-app absolute path before any navigation:
+ *   - must start with a single "/" (rejects external + protocol-relative URLs
+ *     like "//evil.com" and "https://evil.com")
+ *   - never the root ("/" is the landing page — an authed user belongs on
+ *     /explore, which is the fallback everywhere)
+ *   - never back into the auth group (would loop)
+ */
+export function sanitizeReturnTo(raw: string | string[] | undefined): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (!v || typeof v !== 'string') return null;
+  if (!v.startsWith('/') || v.startsWith('//')) return null;
+  if (v === '/' || v.startsWith('/(auth)')) return null;
+  return v;
+}
+
+/**
+ * Where to send a user after a successful sign-in: their sanitized returnTo, or
+ * /explore. Cast to Href because a returnTo is a runtime string, not one of the
+ * statically-typed routes (typedRoutes is on) — but it's already sanitized to a
+ * same-app path above.
+ */
+export function postAuthTarget(raw: string | string[] | undefined): Href {
+  return (sanitizeReturnTo(raw) ?? '/explore') as Href;
+}
+
+/**
+ * Href for the login screen, carrying the page to return to after sign-in.
+ * Callers pass their current `usePathname()`; a root/unsafe value collapses to
+ * a plain login link (post-login fallback is /explore).
+ */
+export function loginHref(returnTo?: string | string[] | null): Href {
+  const clean = sanitizeReturnTo(returnTo ?? undefined);
+  return clean ? { pathname: '/(auth)/login', params: { returnTo: clean } } : '/(auth)/login';
+}
+
+/**
+ * Href for the signup screen, carrying returnTo. Used by the login↔signup switch
+ * links so bouncing between the two forms (without leaving the app) doesn't drop
+ * the return target. Signup itself can't resume inline — it parks on the
+ * email-confirmation card — so a confirmation-link round-trip does lose it.
+ */
+export function signupHref(returnTo?: string | string[] | null): Href {
+  const clean = sanitizeReturnTo(returnTo ?? undefined);
+  return clean ? { pathname: '/(auth)/signup', params: { returnTo: clean } } : '/(auth)/signup';
+}


### PR DESCRIPTION
Spec 1 of the hardening batch — implements `docs/superpowers/specs/2026-07-15-auth-returnto-design.md`.

## Problem
Logged out, you tap **vote / post a take / contribute / report / sign in** → you're sent to login → after signing in you land on `/explore`, losing both the page and your intent.

## Fix
Location is preserved end-to-end (email **and** web OAuth). Intent-resume (auto-reopening the sheet / re-casting the vote) is a deliberate non-goal for v1.

- **`src/lib/loginRedirect.ts`** — `sanitizeReturnTo` (rejects `https://evil.com`, `//evil.com`, `/`, and `/(auth)/*`), `postAuthTarget` (sanitized target or `/explore`, typed `Href`), `loginHref`/`signupHref`.
- **Both AuthGates** now honor `returnTo`. This is the load-bearing insight from the spec research: the gate (`_layout.tsx:66` / `_layout.web.tsx`) is a *second* redirect that would race and clobber any post-login navigation — and it's the **only** post-OAuth redirect on web (OAuth full-page-returns to the login URL, which now carries `returnTo`). So the fix goes through the gate, not just the login handlers.
- **11 gate call sites** pass `loginHref(pathname)`: character contribute/report (native+web), team-battle vote (native+web), takes section, top bar, guest profile (native+web), explore favourites invite. Landing nav stays a plain login link (its pathname is `/`, which sanitizes away — correct).
- **login↔signup switch links** thread `returnTo` so bouncing between the two forms keeps it. Signup can't resume inline (email-confirmation wall) — documented non-goal.

## Verification
- No visual change.
- New `__tests__/lib/loginRedirect.test.ts` (sanitizer + href builders, incl. all the rejection cases).
- `npx tsc --noEmit` clean; `yarn test:ci` → **693 passed** (686 + 7); eslint clean on all touched files (one pre-existing unrelated warning in VitalCount).

## Manual QA suggestions
1. Logged out on `/versus/team/<id>` → tap vote → sign in (email) → back on the battle.
2. Same via Google OAuth on web → back on the battle.
3. Top-bar sign-in while on `/character/123` → return to it.
4. `/(auth)/login?returnTo=https://evil.com` → lands on `/explore`, never off-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)