### PR TITLE
feat(observability): Sentry crash reporting + native ErrorBoundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ SUPABASE_SERVICE_ROLE_KEY=
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
 
+# Sentry crash/error reporting. DSN is client-exposed; empty = reporting off
+# (app runs identically). SENTRY_AUTH_TOKEN is build-only (CI/EAS) for source-map
+# upload — never commit it. SENTRY_ORG/SENTRY_PROJECT feed the upload + plugin.
+EXPO_PUBLIC_SENTRY_DSN=
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+
 # Cloudinary — used by scripts/migrate-portraits-to-cloudinary.ts (server-side only)
 CLOUDINARY_CLOUD_NAME=your_cloud_name
 CLOUDINARY_API_KEY=your_api_key

--- a/__mocks__/@sentry/react-native.js
+++ b/__mocks__/@sentry/react-native.js
@@ -1,0 +1,11 @@
+// No-op Sentry mock for jest (init guards on NODE_ENV==='test' anyway, but the
+// native module must not load under jsdom). Mirrors the plain-CommonJS style of
+// the repo's other manual mocks (see __mocks__/svgMock.js).
+module.exports = {
+  init: () => {},
+  captureException: () => {},
+  captureMessage: () => {},
+  setTag: () => {},
+  setContext: () => {},
+  wrap: (component) => component,
+};

--- a/app.config.ts
+++ b/app.config.ts
@@ -102,6 +102,10 @@ const config: ExpoConfig = {
         imageWidth: 200,
       },
     ],
+    // Crash/error reporting. The config plugin wires native symbolication +
+    // source-map upload at EAS build time (needs SENTRY_AUTH_TOKEN); at runtime
+    // the SDK no-ops without EXPO_PUBLIC_SENTRY_DSN. See src/lib/sentry.ts.
+    '@sentry/react-native/expo',
   ],
   experiments: {
     typedRoutes: true,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,14 @@
 import 'react-native-url-polyfill/auto';
 import { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
+import { Platform, View, Text, Pressable, StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { Stack, useRouter, useSegments, useGlobalSearchParams } from 'expo-router';
+import {
+  Stack,
+  useRouter,
+  useSegments,
+  useGlobalSearchParams,
+  type ErrorBoundaryProps,
+} from 'expo-router';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -20,6 +26,13 @@ import AnalyticsProvider from '../src/components/Analytics';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '../src/lib/query/queryClient';
 import { postAuthTarget } from '../src/lib/loginRedirect';
+import { COLORS } from '../src/constants/colors';
+import { initSentry, captureException } from '../src/lib/sentry';
+
+// Start crash reporting as early as possible (module scope, before any render).
+// No-op without EXPO_PUBLIC_SENTRY_DSN. init() also installs the native
+// ErrorUtils handler that reports fatal JS errors for free.
+initSentry();
 
 if (Platform.OS !== 'web') {
   const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID;
@@ -41,6 +54,66 @@ if (Platform.OS !== 'web') {
 }
 
 SplashScreen.preventAutoHideAsync();
+
+// Expo Router renders this in place of the tree if a render throws, instead of a
+// blank white screen — a graceful, on-brand recovery surface. Mirrors the web
+// ErrorBoundary (app/_layout.web.tsx) visually. Reports via Sentry: the
+// self-hosted client_errors feed is web-only (recordClientError no-ops on
+// native), so native crashes only reach Sentry.
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  useEffect(() => {
+    captureException(error, { boundary: 'root-native' });
+  }, [error]);
+
+  return (
+    <View style={eb.root}>
+      <Text style={eb.title}>Something went wrong</Text>
+      <Text style={eb.body}>
+        An unexpected error interrupted the page. You can try again — if it keeps happening, reload
+        the app.
+      </Text>
+      {__DEV__ ? <Text style={eb.detail}>{error.message}</Text> : null}
+      <Pressable onPress={retry} style={eb.btn}>
+        <Text style={eb.btnText}>Try again</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const eb = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#0b1820',
+    padding: 28,
+  },
+  title: { fontFamily: 'Flame-Regular', fontSize: 28, color: COLORS.beige, textAlign: 'center' },
+  body: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 15,
+    lineHeight: 22,
+    color: 'rgba(245,235,220,0.7)',
+    textAlign: 'center',
+    maxWidth: 420,
+    marginTop: 10,
+  },
+  detail: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 12,
+    color: 'rgba(245,235,220,0.4)',
+    textAlign: 'center',
+    marginTop: 14,
+  },
+  btn: {
+    marginTop: 24,
+    backgroundColor: COLORS.orange,
+    borderRadius: 999,
+    paddingVertical: 13,
+    paddingHorizontal: 28,
+  },
+  btnText: { fontFamily: 'Nunito_700Bold', fontSize: 15, color: '#fff' },
+});
 
 // Drives the presence heartbeat app-wide (no-op when logged out). Rendered as a
 // sibling of the router so it lives for the whole session without re-mounting.

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -31,6 +31,11 @@ import { COLORS } from '../src/constants/colors';
 import { postAuthTarget } from '../src/lib/loginRedirect';
 import AnalyticsProvider from '../src/components/Analytics';
 import { recordClientError, installGlobalErrorCapture } from '../src/lib/db/clientErrors';
+import { initSentry } from '../src/lib/sentry';
+
+// Start crash reporting as early as possible (module scope, before any render).
+// No-op without EXPO_PUBLIC_SENTRY_DSN.
+initSentry();
 
 // Expo Router renders this in place of the tree if a render throws, instead of a
 // blank white screen — a graceful, on-brand recovery surface for production.

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,7 +1,10 @@
-const { getDefaultConfig } = require('expo/metro-config');
+// getSentryExpoConfig wraps Expo's getDefaultConfig to add source-map handling
+// for Sentry symbolication. Every customization below is re-applied on top of
+// it (SVG transformer, ext tweaks, web-stub resolver) — order matters.
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const path = require('path');
 
-const config = getDefaultConfig(__dirname);
+const config = getSentryExpoConfig(__dirname);
 
 // SVG support: transform .svg into react-native-svg components on every
 // platform, instead of treating them as image assets — RN's <Image> can't

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-native-masked-view/masked-view": "^0.3.2",
+    "@sentry/react-native": "~7.11.0",
     "@supabase/supabase-js": "^2.101.1",
     "@tanstack/react-query": "^5.101.0",
     "@vercel/analytics": "^2.0.1",
@@ -127,6 +128,7 @@
     "moduleNameMapper": {
       "^react-native-reanimated/mock$": "<rootDir>/__mocks__/react-native-reanimated-mock-shim.js",
       "^@react-native-async-storage/async-storage$": "@react-native-async-storage/async-storage/jest/async-storage-mock",
+      "^@sentry/react-native$": "<rootDir>/__mocks__/@sentry/react-native.js",
       "\\.svg$": "<rootDir>/__mocks__/svgMock.js",
       "^(\\.{1,2}/.*)\\.ts$": "$1"
     }

--- a/scripts/upload-sourcemaps.mjs
+++ b/scripts/upload-sourcemaps.mjs
@@ -1,0 +1,75 @@
+// Fail-soft Sentry source-map upload for the web export. Runs after
+// `expo export -p web` (see vercel.json buildCommand). If the Sentry env isn't
+// configured (SENTRY_AUTH_TOKEN / org / project), it logs and exits 0 — a
+// missing token or a Sentry hiccup must NEVER break a deploy (same posture as
+// generate-sitemap.mjs).
+//
+// The build emits .map files (expo export --source-maps). With the Sentry env
+// set: injects debug-ids into dist/ and uploads the maps under a release keyed
+// to the app version + the Vercel commit SHA, so minified web stacks
+// symbolicate in Sentry. EITHER WAY, the .map files are deleted from dist/ at
+// the end so they're never served publicly (they live only in Sentry).
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { globSync } from 'node:fs';
+import { rmSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+const AUTH = process.env.SENTRY_AUTH_TOKEN;
+const ORG = process.env.SENTRY_ORG;
+const PROJECT = process.env.SENTRY_PROJECT;
+const DIST = 'dist';
+
+/** Remove every .map under dist/ so source maps are never publicly served. */
+function stripMaps() {
+  try {
+    for (const f of globSync(`${DIST}/**/*.map`)) rmSync(f, { force: true });
+  } catch (e) {
+    console.warn('[sourcemaps] cleanup skipped:', e?.message ?? e);
+  }
+}
+
+if (!AUTH || !ORG || !PROJECT) {
+  console.log('[sourcemaps] SENTRY_AUTH_TOKEN/ORG/PROJECT not set — skipping upload (ok).');
+  stripMaps();
+  process.exit(0);
+}
+
+// Release name: app version + short commit SHA (Vercel provides the SHA).
+const sha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? 'local';
+let version = '0.0.0';
+try {
+  version = require('../app.json')?.expo?.version ?? version;
+} catch {
+  // app.config.ts is dynamic; fall back to package.json version.
+  try {
+    version = require('../package.json')?.version ?? version;
+  } catch {
+    /* keep default */
+  }
+}
+const release = `mythique@${version}+${sha}`;
+
+// Resolve the sentry-cli binary shipped with @sentry/cli (a dep of the SDK).
+let bin;
+try {
+  const SentryCli = require('@sentry/cli');
+  bin = typeof SentryCli.getPath === 'function' ? SentryCli.getPath() : 'sentry-cli';
+} catch {
+  bin = 'sentry-cli';
+}
+
+const env = { ...process.env, SENTRY_AUTH_TOKEN: AUTH, SENTRY_ORG: ORG, SENTRY_PROJECT: PROJECT };
+const run = (args) => execFileSync(bin, args, { stdio: 'inherit', env });
+
+try {
+  run(['sourcemaps', 'inject', DIST]);
+  run(['sourcemaps', 'upload', '--release', release, DIST]);
+  console.log(`[sourcemaps] uploaded for release ${release}.`);
+} catch (e) {
+  // Upload failure is non-fatal — ship the deploy, just without symbolication.
+  console.warn('[sourcemaps] upload failed (non-fatal):', e?.message ?? e);
+} finally {
+  stripMaps();
+}

--- a/src/components/Analytics.web.tsx
+++ b/src/components/Analytics.web.tsx
@@ -3,6 +3,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { usePathname, useSegments } from 'expo-router';
 import { recordPageView } from '../lib/db/pageViews';
+import { setSentryTag } from '../lib/sentry';
 
 export default function AnalyticsProvider() {
   // path is the concrete URL (e.g. /character/123); route is the matched
@@ -20,6 +21,8 @@ export default function AnalyticsProvider() {
     if (!path || lastPath.current === path) return;
     lastPath.current = path;
     void recordPageView(route, path);
+    // Tag the Sentry scope so any error is attributed to the route pattern.
+    setSentryTag('route', route);
   }, [path, route]);
 
   return (

--- a/src/lib/db/clientErrors.ts
+++ b/src/lib/db/clientErrors.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import { supabase } from '../supabase';
+import { captureException } from '../sentry';
 
 // Self-hosted client error collection (web only). Fed by the web ErrorBoundary
 // and global window error / unhandledrejection handlers. Fire-and-forget so
@@ -47,6 +48,13 @@ export function recordClientError(
   const source =
     opts?.source ?? (typeof location !== 'undefined' ? location.pathname + location.search : null);
   const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent.slice(0, 500) : null;
+
+  // Mirror the same deduped/throttled stream into Sentry for aggregation +
+  // alerting (no-op when no DSN). The self-hosted insert below stays the
+  // in-app admin feed — Sentry is additive, not a replacement.
+  const forwarded = new Error(msg);
+  if (stack) forwarded.stack = stack;
+  captureException(forwarded, { kind, source });
 
   void (async () => {
     try {

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,44 @@
+import * as Sentry from '@sentry/react-native';
+
+const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+let started = false;
+
+/**
+ * Initialise crash/error reporting. No-op without a DSN (local dev, tests,
+ * forks) — same fail-soft posture as the sitemap generator — so the app behaves
+ * exactly as before when Sentry isn't configured.
+ *
+ * Errors-only on purpose: tracing/replay/profiling are OFF to protect the
+ * hard-won landing bundle size (the three.js split saved 911 KB — don't hand it
+ * back to an APM bundle). Native fatal-JS coverage comes free from init()
+ * installing the ErrorUtils handler.
+ */
+export function initSentry(): void {
+  if (started || !dsn || process.env.NODE_ENV === 'test') return;
+  started = true;
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 0,
+    enableAutoPerformanceTracing: false,
+    sendDefaultPii: false,
+  });
+}
+
+/**
+ * Report an error to Sentry if configured. Safe to call unconditionally — no-op
+ * when init() never ran. Used alongside the self-hosted client_errors feed, not
+ * instead of it.
+ */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (!started) return;
+  Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+/** Tag the current scope (e.g. the active route) for triage. No-op if uninitialised. */
+export function setSentryTag(key: string, value: string): void {
+  if (!started) return;
+  Sentry.setTag(key, value);
+}
+
+export { Sentry };

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "yarn expo export -p web && node scripts/generate-sitemap.mjs",
+  "buildCommand": "yarn expo export -p web --source-maps && node scripts/generate-sitemap.mjs && node scripts/upload-sourcemaps.mjs",
   "outputDirectory": "dist",
   "rewrites": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3819,6 +3819,211 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/browser-utils@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry-internal/browser-utils@npm:10.37.0"
+  dependencies:
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/d25869667c12268ffebfe24957acc70e6a3295a777b096816d53d6cad2e1defebd8d8121f84d34e5ec79ba7be41b26833f7d0a405953bca037b2ca87bdc2350a
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/feedback@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry-internal/feedback@npm:10.37.0"
+  dependencies:
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/b6438bf58bd2c6dffbdaa48aa80a668337c36f9c330334218e32fb0c38bc076dfc94dda4baf0e1e2b9276d3b788202228cabee4b2d4a6c9026f4b5b247ebf620
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay-canvas@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry-internal/replay-canvas@npm:10.37.0"
+  dependencies:
+    "@sentry-internal/replay": "npm:10.37.0"
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/1a7975ea4063505db766a6913f6fbfb17c35180c55b6a9857ce83579d32c26563b58775c0a871fe7144368678fac20930d21445deb41b86c1c7fd8d9280b07a6
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry-internal/replay@npm:10.37.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:10.37.0"
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/8f8b41f1264969148d580b41cc968525b66b4b05d2a7b405ee44a28ecabd855ee7688866b5e7ed7a70e8b18a64ed3c238dc2c2ad81ae10d5805dafb20a0dde7f
+  languageName: node
+  linkType: hard
+
+"@sentry/babel-plugin-component-annotate@npm:4.8.0":
+  version: 4.8.0
+  resolution: "@sentry/babel-plugin-component-annotate@npm:4.8.0"
+  checksum: 10c0/640f612010b0932c8cf5d753188054735b7d8bc9903c21a431ef6fde65bb91b3b57f4fb859c8e132013a4203ee3983c53326a8978039b97e3155d59e6927eaa0
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry/browser@npm:10.37.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:10.37.0"
+    "@sentry-internal/feedback": "npm:10.37.0"
+    "@sentry-internal/replay": "npm:10.37.0"
+    "@sentry-internal/replay-canvas": "npm:10.37.0"
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/09628c8a987bfa26a1ad119c4f6b7f77bd6a25d1d7c2a70f076c5fe68db455425a41e5e1155bb5bdd489c728e2c1c563c7b68774e05f71dd9a1101a885d2e9ac
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-darwin@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-darwin@npm:2.58.4"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm64@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-linux-arm64@npm:2.58.4"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-linux-arm@npm:2.58.4"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-i686@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-linux-i686@npm:2.58.4"
+  conditions: (os=linux | os=freebsd | os=android) & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-x64@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-linux-x64@npm:2.58.4"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-arm64@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-win32-arm64@npm:2.58.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-i686@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-win32-i686@npm:2.58.4"
+  conditions: os=win32 & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-x64@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli-win32-x64@npm:2.58.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli@npm:2.58.4":
+  version: 2.58.4
+  resolution: "@sentry/cli@npm:2.58.4"
+  dependencies:
+    "@sentry/cli-darwin": "npm:2.58.4"
+    "@sentry/cli-linux-arm": "npm:2.58.4"
+    "@sentry/cli-linux-arm64": "npm:2.58.4"
+    "@sentry/cli-linux-i686": "npm:2.58.4"
+    "@sentry/cli-linux-x64": "npm:2.58.4"
+    "@sentry/cli-win32-arm64": "npm:2.58.4"
+    "@sentry/cli-win32-i686": "npm:2.58.4"
+    "@sentry/cli-win32-x64": "npm:2.58.4"
+    https-proxy-agent: "npm:^5.0.0"
+    node-fetch: "npm:^2.6.7"
+    progress: "npm:^2.0.3"
+    proxy-from-env: "npm:^1.1.0"
+    which: "npm:^2.0.2"
+  dependenciesMeta:
+    "@sentry/cli-darwin":
+      optional: true
+    "@sentry/cli-linux-arm":
+      optional: true
+    "@sentry/cli-linux-arm64":
+      optional: true
+    "@sentry/cli-linux-i686":
+      optional: true
+    "@sentry/cli-linux-x64":
+      optional: true
+    "@sentry/cli-win32-arm64":
+      optional: true
+    "@sentry/cli-win32-i686":
+      optional: true
+    "@sentry/cli-win32-x64":
+      optional: true
+  bin:
+    sentry-cli: bin/sentry-cli
+  checksum: 10c0/9adcc71bf2968f89e1c27c5a24c308a35281eb610bc4736b18f2396e37e9699e1e10f1be95db431e7ff939f3378fbad8634adf0d28fb2b74c74fa81a05070f10
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry/core@npm:10.37.0"
+  checksum: 10c0/129f6d1590a9ced159815b6346ed3a3cf9343d0bb8cb24a4c9e360fae50395af7229168a5c4b2dc04102406961a3851287810b4d05394746171ae65432835b9c
+  languageName: node
+  linkType: hard
+
+"@sentry/react-native@npm:~7.11.0":
+  version: 7.11.0
+  resolution: "@sentry/react-native@npm:7.11.0"
+  dependencies:
+    "@sentry/babel-plugin-component-annotate": "npm:4.8.0"
+    "@sentry/browser": "npm:10.37.0"
+    "@sentry/cli": "npm:2.58.4"
+    "@sentry/core": "npm:10.37.0"
+    "@sentry/react": "npm:10.37.0"
+    "@sentry/types": "npm:10.37.0"
+  peerDependencies:
+    expo: ">=49.0.0"
+    react: ">=17.0.0"
+    react-native: ">=0.65.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
+  bin:
+    sentry-expo-upload-sourcemaps: scripts/expo-upload-sourcemaps.js
+  checksum: 10c0/ce5369f3697ccf4c995b4c1b6af405665d5a3e20b6e20815dccf832690926297dd5d503ee8f0dddbc8937bcd373943285d8ba9db130e77caba19728c94346d52
+  languageName: node
+  linkType: hard
+
+"@sentry/react@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry/react@npm:10.37.0"
+  dependencies:
+    "@sentry/browser": "npm:10.37.0"
+    "@sentry/core": "npm:10.37.0"
+  peerDependencies:
+    react: ^16.14.0 || 17.x || 18.x || 19.x
+  checksum: 10c0/84c15ea511cd973bec571ca34085c8d041e40f51f79cf4206f48391ef2654cdabdaf93be3f58850171c8e13cab8850390c5cdd5fc982416ca3406f988212e8a6
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:10.37.0":
+  version: 10.37.0
+  resolution: "@sentry/types@npm:10.37.0"
+  dependencies:
+    "@sentry/core": "npm:10.37.0"
+  checksum: 10c0/a7e8c582db5b3b709ddfc0cf3c870f5697d6fe6b03a451834e5da39b3197534b86c25737954eeb3ec873d6646f5340fbeeaac7ffc80eeba451f4e0337ba41345
+  languageName: node
+  linkType: hard
+
 "@shuding/opentype.js@npm:1.4.0-beta.0":
   version: 1.4.0-beta.0
   resolution: "@shuding/opentype.js@npm:1.4.0-beta.0"
@@ -8919,7 +9124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.1":
+"https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -11184,6 +11389,7 @@ __metadata:
     "@react-native-google-signin/google-signin": "npm:^16.1.2"
     "@react-native-masked-view/masked-view": "npm:^0.3.2"
     "@react-native/jest-preset": "npm:^0.85.3"
+    "@sentry/react-native": "npm:~7.11.0"
     "@supabase/supabase-js": "npm:^2.101.1"
     "@tanstack/react-query": "npm:^5.101.0"
     "@testing-library/jest-native": "npm:^5.4.3"
@@ -11348,7 +11554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.7.0":
+"node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -12060,6 +12266,13 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 
@@ -14726,7 +14939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1":
+"which@npm:^2.0.1, which@npm:^2.0.2":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:


### PR DESCRIPTION
Spec 2 of the hardening batch — implements `docs/superpowers/specs/2026-07-15-sentry-observability-design.md`.

## Why
The app already had a self-hosted error feed (`client_errors` + a web ErrorBoundary), but **native had nothing** — a native render crash was a silent white screen — and there was no aggregation, alerting, or source-map symbolication anywhere. Sentry slots **beside** the self-hosted feed, never replaces it.

## What
- **`@sentry/react-native`** (`~7.11.0`) via the Expo config plugin + `getSentryExpoConfig` metro wrap — re-applying the SVG transformer + web-stub resolver on top. **Errors-only**: tracing/replay/profiling are OFF to protect the landing bundle (the three.js split saved 911 KB).
- **`src/lib/sentry.ts`** — `initSentry` (no-op without `EXPO_PUBLIC_SENTRY_DSN` or under jest), `captureException`, `setSentryTag`.
- **Native `ErrorBoundary`** in `app/_layout.tsx` (visually mirrors the web one) — the real gap. Reports via Sentry since `recordClientError` is web-only. `initSentry()` at module scope in both root layouts.
- **`recordClientError`** now mirrors its already-deduped/throttled stream into Sentry, so the web boundary + global `error`/`unhandledrejection` handlers forward for free (no new listeners).
- **`Analytics.web`** tags the Sentry scope with the route pattern for triage.
- **Fail-soft source maps** — `expo export --source-maps` emits maps; `scripts/upload-sourcemaps.mjs` uploads to Sentry when `SENTRY_AUTH_TOKEN/ORG/PROJECT` are set (else logs + `exit 0`), then **always strips `.map` from `dist/`** so they reach Sentry but are never served publicly.
- **`__mocks__/@sentry/react-native.js`** (no-op) + `moduleNameMapper`; `.env.example` documents the 4 vars.

## Verification
- `npx tsc --noEmit` clean; `yarn test:ci` → **693 passed**; eslint clean on touched files.
- `yarn expo export -p web --source-maps` **succeeds** — the metro wrap didn't break the SVG transformer or web-stub aliasing.
- Full build chain dry-run: maps emit (2) → upload skips cleanly without env → maps stripped (0 left) → JS bundles intact (2).

## Owner setup (app runs identically until done — safe to merge first)
Create a Sentry project (React Native), then set `EXPO_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` in Vercel env and EAS secrets. With no DSN, the SDK no-ops and zero network calls are made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)