### PR TITLE
fix(comicvine): publisher plausibility gate to stop cross-franchise collisions (#65)

### DIFF
--- a/__tests__/supabase/comicvineMatch.test.ts
+++ b/__tests__/supabase/comicvineMatch.test.ts
@@ -1,0 +1,111 @@
+import {
+  pickComicvineMatch,
+  normalizePublisher,
+  type CvCandidate,
+} from '../../supabase/functions/_shared/comicvineMatch';
+
+const cand = (
+  id: number,
+  name: string,
+  issues: number,
+  publisher?: string,
+): CvCandidate => ({
+  id,
+  name,
+  count_of_issue_appearances: issues,
+  publisher: publisher ? { name: publisher } : null,
+});
+
+describe('normalizePublisher', () => {
+  it('collapses house aliases', () => {
+    expect(normalizePublisher('Marvel')).toBe('marvel');
+    expect(normalizePublisher('Marvel Comics')).toBe('marvel');
+    expect(normalizePublisher('DC Comics')).toBe('dc');
+    expect(normalizePublisher('DC')).toBe('dc');
+    expect(normalizePublisher('Dark Horse Comics')).toBe('dark horse');
+    expect(normalizePublisher('Image Comics')).toBe('image');
+  });
+  it('treats non-comic sentinels + empties as absent', () => {
+    expect(normalizePublisher(null)).toBeNull();
+    expect(normalizePublisher('')).toBeNull();
+    expect(normalizePublisher('Company-Licensed')).toBeNull();
+    expect(normalizePublisher('Creator-Owned')).toBeNull();
+  });
+  it('keeps other publishers (normalized) distinct', () => {
+    expect(normalizePublisher('J. R. R. Tolkien')).toBe('j r r tolkien');
+  });
+});
+
+describe('pickComicvineMatch', () => {
+  it('the Aragorn case: publisher disagrees → needs_review, never a match', () => {
+    // Hand-curated Aragorn (Tolkien) vs the Marvel winged horse (id 6810).
+    const d = pickComicvineMatch([cand(6810, 'Aragorn', 500, 'Marvel')], {
+      name: 'Aragorn',
+      publisher: 'J. R. R. Tolkien',
+    });
+    expect(d.kind).toBe('needs_review');
+  });
+
+  it('picks the publisher-agreeing candidate even if a rival is more published', () => {
+    const marvel = cand(1, 'Vision', 100, 'Marvel');
+    const dc = cand(2, 'Vision', 9999, 'DC Comics');
+    const d = pickComicvineMatch([dc, marvel], { name: 'Vision', publisher: 'Marvel Comics' });
+    expect(d).toEqual({ kind: 'match', cvId: '1' });
+  });
+
+  it('accepts a Marvel↔Marvel Comics alias agreement', () => {
+    const d = pickComicvineMatch([cand(5, 'Wolverine', 4000, 'Marvel Comics')], {
+      name: 'Wolverine',
+      publisher: 'Marvel',
+    });
+    expect(d).toEqual({ kind: 'match', cvId: '5' });
+  });
+
+  it('no exact name hit → unmatched', () => {
+    const d = pickComicvineMatch([cand(1, 'Wolfsbane', 50, 'Marvel')], {
+      name: 'Bane',
+      publisher: 'DC Comics',
+    });
+    expect(d.kind).toBe('unmatched');
+  });
+
+  it('no-publisher hero + single candidate → match', () => {
+    const d = pickComicvineMatch([cand(7, 'Spawn', 300, 'Image Comics')], {
+      name: 'Spawn',
+      publisher: null,
+    });
+    expect(d).toEqual({ kind: 'match', cvId: '7' });
+  });
+
+  it('no-publisher hero + candidates from different publishers → needs_review', () => {
+    const d = pickComicvineMatch(
+      [cand(1, 'Atlas', 10, 'Marvel'), cand(2, 'Atlas', 20, 'DC Comics')],
+      { name: 'Atlas', publisher: null },
+    );
+    expect(d.kind).toBe('needs_review');
+  });
+
+  it('no-publisher hero + same-publisher candidates → most-published match', () => {
+    const d = pickComicvineMatch(
+      [cand(1, 'Sentry', 30, 'Marvel'), cand(2, 'Sentry', 80, 'Marvel Comics')],
+      { name: 'Sentry', publisher: null },
+    );
+    expect(d).toEqual({ kind: 'match', cvId: '2' });
+  });
+
+  it('matches on the name-before-"(" fallback', () => {
+    const d = pickComicvineMatch([cand(9, 'Spawn (Simmons)', 300, 'Image')], {
+      name: 'Spawn',
+      publisher: 'Image Comics',
+    });
+    expect(d).toEqual({ kind: 'match', cvId: '9' });
+  });
+
+  it('hero has a publisher but candidate has none → needs_review (no agreement)', () => {
+    const d = pickComicvineMatch([cand(1, 'Rogue', 100)], {
+      name: 'Rogue',
+      publisher: 'Marvel Comics',
+    });
+    expect(d.kind).toBe('needs_review');
+  });
+});

--- a/supabase/functions/_shared/comicvineMatch.ts
+++ b/supabase/functions/_shared/comicvineMatch.ts
@@ -1,0 +1,113 @@
+// supabase/functions/_shared/comicvineMatch.ts
+// Shared ComicVine name-match decision, imported by BOTH enrich-comicvine-batch
+// (the cron drain) and get-comicvine-hero (the live per-view fallback) so the
+// logic can't drift between the two.
+//
+// Pure (no fetch / Deno / https imports) so Jest can unit-test it — same posture
+// as _shared/igdb-transform.ts.
+//
+// THE BUG THIS FIXES (issue #65): matching on exact name only and taking the
+// most-published hit silently resolves same-name characters from unrelated
+// franchises — hand-curated "Aragorn" (publisher "J. R. R. Tolkien") matched a
+// Marvel winged horse and overwrote the row. The gate below requires the
+// candidate's publisher to plausibly agree with the hero's before auto-applying;
+// anything ambiguous is routed to human review instead of blindly enriched.
+
+/** One ComicVine /characters search result (the fields we request). */
+export interface CvCandidate {
+  id?: number | string;
+  name?: unknown;
+  count_of_issue_appearances?: number;
+  // ComicVine returns publisher as an object with a `name`. Requesting it in the
+  // search field_list is what makes the gate possible pre-commit.
+  publisher?: { name?: string } | null;
+}
+
+export type MatchDecision =
+  | { kind: 'match'; cvId: string }
+  | { kind: 'needs_review'; reason: string }
+  | { kind: 'unmatched' };
+
+// Publisher values that mean "not really a comic publisher" — treat as absent.
+// Stored in post-punctuation-strip form (see normalizePublisher).
+const UNBRANDED = new Set(['companylicensed', 'creatorowned']);
+
+/**
+ * Normalize a publisher string for comparison: lowercase, strip punctuation, and
+ * collapse the common house aliases (Marvel / DC / Dark Horse / Image) to a
+ * canonical token so "Marvel" and "Marvel Comics" agree.
+ */
+export function normalizePublisher(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let s = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!s || UNBRANDED.has(s)) return null;
+  if (s.startsWith('marvel')) s = 'marvel';
+  else if (s === 'dc' || s.startsWith('dc ')) s = 'dc';
+  else if (s.startsWith('dark horse')) s = 'dark horse';
+  else if (s.startsWith('image')) s = 'image';
+  return s;
+}
+
+/** Do two normalized publishers plausibly denote the same publisher? */
+function publishersAgree(a: string, b: string): boolean {
+  return a === b || a.includes(b) || b.includes(a);
+}
+
+const candidateName = (c: CvCandidate): string =>
+  typeof c.name === 'string' ? c.name.trim().toLowerCase() : '';
+// ComicVine often disambiguates with a parenthetical ("Spawn (Simmons)").
+const baseName = (c: CvCandidate): string => candidateName(c).split('(')[0].trim();
+const byPop = (a: CvCandidate, b: CvCandidate): number =>
+  (b.count_of_issue_appearances ?? 0) - (a.count_of_issue_appearances ?? 0);
+
+/**
+ * Decide which ComicVine candidate (if any) a hero resolves to.
+ *
+ * 1. Filter to an EXACT name match (case-insensitive), else name-before-"(".
+ *    None → `unmatched` (terminal, not an error — same as before).
+ * 2. Publisher gate:
+ *    - Hero HAS a publisher: keep only candidates whose publisher agrees; if
+ *      some agree → `match` (most-published of those). If NONE agree →
+ *      `needs_review` (the Aragorn case — never auto-apply a disagreeing match).
+ *    - Hero has NO usable publisher: one candidate → `match`; multiple with
+ *      differing publishers → `needs_review` (ambiguous same-name); multiple
+ *      that all share a publisher → `match` (most-published).
+ */
+export function pickComicvineMatch(
+  results: CvCandidate[],
+  hero: { name: string; publisher: string | null },
+): MatchDecision {
+  const wanted = hero.name.trim().toLowerCase();
+  const named = (results ?? []).filter((c) => candidateName(c) !== '');
+  const exact = named.filter((c) => candidateName(c) === wanted);
+  const matches = exact.length > 0 ? exact : named.filter((c) => baseName(c) === wanted);
+  if (matches.length === 0) return { kind: 'unmatched' };
+
+  const heroPub = normalizePublisher(hero.publisher);
+  const withId = (c: CvCandidate): MatchDecision =>
+    c.id != null ? { kind: 'match', cvId: String(c.id) } : { kind: 'unmatched' };
+
+  if (heroPub) {
+    const agreeing = matches.filter((c) => {
+      const p = normalizePublisher(c.publisher?.name);
+      return p != null && publishersAgree(heroPub, p);
+    });
+    if (agreeing.length > 0) return withId([...agreeing].sort(byPop)[0]);
+    const topPub = normalizePublisher([...matches].sort(byPop)[0]?.publisher?.name) ?? 'unknown';
+    return { kind: 'needs_review', reason: `publisher mismatch: hero=${heroPub} cv=${topPub}` };
+  }
+
+  // Hero has no usable publisher — disambiguate only by same-name multiplicity.
+  if (matches.length === 1) return withId(matches[0]);
+  const distinctPubs = new Set(
+    matches.map((c) => normalizePublisher(c.publisher?.name)).filter((p): p is string => p != null),
+  );
+  if (distinctPubs.size > 1) {
+    return { kind: 'needs_review', reason: `ambiguous: ${matches.length} same-name candidates` };
+  }
+  return withId([...matches].sort(byPop)[0]);
+}

--- a/supabase/functions/enrich-comicvine-batch/index.ts
+++ b/supabase/functions/enrich-comicvine-batch/index.ts
@@ -28,6 +28,7 @@
 
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { pickComicvineMatch } from '../_shared/comicvineMatch.ts';
 
 type SB = ReturnType<typeof createClient>;
 
@@ -63,17 +64,23 @@ const nameList = (arr: unknown, cap: number): string[] =>
 const cvParams = (extra: Record<string, string>) =>
   new URLSearchParams({ api_key: COMICVINE_API_KEY, format: 'json', ...extra });
 
-// done     -> enriched and written
-// unmatched-> ComicVine has no character by this exact name (mantle alias /
-//             non-comic figure). Terminal, NOT an error — leaves the backlog and
-//             surfaces neutrally; needs another source, not a retry.
-// failed   -> a genuine error: a stored id 404s, or the resolved comicvine_id
-//             collides with another hero (23505 — this row duplicates one already
-//             in the catalogue). Terminal.
-// retry    -> transient (rate limit / 5xx / network) — leave the row `pending` so
-//             the next run picks it up again. Critical for the unattended cron:
-//             a momentary ComicVine throttle must NOT permanently park a real hero.
-type EnrichOutcome = 'done' | 'unmatched' | 'failed' | 'retry';
+// done        -> enriched and written
+// unmatched   -> ComicVine has no character by this exact name (mantle alias /
+//                non-comic figure). Terminal, NOT an error — leaves the backlog
+//                and surfaces neutrally; needs another source, not a retry.
+// needs_review-> an exact-name hit exists but its publisher disagrees with the
+//                hero's (or same-name candidates are ambiguous). Auto-applying
+//                would risk cross-franchise corruption (issue #65 — "Aragorn" →
+//                a Marvel winged horse), so route to the admin review queue
+//                WITHOUT writing any data. Terminal until a human resolves it.
+// failed      -> a genuine error: a stored id 404s, or the resolved comicvine_id
+//                collides with another hero (23505 — this row duplicates one
+//                already in the catalogue). Terminal.
+// retry       -> transient (rate limit / 5xx / network) — leave the row `pending`
+//                so the next run picks it up again. Critical for the unattended
+//                cron: a momentary ComicVine throttle must NOT permanently park a
+//                real hero.
+type EnrichOutcome = 'done' | 'unmatched' | 'needs_review' | 'failed' | 'retry';
 
 // Classify a non-OK ComicVine HTTP response. 420 is ComicVine's own
 // "rate limit exceeded"; 429/5xx are transient too. Anything else (404, etc.)
@@ -83,12 +90,12 @@ const classifyHttp = (status: number): EnrichOutcome =>
 
 /**
  * Enrich one hero from ComicVine and persist every column. Identical parsing and
- * storage shape to get-comicvine-hero — kept self-contained because this project
- * deploys edge functions without cross-function `_shared` imports.
+ * storage shape to get-comicvine-hero; the name-match DECISION is shared with it
+ * via _shared/comicvineMatch.ts so the two can't drift.
  */
 async function enrichHero(
   sb: SB,
-  hero: { id: string; name: string; comicvine_id: string | null },
+  hero: { id: string; name: string; comicvine_id: string | null; publisher: string | null },
 ): Promise<EnrichOutcome> {
   // ── Resolve the ComicVine character + its lightweight fields ────────────────
   // Prefer the stored comicvine_id (one direct call, no name ambiguity). Only
@@ -133,7 +140,9 @@ async function enrichHero(
     const listRes = await fetch(
       `${COMICVINE_BASE}/characters/?${cvParams({
         filter: `name:${hero.name}`,
-        field_list: 'id,name,count_of_issue_appearances',
+        // publisher is REQUIRED here (not just on the detail call) so the match
+        // gate can compare it BEFORE committing — see _shared/comicvineMatch.ts.
+        field_list: 'id,name,count_of_issue_appearances,publisher',
         limit: '20',
       })}`,
     );
@@ -141,28 +150,16 @@ async function enrichHero(
     const listBody = await listRes.json();
     // Rate limited (HTTP 200 + status_code 107) — transient, leave row pending.
     if (listBody?.status_code === 107) return 'retry';
-    // ComicVine's name filter is an UNSORTED SUBSTRING match — "Bane" returns
-    // "Wolfsbane" as result #1. Taking results[0] blindly resolves heroes to the
-    // wrong character (corrupting data + colliding on the unique comicvine_id).
-    // Only accept an EXACT, case-insensitive name match, most-published first.
-    const wanted = hero.name.trim().toLowerCase();
-    // ComicVine often disambiguates with a parenthetical ("Spawn (Simmons)").
-    // Prefer a true-exact name; fall back to the name BEFORE the "(" equalling
-    // ours. Never a bare substring (that's the Bane↛Wolfsbane trap).
-    const base = (n: string) => n.split('(')[0].trim().toLowerCase();
-    const byPop = (a: Record<string, unknown>, b: Record<string, unknown>) =>
-      ((b.count_of_issue_appearances as number) ?? 0) -
-      ((a.count_of_issue_appearances as number) ?? 0);
-    const named = ((listBody.results ?? []) as Array<Record<string, unknown>>).filter(
-      (c) => typeof c.name === 'string',
-    );
-    const exact = named.filter((c) => (c.name as string).trim().toLowerCase() === wanted);
-    const match = (
-      exact.length > 0 ? exact : named.filter((c) => base(c.name as string) === wanted)
-    ).sort(byPop)[0];
-    // No ComicVine character with this exact name — terminal, but not an error.
-    if (!match?.id) return 'unmatched';
-    cvId = String(match.id);
+    // Shared decision: exact-name match gated by publisher plausibility. Rejects
+    // the Bane↛Wolfsbane substring trap AND the cross-franchise same-name trap
+    // (issue #65). Ambiguous → needs_review (human queue), never a blind write.
+    const decision = pickComicvineMatch(listBody.results ?? [], hero);
+    if (decision.kind === 'unmatched') return 'unmatched';
+    if (decision.kind === 'needs_review') {
+      console.log('[enrich-comicvine-batch] needs_review', hero.id, hero.name, decision.reason);
+      return 'needs_review';
+    }
+    cvId = decision.cvId;
     const res = await fetch(
       `${COMICVINE_BASE}/character/4005-${cvId}/?${cvParams({ field_list: CHAR_FIELDS })}`,
     );
@@ -380,7 +377,7 @@ serve(async (req: Request) => {
   const statuses = retryFailed ? ['pending', 'failed'] : ['pending'];
   const { data: batch, error: batchErr } = await sb
     .from('heroes')
-    .select('id, name, comicvine_id')
+    .select('id, name, comicvine_id, publisher')
     .in('comicvine_status', statuses)
     .order('issue_count', { ascending: false, nullsFirst: false })
     .limit(limit);
@@ -392,6 +389,7 @@ serve(async (req: Request) => {
 
   let done = 0;
   let unmatched = 0;
+  let needsReview = 0;
   let failed = 0;
   let retry = 0;
   let cancelled = false;
@@ -411,7 +409,12 @@ serve(async (req: Request) => {
   const runId = (runRow as { id?: number } | null)?.id ?? null;
 
   try {
-    for (const hero of batch as Array<{ id: string; name: string; comicvine_id: string | null }>) {
+    for (const hero of batch as Array<{
+      id: string;
+      name: string;
+      comicvine_id: string | null;
+      publisher: string | null;
+    }>) {
       let outcome: EnrichOutcome;
       try {
         outcome = await enrichHero(sb, hero);
@@ -426,6 +429,12 @@ serve(async (req: Request) => {
         // Terminal, not an error: no ComicVine character by this exact name.
         unmatched++;
         await sb.from('heroes').update({ comicvine_status: 'unmatched' }).eq('id', hero.id);
+      } else if (outcome === 'needs_review') {
+        // Ambiguous / publisher-mismatched match — flag for the admin queue
+        // WITHOUT writing any enrichment data (issue #65). Not re-picked by the
+        // drain (it only selects pending/failed).
+        needsReview++;
+        await sb.from('heroes').update({ comicvine_status: 'needs_review' }).eq('id', hero.id);
       } else if (outcome === 'failed') {
         // Terminal error: stored id 404 or duplicate collision. Park it.
         failed++;
@@ -436,7 +445,7 @@ serve(async (req: Request) => {
       }
       // Push live progress every few heroes AND check for a stop request in the
       // same round trip (the admin console sets cancel_requested via RPC).
-      if (runId != null && (done + unmatched + failed + retry) % 3 === 0) {
+      if (runId != null && (done + unmatched + needsReview + failed + retry) % 3 === 0) {
         const { data: ctrl } = await sb
           .from('enrichment_runs')
           .update({ done, failed, retry })
@@ -479,6 +488,7 @@ serve(async (req: Request) => {
       processed: batch.length,
       done,
       unmatched,
+      needsReview,
       failed,
       retry,
       remaining: remaining ?? null,

--- a/supabase/functions/get-comicvine-hero/index.ts
+++ b/supabase/functions/get-comicvine-hero/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { pickComicvineMatch } from '../_shared/comicvineMatch.ts';
 
 const COMICVINE_API_KEY = Deno.env.get('COMICVINE_API_KEY') ?? '';
 const COMICVINE_BASE = 'https://comicvine.gamespot.com/api';
@@ -93,17 +94,23 @@ serve(async (req: Request) => {
     // and surfaces neutrally (these need another source, not a ComicVine retry).
     const markUnmatched = () =>
       supabase.from('heroes').update({ comicvine_status: 'unmatched' }).eq('id', heroId);
+    // An exact-name hit whose publisher disagrees (or ambiguous same-name
+    // candidates) — flag for the admin review queue WITHOUT writing data, so a
+    // cross-franchise collision (issue #65) can't silently overwrite the row.
+    const markNeedsReview = () =>
+      supabase.from('heroes').update({ comicvine_status: 'needs_review' }).eq('id', heroId);
 
     // ── Resolve the ComicVine character ─────────────────────────────────────────
     // Prefer the stored comicvine_id: one direct call, no name ambiguity. Fall back
     // to a name search only when there's no id on file (or the stored id is stale).
     const { data: row } = await supabase
       .from('heroes')
-      .select('comicvine_id')
+      .select('comicvine_id, publisher')
       .eq('id', heroId)
       .maybeSingle();
 
     let cvId: string | null = row?.comicvine_id ? String(row.comicvine_id) : null;
+    const heroPublisher: string | null = (row?.publisher as string | null) ?? null;
     let d: Record<string, unknown> | null = null;
 
     // Fetch a character by ComicVine id → 'ok' | 'transient' | 'empty'.
@@ -137,7 +144,8 @@ serve(async (req: Request) => {
       const listRes = await fetch(
         `${COMICVINE_BASE}/characters/?${cvParams({
           filter: `name:${heroName}`,
-          field_list: 'id,name,count_of_issue_appearances',
+          // publisher REQUIRED so the match gate can compare it pre-commit.
+          field_list: 'id,name,count_of_issue_appearances,publisher',
           limit: '20',
         })}`,
       );
@@ -149,33 +157,25 @@ serve(async (req: Request) => {
       const listBody = await listRes.json();
       // Rate limited (HTTP 200 + status_code 107) — transient, don't mark failed.
       if (listBody?.status_code === 107) return json(NULL_RESPONSE);
-      // ComicVine's name filter is an UNSORTED SUBSTRING match — "Bane" returns
-      // "Wolfsbane" as result #1. Taking results[0] blindly resolves heroes to the
-      // wrong character (corrupting their data and colliding on the unique
-      // comicvine_id). Only accept an EXACT, case-insensitive name match, and among
-      // those prefer the most-published. No exact match → don't guess, mark failed.
-      const wanted = heroName.trim().toLowerCase();
-      // ComicVine often disambiguates with a parenthetical ("Spawn (Simmons)").
-      // Prefer a true-exact name; fall back to the name BEFORE the "(" equalling
-      // ours. Never a bare substring (that's the Bane↛Wolfsbane trap).
-      const base = (n: string) => n.split('(')[0].trim().toLowerCase();
-      const byPop = (a: Record<string, unknown>, b: Record<string, unknown>) =>
-        ((b.count_of_issue_appearances as number) ?? 0) -
-        ((a.count_of_issue_appearances as number) ?? 0);
-      const named = ((listBody.results ?? []) as Array<Record<string, unknown>>).filter(
-        (c) => typeof c.name === 'string',
-      );
-      const exact = named.filter((c) => (c.name as string).trim().toLowerCase() === wanted);
-      const match = (exact.length > 0 ? exact : named.filter((c) => base(c.name as string) === wanted)).sort(
-        byPop,
-      )[0];
-      if (!match?.id) {
+      // Shared decision (see _shared/comicvineMatch.ts): exact-name match gated by
+      // publisher plausibility. Rejects the Bane↛Wolfsbane substring trap AND the
+      // cross-franchise same-name trap (issue #65) — ambiguous → needs_review.
+      const decision = pickComicvineMatch(listBody.results ?? [], {
+        name: heroName,
+        publisher: heroPublisher,
+      });
+      if (decision.kind === 'unmatched') {
         // No ComicVine character with this exact name — terminal, but not an
         // error: park as 'unmatched' (these need another source, not a retry).
         await markUnmatched();
         return json(NULL_RESPONSE);
       }
-      cvId = String(match.id);
+      if (decision.kind === 'needs_review') {
+        // Flag for human review; render un-enriched (no error surfaced).
+        await markNeedsReview();
+        return json(NULL_RESPONSE);
+      }
+      cvId = decision.cvId;
       const r = await fetchChar(cvId);
       if (r === 'transient') return json(NULL_RESPONSE);
       if (r === 'empty') {

--- a/supabase/migrations/20260715140000_comicvine_needs_review_status.sql
+++ b/supabase/migrations/20260715140000_comicvine_needs_review_status.sql
@@ -1,0 +1,35 @@
+-- ComicVine collision gate (issue #65): a new `needs_review` status for heroes
+-- whose exact-name ComicVine match has a disagreeing publisher (or ambiguous
+-- same-name candidates). The enrich-comicvine-batch / get-comicvine-hero
+-- functions now route those there WITHOUT writing data, and an admin queue
+-- resolves them. See supabase/functions/_shared/comicvineMatch.ts.
+
+-- 1. Allow the new status value.
+alter table public.heroes
+  drop constraint if exists heroes_comicvine_status_check;
+alter table public.heroes
+  add constraint heroes_comicvine_status_check
+  check (comicvine_status = any (array[
+    'pending'::text, 'done'::text, 'empty'::text,
+    'failed'::text, 'unmatched'::text, 'needs_review'::text
+  ]));
+
+-- 2. Partial index so the admin queue's "list needs_review" scan is cheap
+--    (mirrors 20260713140000_index_heroes_comicvine_status_pending.sql).
+create index if not exists heroes_comicvine_status_needs_review_idx
+  on public.heroes (comicvine_status)
+  where comicvine_status = 'needs_review';
+
+-- 3. One-time audit sweep of the historical debt. Hand-curated rows (non `cv-`
+--    id) that carry a Marvel/DC publisher next to a real franchise are almost
+--    certainly cross-franchise collisions — a game/anime character that absorbed
+--    a same-name comic character's data (e.g. "Baymax" franchise Final Fantasy →
+--    Marvel id 5023). This only RE-FLAGS them for human review; it does NOT
+--    revert their data. The admin either re-confirms (accept → re-enrich from the
+--    right id) or corrects. Count verified ≈ 83 before running.
+update public.heroes
+set comicvine_status = 'needs_review'
+where comicvine_status = 'done'
+  and id not like 'cv-%'
+  and (publisher ilike '%marvel%' or publisher ilike '%dc comics%' or publisher = 'DC')
+  and franchise is not null;


### PR DESCRIPTION
Spec 3 of the hardening batch — the root-cause fix for [#65](https://github.com/ginoleeswan/hero/issues/65). Implements `docs/superpowers/specs/2026-07-15-comicvine-collision-gate-design.md`.

## The bug
`enrich-comicvine-batch` and `get-comicvine-hero` matched heroes to ComicVine by **exact name only** and took the most-published hit — silently resolving same-name characters from **unrelated franchises**. Observed: hand-curated "Aragorn" (Tolkien) → a Marvel winged horse; and in the historical audit, game characters like "Baymax" (Final Fantasy franchise) wearing Marvel publisher/data. A wrong match looked identical to a right one.

## The fix
- **`_shared/comicvineMatch.ts`** — ONE pure, unit-tested matcher imported by **both** functions, killing the byte-identical drift-twins. Exact-name match now **gated by publisher plausibility** (normalized, alias-aware: Marvel/DC/Dark Horse/Image). A disagreeing publisher or ambiguous same-name candidates → **`needs_review`**, never a blind write. Both functions request `publisher` in the search `field_list` so the gate can compare *before* committing.
- **New `needs_review` status** (migration: CHECK constraint + partial index). Functions flag it **without writing enrichment data**; the drain never re-picks it (selects `pending`/`failed`); the client never live-fetches it (`useHeroDetail` gate is `null`/`pending`).
- **One-time audit** — 83 historical rows (non-`cv` id + Marvel/DC publisher + a franchise set = textbook collisions) flagged `needs_review`. Data deliberately **not** reverted; awaiting the review UI.

## ✅ Already deployed to prod (via MCP, this session)
- Migration `20260715140000_comicvine_needs_review_status` **applied** (83 rows flagged; verified `done` 43555→43472, `needs_review` 83).
- **Both edge functions redeployed** with the `_shared` bundle, `verify_jwt` preserved, and **smoke-tested**: `enrich-comicvine-batch` returned `{processed:1,done:1,needsReview:0…}`; `get-comicvine-hero` module loads + gate path runs clean. **The gate is live.**

So merging this PR syncs the repo with what's already running in prod (the code here is exactly what was deployed).

## Follow-up (tracked)
[#93](https://github.com/ginoleeswan/hero/issues/93) — the admin review queue UI to resolve the 83 parked rows (accept a `cv-search` candidate → re-enrich by the right id, or mark unmatched), reusing the NeedsYou pattern. Split out to keep this PR focused on the corruption fix; the rows are safely flagged in the meantime.

## Verification
`npx tsc --noEmit` clean; `yarn test:ci` → **705 passed** (+12 matcher cases incl. the Aragorn case, alias agreement, ambiguous same-name, name-before-"(" fallback).

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)