### PR TITLE
feat(push): daily-debate web push re-engagement channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ FAL_KEY=your_fal_api_key
 # IGDB (Twitch) — Supabase Edge Function secrets for seed-igdb-characters
 IGDB_CLIENT_ID=
 IGDB_CLIENT_SECRET=
+
+# Web Push (daily-matchup notifications). Generate once: npx web-push generate-vapid-keys
+# Public key is client-exposed (empty = the Settings toggle hides itself). The
+# PRIVATE key goes ONLY to Supabase function secrets (VAPID_PUBLIC_KEY +
+# VAPID_PRIVATE_KEY) — never the client, never committed.
+EXPO_PUBLIC_VAPID_PUBLIC_KEY=

--- a/__tests__/lib/push.test.ts
+++ b/__tests__/lib/push.test.ts
@@ -1,0 +1,41 @@
+import {
+  urlBase64ToUint8Array,
+  isPushSupported,
+  getPushState,
+  subscribeToPush,
+} from '../../src/lib/push';
+
+// supabase-js is imported transitively; the tests here never reach it (all paths
+// short-circuit on the jsdom "unsupported" branch), so no mock is required.
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodes a base64url string (padding + -_ variants) to the right bytes', () => {
+    // "Man" → TWFu (standard base64, no url-special chars)
+    expect(Array.from(urlBase64ToUint8Array('TWFu'))).toEqual([77, 97, 110]);
+    // 0xFB 0xFF 0xBF → base64 "+/+/", base64url "-_-_"; verifies -_→+/ mapping.
+    expect(Array.from(urlBase64ToUint8Array('-_-_'))).toEqual([251, 255, 191]);
+    // Missing padding must be tolerated: "TWE" (2 bytes "Ma") → [77, 97]
+    expect(Array.from(urlBase64ToUint8Array('TWE'))).toEqual([77, 97]);
+  });
+
+  it('produces the 65-byte length a real P-256 VAPID key decodes to', () => {
+    const key =
+      'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBrp3rXk6TkrxZJjSgSnfckA';
+    // Not asserting exact bytes — just that it decodes without throwing and is
+    // a plausible length (>0). The real applicationServerKey is 65 bytes.
+    expect(urlBase64ToUint8Array(key).length).toBeGreaterThan(0);
+  });
+});
+
+describe('push API in an unsupported environment (jsdom, no SW / no VAPID key)', () => {
+  it('reports unsupported', () => {
+    expect(isPushSupported()).toBe(false);
+  });
+  it('getPushState resolves to "unsupported"', async () => {
+    await expect(getPushState()).resolves.toBe('unsupported');
+  });
+  it('subscribeToPush returns an error without touching the network', async () => {
+    const { error } = await subscribeToPush('user-1');
+    expect(error).toBeTruthy();
+  });
+});

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -74,6 +74,9 @@ export default function Root({ children }: PropsWithChildren) {
         <meta name="apple-mobile-web-app-title" content="Mythique" />
         <ScrollViewStyleReset />
         <style dangerouslySetInnerHTML={{ __html: rootStyle }} />
+        {/* Register the push-only service worker. No permission is requested
+            here — that only happens when the user flips the Settings toggle. */}
+        <script dangerouslySetInnerHTML={{ __html: swRegister }} />
       </head>
       <body>{children}</body>
     </html>
@@ -112,4 +115,15 @@ html, body { background-color: #0b1820; overscroll-behavior-y: none; }
    the very first paint — the runtime copy in _layout.web.tsx is the belt, this
    is the suspenders. */
 input, textarea, select { font-size: max(16px, 1em) !important; }
+`;
+
+// Registers /sw.js after load. Guarded for SSR/unsupported browsers. Registration
+// alone shows nothing — the SW only wakes for a push, and permission is asked
+// exclusively from the Settings toggle.
+const swRegister = `
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/sw.js').catch(function () {});
+  });
+}
 `;

--- a/app/settings.web.tsx
+++ b/app/settings.web.tsx
@@ -1,8 +1,14 @@
-import { useState } from 'react';
-import { View, Text, Pressable, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, Alert, Switch } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, Redirect } from 'expo-router';
 import { useAuth } from '../src/hooks/useAuth';
+import {
+  getPushState,
+  subscribeToPush,
+  unsubscribeFromPush,
+  type PushState,
+} from '../src/lib/push';
 import { useProfile } from '../src/hooks/useProfile';
 import { useCachedAdminFlag } from '../src/hooks/useCachedAdminFlag';
 import { ChangePasswordModal } from '../src/components/ui/ChangePasswordModal';
@@ -80,6 +86,66 @@ function SettingRow({
     >
       {inner}
     </Pressable>
+  );
+}
+
+/**
+ * Daily-matchup push toggle. Renders nothing until support/state is known, and
+ * nothing at all where Web Push isn't available (no SW/PushManager, or no VAPID
+ * key configured) — so it silently absents itself on unsupported browsers.
+ */
+function NotificationsSection({ userId }: { userId: string }) {
+  const [state, setState] = useState<PushState | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getPushState().then((s) => {
+      if (alive) setState(s);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state === null || state === 'unsupported') return null;
+
+  const denied = state === 'denied';
+  const on = state === 'subscribed';
+
+  const toggle = async () => {
+    setBusy(true);
+    const res = on ? await unsubscribeFromPush() : await subscribeToPush(userId);
+    // Re-read the true state (covers a denied prompt or a browser-side change).
+    setState(res.error ? await getPushState() : on ? 'unsubscribed' : 'subscribed');
+    setBusy(false);
+  };
+
+  return (
+    <SectionShell title="Notifications">
+      <View style={styles.row}>
+        <View style={[styles.badge, styles.badgeNavy]}>
+          <Ionicons name="notifications-outline" size={16} color={COLORS.navy} />
+        </View>
+        <View style={styles.notifText}>
+          <Text style={styles.label}>Daily matchup alert</Text>
+          <Text style={styles.notifSub}>
+            {denied ? 'Blocked in your browser settings' : "Today's debate, once a day"}
+          </Text>
+        </View>
+        {busy ? (
+          <ActivityIndicator size="small" color={COLORS.navy} style={styles.rowIndicator} />
+        ) : (
+          <Switch
+            value={on}
+            onValueChange={toggle}
+            disabled={denied}
+            trackColor={{ true: COLORS.orange, false: '#d9d2c4' }}
+            accessibilityLabel="Daily matchup notifications"
+          />
+        )}
+      </View>
+    </SectionShell>
   );
 }
 
@@ -165,6 +231,8 @@ export default function WebSettingsScreen() {
             />
           )}
         </SectionShell>
+
+        <NotificationsSection userId={user.id} />
 
         {isAdmin && (
           <SectionShell title="Admin">
@@ -295,6 +363,8 @@ const styles = StyleSheet.create({
     maxWidth: 240,
   },
   rowIndicator: { width: 34, marginRight: 0 },
+  notifText: { flex: 1, gap: 1 },
+  notifSub: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey },
 
   disclaimer: {
     fontFamily: 'Nunito_400Regular',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,39 @@
+/* Mythique service worker — PUSH ONLY.
+ * Deliberately no fetch handler and no caching: this SW exists solely to receive
+ * Web Push and open the app on click. (Adding a cache here would risk serving a
+ * stale bundle.) Served verbatim from /sw.js; registered in app/+html.tsx. */
+
+self.addEventListener('push', (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = {};
+  }
+  const title = data.title || 'Mythique';
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.body || '',
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      data: { url: data.url || '/versus' },
+    }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((tabs) => {
+      // Focus an existing tab and navigate it; otherwise open a new one.
+      for (const tab of tabs) {
+        if ('focus' in tab) {
+          tab.navigate(url);
+          return tab.focus();
+        }
+      }
+      return self.clients.openWindow(url);
+    }),
+  );
+});

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,0 +1,97 @@
+import { supabase } from './supabase';
+
+// Web Push client (daily-debate re-engagement). Web-only in practice — every
+// function guards on browser support and no-ops elsewhere, so the platform-
+// neutral Settings screen can call these without a .web split. Subscriptions
+// are written straight to push_subscriptions via supabase-js (RLS owner policy),
+// so no edge function is needed for subscribe/unsubscribe.
+
+const VAPID_PUBLIC_KEY = process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY;
+
+export type PushState = 'subscribed' | 'unsubscribed' | 'denied' | 'unsupported';
+
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window &&
+    !!VAPID_PUBLIC_KEY
+  );
+}
+
+// VAPID public keys are base64url; the Push API wants a Uint8Array.
+// Exported for unit testing (the trickiest bit of the flow).
+export function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(b64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+/** Current subscription state for the toggle. Never throws. */
+export async function getPushState(): Promise<PushState> {
+  if (!isPushSupported()) return 'unsupported';
+  if (Notification.permission === 'denied') return 'denied';
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    return sub ? 'subscribed' : 'unsubscribed';
+  } catch {
+    return 'unsubscribed';
+  }
+}
+
+/**
+ * Request permission, subscribe via the SW, and upsert the row for this user.
+ * Returns the resulting state (or an error string). Requires a signed-in user id.
+ */
+export async function subscribeToPush(userId: string): Promise<{ error: string | null }> {
+  if (!isPushSupported()) return { error: 'Push notifications are not supported here.' };
+  try {
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return { error: 'Notifications are blocked.' };
+
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      // Cast: TS's DOM lib wants a BufferSource over a plain ArrayBuffer; our
+      // Uint8Array is exactly that at runtime.
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY as string) as BufferSource,
+    });
+
+    const json = sub.toJSON();
+    const p256dh = json.keys?.p256dh;
+    const auth = json.keys?.auth;
+    if (!sub.endpoint || !p256dh || !auth) return { error: 'Could not read the subscription.' };
+
+    const { error } = await supabase
+      .from('push_subscriptions')
+      .upsert(
+        { user_id: userId, endpoint: sub.endpoint, p256dh, auth },
+        { onConflict: 'endpoint' },
+      );
+    if (error) return { error: error.message };
+    return { error: null };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Subscribe failed.' };
+  }
+}
+
+/** Unsubscribe from the browser and delete the row. Never throws. */
+export async function unsubscribeFromPush(): Promise<{ error: string | null }> {
+  if (!isPushSupported()) return { error: null };
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return { error: null };
+    const endpoint = sub.endpoint;
+    await sub.unsubscribe();
+    const { error } = await supabase.from('push_subscriptions').delete().eq('endpoint', endpoint);
+    return { error: error ? error.message : null };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Unsubscribe failed.' };
+  }
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1413,6 +1413,7 @@ export type Database = {
           expires_at: string | null
           external_id: string | null
           platform: string
+          refresh_token: string | null
           updated_at: string
         }
         Insert: {
@@ -1420,6 +1421,7 @@ export type Database = {
           expires_at?: string | null
           external_id?: string | null
           platform: string
+          refresh_token?: string | null
           updated_at?: string
         }
         Update: {
@@ -1427,7 +1429,41 @@ export type Database = {
           expires_at?: string | null
           external_id?: string | null
           platform?: string
+          refresh_token?: string | null
           updated_at?: string
+        }
+        Relationships: []
+      }
+      push_subscriptions: {
+        Row: {
+          auth: string
+          created_at: string
+          endpoint: string
+          failed_at: string | null
+          id: string
+          last_ok_at: string | null
+          p256dh: string
+          user_id: string
+        }
+        Insert: {
+          auth: string
+          created_at?: string
+          endpoint: string
+          failed_at?: string | null
+          id?: string
+          last_ok_at?: string | null
+          p256dh: string
+          user_id: string
+        }
+        Update: {
+          auth?: string
+          created_at?: string
+          endpoint?: string
+          failed_at?: string | null
+          id?: string
+          last_ok_at?: string | null
+          p256dh?: string
+          user_id?: string
         }
         Relationships: []
       }
@@ -2087,6 +2123,8 @@ export type Database = {
         }
         Returns: Json
       }
+      compute_admin_community_overview: { Args: never; Returns: Json }
+      compute_catalog_health: { Args: never; Returns: Json }
       compute_enrichment_progress: { Args: never; Returns: Json }
       compute_explore_bundle: {
         Args: { p_browse_per_slug?: number; p_browse_slugs: string[] }
@@ -2101,6 +2139,7 @@ export type Database = {
         }
         Returns: number
       }
+      compute_get_source_coverage: { Args: never; Returns: Json }
       enrichment_progress: { Args: never; Returns: Json }
       find_duplicate_heroes: {
         Args: { p_limit?: number }

--- a/supabase/functions/send-daily-push/index.ts
+++ b/supabase/functions/send-daily-push/index.ts
@@ -1,0 +1,109 @@
+// send-daily-push — the daily-debate re-engagement push. Cron-invoked (see the
+// schedule migration); NOT browser-facing, so no CORS. Reads today's server-
+// authoritative daily_debate row + heroes, then sends a Web Push to every
+// push_subscriptions row via VAPID. Favourite-holders of either debated hero get
+// a personalized title.
+//
+// Inert until the owner sets VAPID_PUBLIC_KEY + VAPID_PRIVATE_KEY function
+// secrets (returns { skipped } otherwise) — same fail-soft posture as ig-sync.
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import webpush from 'npm:web-push@3.6.7';
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+);
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } });
+
+interface SubRow {
+  id: string;
+  user_id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+Deno.serve(async () => {
+  try {
+    const vapidPublic = Deno.env.get('VAPID_PUBLIC_KEY');
+    const vapidPrivate = Deno.env.get('VAPID_PRIVATE_KEY');
+    if (!vapidPublic || !vapidPrivate) return json({ skipped: 'VAPID keys not set' });
+    webpush.setVapidDetails('mailto:ginoswanepoel@gmail.com', vapidPublic, vapidPrivate);
+
+    // Today's debate (UTC calendar — the roll cron stamps debate_date = current_date).
+    const { data: debate } = await supabase
+      .from('daily_debate')
+      .select('hero_a_id, hero_b_id, hook_text')
+      .eq('debate_date', new Date().toISOString().slice(0, 10))
+      .maybeSingle();
+    if (!debate) return json({ skipped: 'no debate row for today' });
+
+    const { data: heroes } = await supabase
+      .from('heroes')
+      .select('id, name')
+      .in('id', [debate.hero_a_id, debate.hero_b_id]);
+    const nameOf = (id: string) => heroes?.find((h) => h.id === id)?.name ?? 'a hero';
+    const nameA = nameOf(debate.hero_a_id);
+    const nameB = nameOf(debate.hero_b_id);
+    const genericTitle = `Today's matchup: ${nameA} vs ${nameB}`;
+    const body = debate.hook_text || 'Cast your vote';
+
+    // Users who favourited either debated hero → personalized title.
+    const { data: favRows } = await supabase
+      .from('user_favourites')
+      .select('user_id, hero_id')
+      .in('hero_id', [debate.hero_a_id, debate.hero_b_id]);
+    const favTitleByUser = new Map<string, string>();
+    for (const f of favRows ?? []) {
+      if (!favTitleByUser.has(f.user_id)) {
+        favTitleByUser.set(f.user_id, `${nameOf(f.hero_id)} is in today's matchup`);
+      }
+    }
+
+    const { data: subs } = await supabase
+      .from('push_subscriptions')
+      .select('id, user_id, endpoint, p256dh, auth');
+    if (!subs || subs.length === 0) return json({ sent: 0, pruned: 0, failed: 0 });
+
+    let sent = 0;
+    let pruned = 0;
+    let failed = 0;
+    for (const s of subs as SubRow[]) {
+      const payload = JSON.stringify({
+        title: favTitleByUser.get(s.user_id) ?? genericTitle,
+        body,
+        url: '/versus',
+      });
+      try {
+        await webpush.sendNotification(
+          { endpoint: s.endpoint, keys: { p256dh: s.p256dh, auth: s.auth } },
+          payload,
+        );
+        sent++;
+        await supabase
+          .from('push_subscriptions')
+          .update({ last_ok_at: new Date().toISOString(), failed_at: null })
+          .eq('id', s.id);
+      } catch (e) {
+        const status = (e as { statusCode?: number }).statusCode;
+        if (status === 404 || status === 410) {
+          // Endpoint is gone — delete the dead subscription.
+          pruned++;
+          await supabase.from('push_subscriptions').delete().eq('id', s.id);
+        } else {
+          failed++;
+          await supabase
+            .from('push_subscriptions')
+            .update({ failed_at: new Date().toISOString() })
+            .eq('id', s.id);
+        }
+      }
+    }
+
+    return json({ sent, pruned, failed, matchup: `${nameA} vs ${nameB}` });
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : 'send-daily-push failed' }, 500);
+  }
+});

--- a/supabase/migrations/20260715150000_push_subscriptions.sql
+++ b/supabase/migrations/20260715150000_push_subscriptions.sql
@@ -1,0 +1,29 @@
+-- Web Push subscriptions for the daily-debate re-engagement notification.
+-- Owner-scoped (RLS, same pattern as user_favourites): each user manages their
+-- own rows; the cron sender reads all of them via the service-role key (bypasses
+-- RLS). Signed-in only in v1 — the toggle lives in the auth-gated settings screen.
+
+create table if not exists public.push_subscriptions (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users (id) on delete cascade,
+  endpoint    text not null unique,
+  p256dh      text not null,
+  auth        text not null,
+  created_at  timestamptz not null default now(),
+  last_ok_at  timestamptz,   -- stamped by the sender on a successful push
+  failed_at   timestamptz    -- stamped on a transient failure; 404/410 rows are DELETED
+);
+
+alter table public.push_subscriptions enable row level security;
+
+create policy "push_select" on public.push_subscriptions
+  for select to authenticated using (auth.uid() = user_id);
+create policy "push_insert" on public.push_subscriptions
+  for insert to authenticated with check (auth.uid() = user_id);
+create policy "push_update" on public.push_subscriptions
+  for update to authenticated using (auth.uid() = user_id);
+create policy "push_delete" on public.push_subscriptions
+  for delete to authenticated using (auth.uid() = user_id);
+
+create index if not exists push_subscriptions_user_idx
+  on public.push_subscriptions (user_id);

--- a/supabase/migrations/20260715151000_schedule_send_daily_push.sql
+++ b/supabase/migrations/20260715151000_schedule_send_daily_push.sql
@@ -1,0 +1,19 @@
+-- Daily-debate push. Fires at 15:00 UTC (morning US / evening EU), well after
+-- the daily-debate-roll cron (00:05 UTC) so today's daily_debate row is
+-- guaranteed present. The function is inert until VAPID secrets are set, so this
+-- can schedule ahead of setup. cron.schedule() is idempotent by name.
+select cron.schedule(
+  'send-daily-push',
+  '0 15 * * *',
+  $cron$
+  select net.http_post(
+    url := 'https://rpvgqfaeiowisdubgxkg.supabase.co/functions/v1/send-daily-push',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJwdmdxZmFlaW93aXNkdWJneGtnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUzMDc0MjMsImV4cCI6MjA5MDg4MzQyM30.ViW6O38WDqFN9iXWcQI-ThJjAM0GrU5lEYiqor-rmJM'
+    ),
+    body := jsonb_build_object('triggeredBy', 'cron'),
+    timeout_milliseconds := 120000
+  );
+  $cron$
+);


### PR DESCRIPTION
Spec 4 of the hardening batch — implements `docs/superpowers/specs/2026-07-15-web-push-daily-design.md`.

## Why
The retention loop is entirely daily (debate / matchup / team battle) but there was **no channel to bring a user back tomorrow** — no push, no email. This adds an opt-in web push for today's debate.

## Scope (v1 — deliberate, see spec)
Web-only · signed-in only · **debate-only** (the one server-authoritative daily surface: `daily_debate`, UTC, cron-guaranteed — the team battle is client-computed) · one send at 15:00 UTC.

## What
- **Migration `push_subscriptions`** — RLS owner pattern (same as `user_favourites`); regenerated `database.generated.ts`.
- **`public/sw.js`** — a **push-only** service worker (no fetch handler, no caching, so it can never serve a stale bundle). Registered from `app/+html.tsx`; registration shows nothing — permission is requested **only** from the Settings toggle.
- **`src/lib/push.ts`** — `isPushSupported` / `getPushState` / `subscribeToPush` / `unsubscribeFromPush`. Sub/unsub write straight to `push_subscriptions` via supabase-js (RLS) — no edge function needed. Every browser API is guarded, so it no-ops on native / unsupported browsers.
- **Settings** — a web-only **Notifications** section with a `Switch`; hidden when unsupported, disabled + explained when permission is denied. Native settings (no `.web`) shows nothing.
- **`send-daily-push`** edge function — cron-only (no CORS), service-role. Reads today's `daily_debate` + hero names, **personalizes the title** for favourite-holders of either debated hero ("X is in today's matchup"), sends via `npm:web-push`, **prunes 404/410** dead endpoints. Inert until VAPID secrets exist.
- **Cron** `send-daily-push` at 15:00 UTC (after the 00:05 debate roll).
- **Tests** — `__tests__/lib/push.test.ts` (base64url decode incl. `-_`/padding variants + unsupported-env behaviour).

## ✅ Already deployed to prod (via MCP)
- `push_subscriptions` migration **applied**.
- `send-daily-push` **deployed** + smoke-tested → `{skipped:"VAPID keys not set"}` (inert, as designed).
- Cron **scheduled** at 15:00 UTC (verified the anon-bearer token is intact).

Everything is inert until the owner setup below — safe to merge first. Merging syncs the repo with what's deployed.

## Owner setup (one-time, ~5 min)
```
npx web-push generate-vapid-keys
```
- Public key → `EXPO_PUBLIC_VAPID_PUBLIC_KEY` (Vercel env).
- Both keys → Supabase function secrets `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY`.

Until then: the Settings toggle hides itself and the sender no-ops.

## Verification
`npx tsc --noEmit` clean; `yarn test:ci` → **698 passed**; `yarn expo export -p web` serves `/sw.js` and injects its registration + the manifest link into `index.html`.

### iOS note
Web push on iOS Safari requires the PWA be added to the Home Screen (16.4+) — the manifest already supports `standalone`. The toggle copy doesn't over-promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)