### PR TITLE
feat(admin): ComicVine review queue for needs_review heroes (closes #93)

### DIFF
--- a/__tests__/lib/db/comicvineReview.test.ts
+++ b/__tests__/lib/db/comicvineReview.test.ts
@@ -1,0 +1,83 @@
+import {
+  listComicvineNeedsReview,
+  countComicvineNeedsReview,
+  acceptComicvineMatch,
+  markComicvineUnmatched,
+} from '../../../src/lib/db/comicvineReview';
+
+// A thenable chain: every builder method returns the chain, and awaiting it
+// resolves the current `mockResult` (list awaits after .limit; count after .eq).
+let mockResult: { data?: unknown[]; count?: number; error: unknown } = { data: [], error: null };
+const mockRpc = jest.fn().mockResolvedValue({ error: null });
+
+jest.mock('../../../src/lib/supabase', () => {
+  const chain: Record<string, unknown> = {};
+  ['select', 'eq', 'order', 'limit'].forEach((m) => {
+    chain[m] = jest.fn().mockReturnValue(chain);
+  });
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(mockResult);
+  return {
+    supabase: {
+      from: jest.fn().mockReturnValue(chain),
+      rpc: (...args: unknown[]) => mockRpc(...args),
+    },
+  };
+});
+
+beforeEach(() => {
+  mockResult = { data: [], error: null };
+  mockRpc.mockClear();
+});
+
+describe('listComicvineNeedsReview', () => {
+  it('maps rows and prefers image_md_url over image_url', async () => {
+    mockResult = {
+      data: [
+        { id: 'h1', name: 'Aragorn', publisher: 'Marvel', image_md_url: 'md.jpg', image_url: 'x.jpg' },
+        { id: 'h2', name: 'Baymax', publisher: 'DC Comics', image_md_url: null, image_url: 'fallback.jpg' },
+      ],
+      error: null,
+    };
+    const rows = await listComicvineNeedsReview();
+    expect(rows).toEqual([
+      { id: 'h1', name: 'Aragorn', publisher: 'Marvel', imageUrl: 'md.jpg' },
+      { id: 'h2', name: 'Baymax', publisher: 'DC Comics', imageUrl: 'fallback.jpg' },
+    ]);
+  });
+
+  it('returns [] on error', async () => {
+    mockResult = { data: null as unknown as unknown[], error: { message: 'boom' } };
+    await expect(listComicvineNeedsReview()).resolves.toEqual([]);
+  });
+});
+
+describe('countComicvineNeedsReview', () => {
+  it('returns the exact count', async () => {
+    mockResult = { count: 83, error: null };
+    await expect(countComicvineNeedsReview()).resolves.toBe(83);
+  });
+  it('returns 0 on error', async () => {
+    mockResult = { count: undefined, error: { message: 'boom' } };
+    await expect(countComicvineNeedsReview()).resolves.toBe(0);
+  });
+});
+
+describe('admin write RPCs', () => {
+  it('acceptComicvineMatch calls admin_set_comicvine_match with hero + cv id', async () => {
+    await acceptComicvineMatch('h1', '6810');
+    expect(mockRpc).toHaveBeenCalledWith('admin_set_comicvine_match', {
+      p_hero_id: 'h1',
+      p_comicvine_id: '6810',
+    });
+  });
+
+  it('markComicvineUnmatched calls admin_mark_comicvine_unmatched', async () => {
+    await markComicvineUnmatched('h2');
+    expect(mockRpc).toHaveBeenCalledWith('admin_mark_comicvine_unmatched', { p_hero_id: 'h2' });
+  });
+
+  it('throws when the RPC errors', async () => {
+    mockRpc.mockResolvedValueOnce({ error: { message: 'not authorized' } });
+    await expect(acceptComicvineMatch('h1', '1')).rejects.toEqual({ message: 'not authorized' });
+  });
+});

--- a/app/admin/health.web.tsx
+++ b/app/admin/health.web.tsx
@@ -425,7 +425,7 @@ export default function AdminHealthScreen() {
             ) : showHealthSkeleton ? (
               <PipelinesSkeleton narrow={narrow} />
             ) : null)}
-          {domain === 'inbox' && <InboxLane jump={inboxJump} />}
+          {domain === 'inbox' && <InboxLane jump={inboxJump} flash={flash} />}
           {domain === 'audience' && (
             <AudienceLane narrow={narrow} onOpenReview={() => jumpInbox('review')} />
           )}

--- a/src/components/admin/health/domains/ComicvineReview.tsx
+++ b/src/components/admin/health/domains/ComicvineReview.tsx
@@ -1,0 +1,345 @@
+// ComicVine review queue (issue #93) — resolves heroes the collision gate
+// flagged `needs_review` (an exact-name match whose publisher disagreed, or
+// ambiguous same-name candidates). Each hero shows LIVE cv-search candidates
+// (name · publisher · appearances) to accept inline, a manual-id escape hatch,
+// and "Not on ComicVine". Accepting re-queues the hero so the drain re-enriches
+// by the right id, overwriting the collision's bad data. Renders nothing when
+// the queue is clear.
+import { useEffect, useState, useCallback } from 'react';
+import { View, Text, TextInput, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../../../constants/colors';
+import { Panel } from '../Panel';
+import { InfoTip } from '../InfoTip';
+import { HeroThumb, LoadMore, EmptyState } from '../ui';
+import {
+  listComicvineNeedsReview,
+  countComicvineNeedsReview,
+  acceptComicvineMatch,
+  markComicvineUnmatched,
+  type ComicvineReviewHero,
+} from '../../../../lib/db/comicvineReview';
+import {
+  searchComicvineCharacters,
+  existingComicvineIds,
+  type CvCharacter,
+} from '../../../../lib/db/cvIngest';
+
+type Flash = (msg: string, tone?: 'info' | 'success' | 'error' | 'pending') => void;
+
+const PAGE = 25;
+
+// Same publisher-normalisation intent as the server gate — just enough to
+// highlight the candidate that agrees with the hero's publisher (the likely fix).
+function samePublisher(a: string | null, b: string | null): boolean {
+  if (!a || !b) return false;
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const x = norm(a);
+  const y = norm(b);
+  return x === y || x.includes(y) || y.includes(x);
+}
+
+export function ComicvineReview({ flash, onChanged }: { flash: Flash; onChanged: () => void }) {
+  const [heroes, setHeroes] = useState<ComicvineReviewHero[]>([]);
+  const [total, setTotal] = useState(0);
+  const [limit, setLimit] = useState(PAGE);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  // Live candidates per hero id (null = loading, [] = none found).
+  const [cands, setCands] = useState<Record<string, CvCharacter[] | null>>({});
+  // Candidate ids already linked to another hero (accepting would collide).
+  const [linked, setLinked] = useState<Set<string>>(new Set());
+  const [manual, setManual] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [list, count] = await Promise.all([
+        listComicvineNeedsReview(limit),
+        countComicvineNeedsReview(),
+      ]);
+      setHeroes(list);
+      setTotal(count);
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, [load]);
+
+  // Fetch cv-search candidates for any hero we haven't looked up yet.
+  useEffect(() => {
+    const missing = heroes.filter((h) => !(h.id in cands));
+    if (missing.length === 0) return;
+    let alive = true;
+    // Mark them loading so we don't refetch on the next render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCands((prev) => {
+      const next = { ...prev };
+      for (const h of missing) next[h.id] = null;
+      return next;
+    });
+    (async () => {
+      const results = await Promise.all(
+        missing.map(async (h) => [h.id, await searchComicvineCharacters(h.name)] as const),
+      );
+      if (!alive) return;
+      setCands((prev) => {
+        const next = { ...prev };
+        for (const [id, list] of results) next[id] = list;
+        return next;
+      });
+      // Flag candidate ids already used elsewhere, so we can block a colliding accept.
+      const allIds = results.flatMap(([, list]) => list.map((c) => c.id));
+      if (allIds.length > 0) {
+        const used = await existingComicvineIds(allIds);
+        if (alive) setLinked((prev) => new Set([...prev, ...used]));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroes]);
+
+  const removeHero = (id: string) => setHeroes((hs) => hs.filter((h) => h.id !== id));
+
+  const accept = async (hero: ComicvineReviewHero, cvId: string) => {
+    setBusy(`accept-${hero.id}`);
+    try {
+      await acceptComicvineMatch(hero.id, cvId);
+      flash(`${hero.name} → CV ${cvId}; re-queued for enrichment.`, 'success');
+      removeHero(hero.id);
+      setTotal((t) => Math.max(0, t - 1));
+      onChanged();
+    } catch (e) {
+      flash(`Accept failed: ${(e as Error).message}`, 'error');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const markUnmatched = async (hero: ComicvineReviewHero) => {
+    setBusy(`unmatched-${hero.id}`);
+    try {
+      await markComicvineUnmatched(hero.id);
+      flash(`${hero.name} marked "not on ComicVine".`, 'success');
+      removeHero(hero.id);
+      setTotal((t) => Math.max(0, t - 1));
+      onChanged();
+    } catch (e) {
+      flash(`Failed: ${(e as Error).message}`, 'error');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading && heroes.length === 0) {
+    return (
+      <Panel title="ComicVine review" hint="Loading the queue…">
+        <ActivityIndicator color={COLORS.orange} style={styles.spin} />
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel
+      title="ComicVine review"
+      hint={total > 0 ? `${total.toLocaleString()} to review` : 'Collision suspects land here'}
+      action={
+        <InfoTip text="Heroes whose ComicVine name-match was rejected because its publisher disagreed (or several same-name characters were ambiguous) — the cross-franchise collision guard. Pick the right ComicVine character to re-enrich from, paste an id manually, or mark it as not on ComicVine. Accepting re-queues the hero so the enrichment drain overwrites the bad data with the correct character." />
+      }
+    >
+      {heroes.length === 0 ? (
+        <EmptyState text="All clear — no collisions waiting on you." />
+      ) : (
+        <View style={styles.list}>
+          {heroes.map((hero) => {
+            const candidates = cands[hero.id];
+            const busyThis = busy === `accept-${hero.id}` || busy === `unmatched-${hero.id}`;
+            return (
+              <View key={hero.id} style={styles.heroRow}>
+                <View style={styles.who}>
+                  <HeroThumb uri={hero.imageUrl} width={30} height={40} radius={6} />
+                  <View style={styles.meta}>
+                    <Text style={styles.name} numberOfLines={1}>
+                      {hero.name}
+                    </Text>
+                    <Text style={styles.pub} numberOfLines={1}>
+                      currently: {hero.publisher ?? '—'}
+                    </Text>
+                  </View>
+                </View>
+
+                {candidates === undefined || candidates === null ? (
+                  <ActivityIndicator size="small" color={COLORS.grey} style={styles.candSpin} />
+                ) : candidates.length === 0 ? (
+                  <Text style={styles.noneFound}>No ComicVine characters by this name.</Text>
+                ) : (
+                  <View style={styles.candidates}>
+                    {candidates.map((c) => {
+                      const isLinked = linked.has(c.id);
+                      const agrees = samePublisher(hero.publisher, c.publisher);
+                      return (
+                        <Pressable
+                          key={c.id}
+                          onPress={() => accept(hero, c.id)}
+                          disabled={!!busy || isLinked}
+                          style={[
+                            styles.cand,
+                            agrees && styles.candAgrees,
+                            (!!busy || isLinked) && styles.dim,
+                          ]}
+                          accessibilityLabel={`Accept ${c.name} (CV ${c.id}) for ${hero.name}`}
+                        >
+                          <HeroThumb uri={c.image} width={28} height={38} radius={5} />
+                          <View style={styles.candText}>
+                            <Text style={styles.candName} numberOfLines={1}>
+                              {c.name}
+                              {agrees ? <Text style={styles.matchTag}>{'  · match'}</Text> : null}
+                            </Text>
+                            <Text style={styles.candSub} numberOfLines={1}>
+                              {c.publisher ?? '—'}
+                              {c.appearances != null
+                                ? ` · ${c.appearances.toLocaleString()} apps`
+                                : ''}
+                              {isLinked ? ' · already linked' : ` · CV ${c.id}`}
+                            </Text>
+                            {c.deck ? (
+                              <Text style={styles.candDeck} numberOfLines={2}>
+                                {c.deck}
+                              </Text>
+                            ) : null}
+                          </View>
+                          <Ionicons
+                            name={isLinked ? 'lock-closed-outline' : 'checkmark-circle-outline'}
+                            size={18}
+                            color={isLinked ? COLORS.grey : COLORS.orange}
+                          />
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                )}
+
+                <View style={styles.actions}>
+                  <Pressable
+                    onPress={() => markUnmatched(hero)}
+                    disabled={!!busy}
+                    style={[styles.noneBtn, !!busy && styles.dim]}
+                  >
+                    {busy === `unmatched-${hero.id}` ? (
+                      <ActivityIndicator size="small" color={COLORS.grey} />
+                    ) : (
+                      <Ionicons name="close-circle-outline" size={14} color={COLORS.grey} />
+                    )}
+                    <Text style={styles.noneText}>Not on ComicVine</Text>
+                  </Pressable>
+                  <View style={styles.manualBox}>
+                    <TextInput
+                      value={manual[hero.id] ?? ''}
+                      onChangeText={(t) => setManual((m) => ({ ...m, [hero.id]: t }))}
+                      placeholder="CV id…"
+                      placeholderTextColor={COLORS.grey}
+                      keyboardType="number-pad"
+                      style={[styles.manualInput, { outlineStyle: 'none' }] as object}
+                    />
+                    <Pressable
+                      onPress={() => {
+                        const id = (manual[hero.id] ?? '').trim();
+                        if (/^\d+$/.test(id)) accept(hero, id);
+                        else flash('Enter a numeric ComicVine id', 'error');
+                      }}
+                      disabled={busyThis || !(manual[hero.id] ?? '').trim()}
+                      style={[
+                        styles.manualSet,
+                        (busyThis || !(manual[hero.id] ?? '').trim()) && styles.dim,
+                      ]}
+                    >
+                      <Text style={styles.manualSetText}>Set</Text>
+                    </Pressable>
+                  </View>
+                </View>
+              </View>
+            );
+          })}
+          {heroes.length < total ? (
+            <LoadMore
+              onPress={() => setLimit((l) => l + PAGE)}
+              loading={loading}
+              label={`Load more · ${(total - heroes.length).toLocaleString()} left`}
+            />
+          ) : null}
+        </View>
+      )}
+    </Panel>
+  );
+}
+
+const styles = StyleSheet.create({
+  spin: { marginVertical: 10 },
+  candSpin: { alignSelf: 'flex-start', marginVertical: 4 },
+  list: { gap: 4 },
+  dim: { opacity: 0.4 },
+  heroRow: {
+    gap: 8,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(41,60,67,0.06)',
+  },
+  who: { flexDirection: 'row', alignItems: 'center', gap: 9, minWidth: 0 },
+  meta: { flex: 1, minWidth: 0 },
+  name: { fontFamily: 'Nunito_700Bold', fontSize: 13.5, color: COLORS.black },
+  pub: { fontFamily: 'Nunito_400Regular', fontSize: 11.5, color: COLORS.grey },
+  noneFound: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: COLORS.grey },
+  candidates: { gap: 5 },
+  cand: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: 'rgba(41,60,67,0.05)',
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: 'transparent',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  candAgrees: { borderColor: COLORS.green, backgroundColor: 'rgba(74,153,110,0.08)' },
+  candText: { flex: 1, minWidth: 0, gap: 1 },
+  candName: { fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.navy },
+  matchTag: { fontFamily: 'Nunito_700Bold', fontSize: 11, color: COLORS.green },
+  candSub: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 11,
+    color: COLORS.grey,
+    fontVariant: ['tabular-nums'],
+  },
+  candDeck: { fontFamily: 'Nunito_400Regular', fontSize: 11, color: COLORS.grey, lineHeight: 14 },
+  actions: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 3, flexWrap: 'wrap' },
+  noneBtn: { flexDirection: 'row', alignItems: 'center', gap: 4, paddingVertical: 5 },
+  noneText: { fontFamily: 'Nunito_700Bold', fontSize: 11.5, color: COLORS.grey },
+  manualBox: { flexDirection: 'row', alignItems: 'stretch', gap: 1, flex: 1, justifyContent: 'flex-end' },
+  manualInput: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 12,
+    color: COLORS.navy,
+    width: 90,
+    backgroundColor: '#f6f0e6',
+    borderTopLeftRadius: 8,
+    borderBottomLeftRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  manualSet: {
+    backgroundColor: COLORS.navy,
+    borderTopRightRadius: 8,
+    borderBottomRightRadius: 8,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  manualSetText: { fontFamily: 'Nunito_700Bold', fontSize: 11.5, color: '#fff' },
+});

--- a/src/components/admin/health/domains/InboxLane.tsx
+++ b/src/components/admin/health/domains/InboxLane.tsx
@@ -3,20 +3,33 @@
 // contributions (field edits, "Did You Know" facts). Merges the old top-level
 // Reports tab and the old Catalog › Review sub-tab. Sub-tab badges are live
 // queue counts; both panels self-fetch and stay unchanged.
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useUrlTabState } from '../../../../hooks/useUrlTabState';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { SubTabs } from '../SubTabs';
 import { ReportsDomain } from './ReportsDomain';
 import { ReviewDomain } from './ReviewDomain';
+import { ComicvineReview } from './ComicvineReview';
 import { fetchReportsQueue } from '../../../../lib/db/reports';
 import { getReviewQueue } from '../../../../lib/db/contributions';
-import type { LaneJump } from '../format';
+import { countComicvineNeedsReview } from '../../../../lib/db/comicvineReview';
+import type { LaneJump, LogTone } from '../format';
 
-export type InboxSub = 'reports' | 'review';
+export type InboxSub = 'reports' | 'review' | 'comicvine';
 
-export function InboxLane({ jump }: { jump?: LaneJump<InboxSub> | null }) {
-  const [sub, setSub] = useUrlTabState<InboxSub>('sub', 'reports', ['reports', 'review'] as const);
+export function InboxLane({
+  jump,
+  flash,
+}: {
+  jump?: LaneJump<InboxSub> | null;
+  flash: (msg: string, tone?: LogTone) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [sub, setSub] = useUrlTabState<InboxSub>('sub', 'reports', [
+    'reports',
+    'review',
+    'comicvine',
+  ] as const);
   useEffect(() => {
     if (jump) setSub(jump.sub);
   }, [jump]);
@@ -31,6 +44,11 @@ export function InboxLane({ jump }: { jump?: LaneJump<InboxSub> | null }) {
   const reviewQ = useQuery({
     queryKey: ['reviewQueue'],
     queryFn: () => getReviewQueue(),
+    staleTime: 30_000,
+  });
+  const cvReviewQ = useQuery({
+    queryKey: ['comicvineReviewCount'],
+    queryFn: () => countComicvineNeedsReview(),
     staleTime: 30_000,
   });
 
@@ -50,11 +68,28 @@ export function InboxLane({ jump }: { jump?: LaneJump<InboxSub> | null }) {
             icon: 'shield-checkmark-outline',
             badge: reviewQ.data?.length ?? 0,
           },
+          {
+            key: 'comicvine',
+            label: 'Collisions',
+            icon: 'git-compare-outline',
+            badge: cvReviewQ.data ?? 0,
+          },
         ]}
         active={sub}
         onChange={setSub}
       />
-      {sub === 'reports' ? <ReportsDomain /> : <ReviewDomain />}
+      {sub === 'reports' ? (
+        <ReportsDomain />
+      ) : sub === 'review' ? (
+        <ReviewDomain />
+      ) : (
+        <ComicvineReview
+          flash={flash}
+          onChanged={() =>
+            queryClient.invalidateQueries({ queryKey: ['comicvineReviewCount'] })
+          }
+        />
+      )}
     </>
   );
 }

--- a/src/lib/db/comicvineReview.ts
+++ b/src/lib/db/comicvineReview.ts
@@ -1,0 +1,63 @@
+import { supabase } from '../supabase';
+
+// Data layer for the admin ComicVine review queue (issue #93). Heroes flagged
+// `comicvine_status='needs_review'` by the collision gate (see
+// supabase/functions/_shared/comicvineMatch.ts) are resolved here: accept a
+// live cv-search candidate (or a manual id) → re-queue for enrichment by the
+// right id, or mark unmatched. Writes go through admin-gated SECURITY DEFINER
+// RPCs (heroes has no client write grant).
+
+export interface ComicvineReviewHero {
+  id: string;
+  name: string;
+  publisher: string | null;
+  imageUrl: string | null;
+}
+
+/** Heroes awaiting a human ComicVine decision, most-published first. */
+export async function listComicvineNeedsReview(limit = 25): Promise<ComicvineReviewHero[]> {
+  const { data, error } = await supabase
+    .from('heroes')
+    .select('id, name, publisher, image_md_url, image_url')
+    .eq('comicvine_status', 'needs_review')
+    .order('issue_count', { ascending: false, nullsFirst: false })
+    .limit(limit);
+  if (error || !data) return [];
+  return (
+    data as { id: string; name: string; publisher: string | null; image_md_url: string | null; image_url: string | null }[]
+  ).map((r) => ({
+    id: r.id,
+    name: r.name,
+    publisher: r.publisher,
+    imageUrl: r.image_md_url ?? r.image_url,
+  }));
+}
+
+/** Total needs_review count (drives the LoadMore + the sub-tab badge). */
+export async function countComicvineNeedsReview(): Promise<number> {
+  const { count, error } = await supabase
+    .from('heroes')
+    .select('id', { count: 'exact', head: true })
+    .eq('comicvine_status', 'needs_review');
+  if (error) return 0;
+  return count ?? 0;
+}
+
+/**
+ * Accept a ComicVine id for a hero (a picked candidate or a manual entry):
+ * points the row at it and re-queues it so the drain re-enriches by the right
+ * id, overwriting the collision's bad data.
+ */
+export async function acceptComicvineMatch(heroId: string, comicvineId: string): Promise<void> {
+  const { error } = await supabase.rpc('admin_set_comicvine_match', {
+    p_hero_id: heroId,
+    p_comicvine_id: comicvineId,
+  });
+  if (error) throw error;
+}
+
+/** Terminal: ComicVine has no correct match for this hero. */
+export async function markComicvineUnmatched(heroId: string): Promise<void> {
+  const { error } = await supabase.rpc('admin_mark_comicvine_unmatched', { p_hero_id: heroId });
+  if (error) throw error;
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2018,6 +2018,10 @@ export type Database = {
         }
         Returns: Json
       }
+      admin_mark_comicvine_unmatched: {
+        Args: { p_hero_id: string }
+        Returns: undefined
+      }
       admin_merge_heroes: {
         Args: { p_loser: string; p_winner: string }
         Returns: undefined
@@ -2059,6 +2063,10 @@ export type Database = {
       admin_run_wikidata_resolve: {
         Args: { p_limit?: number }
         Returns: string
+      }
+      admin_set_comicvine_match: {
+        Args: { p_comicvine_id: string; p_hero_id: string }
+        Returns: undefined
       }
       admin_set_drain_cron: { Args: { p_enabled: boolean }; Returns: string }
       admin_set_universe: {

--- a/supabase/migrations/20260715160000_comicvine_review_rpcs.sql
+++ b/supabase/migrations/20260715160000_comicvine_review_rpcs.sql
@@ -1,0 +1,55 @@
+-- Admin RPCs for the ComicVine review queue (issue #93). heroes has no client
+-- write grant (see 20260715104931_heroes_reads_without_rls.sql), so resolving a
+-- needs_review row must go through a SECURITY DEFINER RPC that self-checks
+-- is_admin — same pattern as resolve_hero_qid / mark_hero_unresolved.
+
+-- Accept a ComicVine match: point the hero at the confirmed id and re-queue it
+-- so the enrichment drain re-fetches the RIGHT character by id (overwriting the
+-- bad data the collision left). Also used for a manually-entered id.
+create or replace function public.admin_set_comicvine_match(p_hero_id text, p_comicvine_id text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  update public.heroes
+     set comicvine_id = p_comicvine_id,
+         comicvine_status = 'pending'
+   where id = p_hero_id;
+end;
+$function$;
+
+-- Terminal: ComicVine genuinely has no right match for this hero.
+create or replace function public.admin_mark_comicvine_unmatched(p_hero_id text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  update public.heroes
+     set comicvine_status = 'unmatched'
+   where id = p_hero_id;
+end;
+$function$;
+
+-- Admins (guard enforces is_admin at runtime) + service_role only; revoke PUBLIC/anon.
+do $$
+declare f text;
+begin
+  foreach f in array array[
+    'public.admin_set_comicvine_match(text, text)',
+    'public.admin_mark_comicvine_unmatched(text)'
+  ]
+  loop
+    execute format('revoke all on function %s from public, anon;', f);
+    execute format('grant execute on function %s to authenticated, service_role;', f);
+  end loop;
+end $$;


### PR DESCRIPTION
Closes [#93](https://github.com/ginoleeswan/hero/issues/93) — the follow-up to the collision-gate fix (#94). The gate flags cross-franchise/ambiguous ComicVine matches as `needs_review` but left them with no way to resolve; this is the admin queue that clears them (starting with the 83 flagged rows).

## What
- **Two admin RPCs** (migration) — `admin_set_comicvine_match` + `admin_mark_comicvine_unmatched`. These **must** be `SECURITY DEFINER` RPCs: `heroes` has no client write grant (post the RLS-removal migration), so the client can't UPDATE it directly. Both self-check `is_admin` and follow the `resolve_hero_qid` template + grant loop exactly.
- **`src/lib/db/comicvineReview.ts`** — `listComicvineNeedsReview` / `countComicvineNeedsReview` (direct SELECT, uses the existing `needs_review` partial index) + the accept/unmatched RPC wrappers.
- **`ComicvineReview` panel** — self-contained (DuplicatesPanel shape) with NeedsYou-style candidate cards. Per hero it fetches **live `cv-search` candidates** (reuses `searchComicvineCharacters`), and:
  - highlights the candidate whose **publisher agrees** with the hero as the likely fix (green "· match");
  - **locks candidates already linked to another hero** (`existingComicvineIds`) so you can't accept into a `comicvine_id` collision (23505);
  - **Accept** → `comicvine_id` + `status='pending'` → the drain re-enriches by the right id, **overwriting the collision's bad data**;
  - **manual numeric-id** escape hatch; **"Not on ComicVine"** → `unmatched`.
- **Wired into the Inbox lane** as a new **Collisions** sub-tab with a live count badge; threaded `flash` into `InboxLane` (mirrors how CatalogLane feeds DuplicatesPanel).

## ✅ Deployed to prod (via MCP)
Both RPCs **applied**; `database.generated.ts` regenerated. Admin-gated on the read side (`canQuery`) and **re-verified server-side** in every RPC (a stale client flag just yields empty results).

## How the 83 rows get resolved
Open **Command Center → Inbox → Collisions**. For each hero: pick the correct ComicVine character (the publisher-matching one is highlighted) → it re-enriches with correct data on the next drain pass; or mark it not-on-ComicVine. Rows ComicVine genuinely can't match still need manual data cleanup separately, but the queue gets them out of the wrong-data state.

## Verification
`npx tsc --noEmit` clean; `yarn test:ci` → **717 passed** (+7 db-layer cases: row mapping, count, both RPC signatures, error propagation); eslint clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)