### PR TITLE
SEO: comprehensive crawler coverage — hub pages, canonical universe URLs, structured data, expanded sitemap

### DIFF
--- a/__tests__/api/botPage.test.ts
+++ b/__tests__/api/botPage.test.ts
@@ -1,14 +1,18 @@
 import {
+  buildCategoryBotPage,
   buildCharacterBotPage,
   buildNotFoundPage,
   buildTeamBotPage,
   buildTitleBotPage,
+  buildUniverseBotPage,
   buildVsBotPage,
+  CATEGORY_SEO,
   metaDescription,
   stripHtml,
   universePath,
   type BotHero,
   type BotTitle,
+  type RelatedLite,
 } from '../../api/_lib/botPage';
 
 const hero = (overrides: Partial<BotHero> = {}): BotHero => ({
@@ -225,5 +229,63 @@ describe('buildVsBotPage', () => {
 describe('buildNotFoundPage', () => {
   it('is noindex so crawlers drop dead URLs', () => {
     expect(buildNotFoundPage()).toContain('name="robots" content="noindex"');
+  });
+});
+
+const roster = (): RelatedLite[] => [
+  { id: 'h_1', name: 'Superman' },
+  { id: 'h_2', name: 'Batman' },
+  { id: 'h_3', name: 'Wonder Woman' },
+];
+
+describe('buildCategoryBotPage', () => {
+  const html = buildCategoryBotPage('strongest', roster());
+
+  it('renders the keyword-targeted title and H1 from CATEGORY_SEO', () => {
+    // buildDoc HTML-escapes the title, so the ampersand becomes &amp;.
+    expect(html).toContain(
+      `<title>${CATEGORY_SEO.strongest.label} — Powers, Stats &amp; Rankings | Mythique</title>`,
+    );
+    expect(html).toContain(`<h1>${CATEGORY_SEO.strongest.label}</h1>`);
+  });
+
+  it('canonicalizes to the category path', () => {
+    expect(html).toContain('rel="canonical" href="https://mythique.app/category/strongest"');
+  });
+
+  it('links every character in an ordered list', () => {
+    expect(html).toContain('<ol><li><a href="/character/h_1">Superman</a></li>');
+    expect(html).toContain('href="/character/h_3"');
+  });
+
+  it('emits CollectionPage + ItemList JSON-LD', () => {
+    expect(html).toContain('"@type":"CollectionPage"');
+    expect(html).toContain('"@type":"ItemList"');
+    expect(html).toContain('"numberOfItems":3');
+  });
+
+  it('cross-links sibling hubs but not itself', () => {
+    expect(html).toContain('href="/category/marvel"');
+    expect(html).not.toContain('href="/category/strongest"');
+  });
+});
+
+describe('buildUniverseBotPage', () => {
+  const html = buildUniverseBotPage('Marvel Comics', roster());
+
+  it('canonicalizes with the encoded publisher name', () => {
+    expect(html).toContain('rel="canonical" href="https://mythique.app/universe/Marvel%20Comics"');
+  });
+
+  it('puts the universe name in the title and heading', () => {
+    expect(html).toContain(
+      'Marvel Comics Characters — Heroes, Villains &amp; Power Stats | Mythique',
+    );
+    expect(html).toContain('<h1>Marvel Comics Characters</h1>');
+  });
+
+  it('links the roster into the character graph', () => {
+    expect(html).toContain('href="/character/h_2"');
+    expect(html).toContain('"@type":"CollectionPage"');
   });
 });

--- a/__tests__/api/botPage.test.ts
+++ b/__tests__/api/botPage.test.ts
@@ -54,8 +54,14 @@ describe('stripHtml', () => {
 });
 
 describe('universePath', () => {
-  it('links real universes by raw name', () => {
-    expect(universePath('DC Comics')).toBe('/universe/DC%20Comics');
+  it('links registered universes by their canonical slug (not raw name)', () => {
+    // "DC Comics" resolves to the dc brand → /universe/dc, matching the app and
+    // sitemap so the two URL forms never compete as duplicate content.
+    expect(universePath('DC Comics')).toBe('/universe/dc');
+    expect(universePath('Marvel Comics')).toBe('/universe/marvel');
+  });
+  it('links unregistered universes by encoded raw name', () => {
+    expect(universePath('Some Indie Press')).toBe('/universe/Some%20Indie%20Press');
   });
   it('never links category buckets', () => {
     expect(universePath('Creator-Owned')).toBeNull();
@@ -118,7 +124,7 @@ describe('buildCharacterBotPage', () => {
     expect(html).toContain('href="/character/h_4"');
     expect(html).toContain('href="/compare/h_1/h_3"');
     expect(html).toContain('Superman vs Lex Luthor — who wins?');
-    expect(html).toContain('href="/universe/DC%20Comics"');
+    expect(html).toContain('href="/universe/dc"');
   });
 
   it('escapes hero-controlled fields everywhere, including JSON-LD', () => {
@@ -183,7 +189,7 @@ describe('buildTeamBotPage', () => {
     expect(html).toContain('<title>Justice League — Members &amp; Roster | Mythique</title>');
     expect(html).toContain('href="/character/h_1"');
     expect(html).toContain('"@type":"ItemList"');
-    expect(html).toContain('href="/universe/DC%20Comics"');
+    expect(html).toContain('href="/universe/dc"');
   });
 });
 
@@ -215,6 +221,25 @@ describe('buildVsBotPage', () => {
   it('renders the tally and stat comparison', () => {
     expect(html).toContain('Community votes: Superman 3 — 1 Doomsday.');
     expect(html).toContain('<th>Superman</th><th>Doomsday</th>');
+  });
+
+  it('emits FAQPage JSON-LD targeting the "who would win" query', () => {
+    const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    const ld = JSON.parse(m![1]);
+    const faq = ld['@graph'].find((n: { '@type': string }) => n['@type'] === 'FAQPage');
+    expect(faq).toBeDefined();
+    expect(faq.mainEntity[0].name).toBe('Who would win in a fight, Superman or Doomsday?');
+    // 3–1 tally → Superman favoured at 75% of 4 votes.
+    expect(faq.mainEntity[0].acceptedAnswer.text).toContain('favours Superman, with 75% of 4');
+  });
+
+  it('gives an open-debate FAQ answer when there are no votes', () => {
+    const noVotes = buildVsBotPage(a, b, { votesA: 0, votesB: 0 }, { forA: [], forB: [] });
+    const ld = JSON.parse(
+      noVotes.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)![1],
+    );
+    const faq = ld['@graph'].find((n: { '@type': string }) => n['@type'] === 'FAQPage');
+    expect(faq.mainEntity[0].acceptedAnswer.text).toContain('open debate');
   });
 
   it('links both fighters and onward matchups, skipping the current pair', () => {
@@ -271,21 +296,27 @@ describe('buildCategoryBotPage', () => {
 });
 
 describe('buildUniverseBotPage', () => {
-  const html = buildUniverseBotPage('Marvel Comics', roster());
+  // Registered brand: display name "Marvel", canonical slug "marvel".
+  const html = buildUniverseBotPage('Marvel', 'marvel', roster());
 
-  it('canonicalizes with the encoded publisher name', () => {
-    expect(html).toContain('rel="canonical" href="https://mythique.app/universe/Marvel%20Comics"');
+  it('canonicalizes to the brand slug', () => {
+    expect(html).toContain('rel="canonical" href="https://mythique.app/universe/marvel"');
   });
 
   it('puts the universe name in the title and heading', () => {
-    expect(html).toContain(
-      'Marvel Comics Characters — Heroes, Villains &amp; Power Stats | Mythique',
-    );
-    expect(html).toContain('<h1>Marvel Comics Characters</h1>');
+    expect(html).toContain('Marvel Characters — Heroes, Villains &amp; Power Stats | Mythique');
+    expect(html).toContain('<h1>Marvel Characters</h1>');
   });
 
   it('links the roster into the character graph', () => {
     expect(html).toContain('href="/character/h_2"');
     expect(html).toContain('"@type":"CollectionPage"');
+  });
+
+  it('encodes an unregistered raw-name slug in the canonical', () => {
+    const raw = buildUniverseBotPage('Some Indie Press', 'Some Indie Press', roster());
+    expect(raw).toContain(
+      'rel="canonical" href="https://mythique.app/universe/Some%20Indie%20Press"',
+    );
   });
 });

--- a/__tests__/api/botPage.test.ts
+++ b/__tests__/api/botPage.test.ts
@@ -1,6 +1,7 @@
 import {
   buildCategoryBotPage,
   buildCharacterBotPage,
+  buildFranchiseBotPage,
   buildNotFoundPage,
   buildTeamBotPage,
   buildTitleBotPage,
@@ -318,5 +319,23 @@ describe('buildUniverseBotPage', () => {
     expect(raw).toContain(
       'rel="canonical" href="https://mythique.app/universe/Some%20Indie%20Press"',
     );
+  });
+});
+
+describe('buildFranchiseBotPage', () => {
+  const html = buildFranchiseBotPage('Star Wars', roster());
+
+  it('canonicalizes to the encoded franchise name under /franchise', () => {
+    expect(html).toContain('rel="canonical" href="https://mythique.app/franchise/Star%20Wars"');
+  });
+
+  it('puts the franchise name in the title, heading and CollectionPage LD', () => {
+    expect(html).toContain('Star Wars Characters — Full List, Powers &amp; Stats | Mythique');
+    expect(html).toContain('<h1>Star Wars Characters</h1>');
+    expect(html).toContain('"@type":"CollectionPage"');
+  });
+
+  it('links the roster into the character graph', () => {
+    expect(html).toContain('href="/character/h_1"');
   });
 });

--- a/__tests__/constants/universeBrands.test.ts
+++ b/__tests__/constants/universeBrands.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PUBLISHER_BRANDS } from '../../src/constants/publishers';
+import {
+  UNIVERSE_BRANDS,
+  universeBrandForPublisher,
+  universeBrandBySlug,
+  universeHref,
+} from '../../src/constants/universeBrands';
+
+// universeBrands.ts is a hand-maintained, asset-free MIRROR of PUBLISHER_BRANDS
+// so the RN-free crawler bundle and the sitemap script can canonicalize
+// universe URLs. These guards fail CI the moment the registry drifts from the
+// mirror (or the sitemap's slug list), forcing all three back into sync.
+
+describe('UNIVERSE_BRANDS mirrors PUBLISHER_BRANDS', () => {
+  it('matches slug/name/query/match exactly, in registry order', () => {
+    const expected = PUBLISHER_BRANDS.map((b) => ({
+      slug: b.slug,
+      name: b.name,
+      query: b.query,
+      match: b.match,
+    }));
+    expect(UNIVERSE_BRANDS).toEqual(expected);
+  });
+
+  it('resolves raw publishers to the same brand the registry would', () => {
+    expect(universeBrandForPublisher('Marvel Comics')?.slug).toBe('marvel');
+    expect(universeBrandForPublisher('DC Comics')?.slug).toBe('dc');
+    expect(universeBrandForPublisher('George Lucas')?.slug).toBe('star-wars');
+    expect(universeBrandForPublisher('Totally Unknown Press')).toBeUndefined();
+  });
+
+  it('resolves slugs and produces canonical hrefs', () => {
+    expect(universeBrandBySlug('dc')?.name).toBe('DC');
+    expect(universeHref('Marvel Comics')).toBe('/universe/marvel');
+    expect(universeHref('Some Indie Press')).toBe('/universe/Some%20Indie%20Press');
+    expect(universeHref('Creator-Owned')).toBeNull();
+  });
+});
+
+describe('sitemap UNIVERSE_SLUGS stays in sync with the registry', () => {
+  it('lists exactly the registered brand slugs, in order', () => {
+    const src = readFileSync(join(__dirname, '../../scripts/generate-sitemap.mjs'), 'utf8');
+    const block = src.match(/const UNIVERSE_SLUGS = \[([\s\S]*?)\];/);
+    expect(block).not.toBeNull();
+    const slugs = [...block![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(slugs).toEqual(UNIVERSE_BRANDS.map((b) => b.slug));
+  });
+});

--- a/api/_lib/botPage.ts
+++ b/api/_lib/botPage.ts
@@ -492,6 +492,195 @@ export function buildVsBotPage(
   });
 }
 
+// --- Browsable hub pages (categories + universes) -------------------------
+// These target head/mid-tail queries ("strongest characters", "marvel
+// villains", "dc characters") that a single character page can't rank for, and
+// they funnel crawl equity down into the character graph via dense links.
+
+/** SEO copy for each browsable category hub. Mirrors CATEGORY_LABELS /
+ *  CATEGORY_DESCRIPTIONS in src/lib/db/heroes/categories.ts — the RN-free api/
+ *  bundle can't import that RN module, so keep the slug set in sync when
+ *  categories change. Labels are written as the search phrases we want to win,
+ *  not the app's short UI labels. */
+export const CATEGORY_SEO: Record<string, { label: string; blurb: string }> = {
+  popular: {
+    label: 'Most Popular Superheroes & Villains',
+    blurb:
+      'The most beloved and recognizable characters across all of fiction — Marvel, DC, anime, games and beyond — ranked by fame on Mythique.',
+  },
+  villain: {
+    label: 'Greatest Supervillains of All Time',
+    blurb:
+      'The forces of darkness across Marvel, DC, anime and beyond — the most iconic supervillains, ranked by fame, with powers and stats.',
+  },
+  xmen: {
+    label: 'X-Men Characters',
+    blurb:
+      "Every member of Charles Xavier's world — X-Men mutants, allies and villains — with powers, stats and who-would-win matchups.",
+  },
+  'anti-heroes': {
+    label: 'Greatest Anti-Heroes',
+    blurb:
+      'Characters who walk the line between hero and villain — the most iconic anti-heroes across all fiction, with powers and stats.',
+  },
+  marvel: {
+    label: 'Marvel Characters',
+    blurb:
+      'Heroes and villains from the Marvel Universe — powers, stats, teams and who-would-win matchups, ranked by fame.',
+  },
+  dc: {
+    label: 'DC Characters',
+    blurb:
+      'Heroes and villains of the DC Universe — powers, stats, teams and who-would-win matchups, ranked by fame.',
+  },
+  image: {
+    label: 'Image Comics Characters',
+    blurb:
+      'Creator-owned heroes and villains from Image Comics — Spawn, Invincible and more — with powers, stats and matchups.',
+  },
+  'dark-horse': {
+    label: 'Dark Horse Characters',
+    blurb:
+      'Heroes and villains from Dark Horse Comics — Hellboy, Sin City and beyond — with powers, stats and matchups.',
+  },
+  strongest: {
+    label: 'Strongest Characters',
+    blurb:
+      'The most physically powerful characters in fiction, ranked by raw strength — with full power stats and matchups.',
+  },
+  'most-intelligent': {
+    label: 'Most Intelligent Characters',
+    blurb:
+      'The greatest minds across comics, film and games, ranked by intelligence — with full power stats and matchups.',
+  },
+  'most-iconic': {
+    label: 'Most Iconic Characters',
+    blurb:
+      'The most recognizable characters across comics and screen, ranked by fame — with powers, stats and matchups.',
+  },
+  'franchise-icons': {
+    label: 'Icons Beyond the Comics',
+    blurb:
+      'Legendary characters from film, TV, games and anime — icons that transcend the page, with powers, stats and matchups.',
+  },
+  anime: {
+    label: 'Anime & Manga Characters',
+    blurb:
+      'Heroes and villains from the biggest anime and manga — powers, stats and who-would-win matchups, ranked.',
+  },
+  'video-games': {
+    label: 'Video Game Characters',
+    blurb:
+      'Legends straight out of video-game history — powers, stats and who-would-win matchups, ranked by fame.',
+  },
+  horror: {
+    label: 'Horror Icons',
+    blurb:
+      'The slashers and monsters of horror cinema — the most iconic villains of horror, with powers, stats and matchups.',
+  },
+};
+
+/** Cross-links to the other hub pages so crawlers walk between them and equity
+ *  spreads across the hub graph. Optionally excludes the current category. */
+function hubNav(excludeSlug?: string): string {
+  const items = Object.entries(CATEGORY_SEO)
+    .filter(([slug]) => slug !== excludeSlug)
+    .map(([slug, m]) => `<li><a href="/category/${slug}">${escapeHtml(m.label)}</a></li>`)
+    .join('');
+  return items ? `<nav><h2>Browse more</h2><ul>${items}</ul></nav>` : '';
+}
+
+/** Ordered, linked character list — the internal-link payload of a hub page. */
+function characterOrderedList(heroes: RelatedLite[]): string {
+  if (heroes.length === 0) return '';
+  return `<ol>${heroes.map((h) => `<li>${heroLink(h)}</li>`).join('')}</ol>`;
+}
+
+/** JSON-LD for a hub page: CollectionPage wrapping an ItemList of the linked
+ *  characters, plus breadcrumbs. `<` escaped so data text can't close the tag. */
+function hubJsonLd(name: string, path: string, description: string, heroes: RelatedLite[]): string {
+  const itemListElement = heroes.map((h, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: h.name,
+    url: `${SITE_URL}/character/${encodeURIComponent(h.id)}`,
+  }));
+  return serializeLd({
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name,
+    description,
+    url: `${SITE_URL}${path}`,
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: heroes.length,
+      itemListElement,
+    },
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Mythique', item: SITE_URL },
+        { '@type': 'ListItem', position: 2, name: 'Browse', item: `${SITE_URL}/explore` },
+        { '@type': 'ListItem', position: 3, name },
+      ],
+    },
+  });
+}
+
+/**
+ * Crawlable category hub (e.g. /category/strongest): a keyword-targeted H1 +
+ * intro, an ordered list of the top characters (each linked into the graph),
+ * cross-links to sibling hubs, and CollectionPage JSON-LD. `slug` must be a key
+ * of CATEGORY_SEO — the handler validates before calling.
+ */
+export function buildCategoryBotPage(slug: string, heroes: RelatedLite[]): string {
+  const meta = CATEGORY_SEO[slug];
+  const path = `/category/${slug}`;
+  const body = [
+    `<header><h1>${escapeHtml(meta.label)}</h1><p>${escapeHtml(meta.blurb)}</p></header>`,
+    section('Characters', characterOrderedList(heroes)),
+    hubNav(slug),
+    FOOTER,
+  ].join('\n');
+  return buildDoc({
+    title: `${meta.label} — Powers, Stats & Rankings | Mythique`,
+    description: meta.blurb,
+    path,
+    ogImage: `${SITE_URL}/og.png`,
+    ogType: 'website',
+    jsonLd: hubJsonLd(meta.label, path, meta.blurb, heroes),
+    body,
+  });
+}
+
+/**
+ * Crawlable universe hub (e.g. /universe/Marvel Comics): every catalogue
+ * character from one publisher/studio, linked into the graph. `name` is the raw
+ * (decoded) publisher term; the canonical re-encodes it to match universePath().
+ */
+export function buildUniverseBotPage(name: string, heroes: RelatedLite[]): string {
+  const label = `${name} Characters`;
+  const blurb =
+    `Every character from ${name} on Mythique — heroes, villains, powers, stats and ` +
+    `who-would-win matchups, ranked by fame.`;
+  const path = `/universe/${encodeURIComponent(name)}`;
+  const body = [
+    `<header><h1>${escapeHtml(label)}</h1><p>${escapeHtml(blurb)}</p></header>`,
+    section('Characters', characterOrderedList(heroes)),
+    hubNav(),
+    FOOTER,
+  ].join('\n');
+  return buildDoc({
+    title: `${name} Characters — Heroes, Villains & Power Stats | Mythique`,
+    description: blurb,
+    path,
+    ogImage: `${SITE_URL}/og.png`,
+    ogType: 'website',
+    jsonLd: hubJsonLd(label, path, blurb, heroes),
+    body,
+  });
+}
+
 /** Unknown-id response — noindex so crawlers drop dead URLs instead of
  *  indexing an empty shell. Served with a 404 status by the handler. */
 export function buildNotFoundPage(): string {

--- a/api/_lib/botPage.ts
+++ b/api/_lib/botPage.ts
@@ -7,6 +7,7 @@
 // Kept free of runtime deps (like shareMeta.ts) so it's unit-testable under
 // jest and safe to bundle into the RN-free Vercel functions in api/.
 import { SITE_URL } from '../../src/constants/site';
+import { universeHref } from '../../src/constants/universeBrands';
 import { escapeHtml, vsShareLine } from './shareMeta';
 
 /** The hero columns the bot page renders. Subset of the heroes Row. */
@@ -59,21 +60,13 @@ export function stripHtml(s: string | null | undefined): string {
     .trim();
 }
 
-/** SuperheroAPI category buckets that must never link as a browsable universe
- *  (mirrors NON_UNIVERSE_PUBLISHERS in src/constants/publishers.ts, which the
- *  RN-free api/ bundle can't import). */
-const NON_UNIVERSE_PUBLISHERS = new Set([
-  'Non-Fictional',
-  'Creator-Owned',
-  'Company-Licensed',
-  'In the Public Domain',
-]);
-
 /** /universe browse link for a publisher, or null when it isn't browsable.
- *  Routes by raw name — /universe/[slug] ilike-matches unregistered slugs. */
+ *  Delegates to the shared canonicaliser so character bot pages link universes
+ *  by the SAME URL the app and sitemap use (registered brands by stable slug,
+ *  others by encoded raw name) — no duplicate /universe/<raw> vs /universe/<slug>
+ *  competing for the same content. */
 export function universePath(publisher: string | null | undefined): string | null {
-  if (!publisher || NON_UNIVERSE_PUBLISHERS.has(publisher)) return null;
-  return `/universe/${encodeURIComponent(publisher)}`;
+  return universeHref(publisher);
 }
 
 function heroLink(h: RelatedLite): string {
@@ -475,21 +468,58 @@ export function buildVsBotPage(
     section('More matchups', more ? `<ul>${more}</ul>` : ''),
     FOOTER,
   ].join('\n');
+  const canonicalUrl = `${SITE_URL}/compare/${encodeURIComponent(cA.id)}/${encodeURIComponent(
+    cB.id,
+  )}`;
   return buildDoc({
     title: titleText,
     description: desc,
     path: `/compare/${encodeURIComponent(cA.id)}/${encodeURIComponent(cB.id)}`,
     ogImage: `${SITE_URL}/api/og?a=${encodeURIComponent(a.id)}&b=${encodeURIComponent(b.id)}`,
     ogType: 'website',
+    // WebPage + FAQPage: the FAQ targets the "who would win, X vs Y?" query
+    // directly (People-Also-Ask / featured-snippet real estate) with a factual,
+    // data-backed answer — this matchup content is unique to Mythique.
     jsonLd: serializeLd({
       '@context': 'https://schema.org',
-      '@type': 'WebPage',
-      name: titleText,
-      description: desc,
-      url: `${SITE_URL}/compare/${encodeURIComponent(cA.id)}/${encodeURIComponent(cB.id)}`,
+      '@graph': [
+        { '@type': 'WebPage', name: titleText, description: desc, url: canonicalUrl },
+        {
+          '@type': 'FAQPage',
+          url: canonicalUrl,
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: `Who would win in a fight, ${a.name} or ${b.name}?`,
+              acceptedAnswer: { '@type': 'Answer', text: vsAnswer(a.name, b.name, tally) },
+            },
+          ],
+        },
+      ],
     }),
     body,
   });
+}
+
+/** Plain-text answer for the versus FAQ — the community lean when votes exist,
+ *  otherwise an open-debate invite. Kept factual so the rich result never
+ *  overstates a verdict. */
+function vsAnswer(aName: string, bName: string, tally: { votesA: number; votesB: number }): string {
+  const total = tally.votesA + tally.votesB;
+  if (total > 0) {
+    const aLeads = tally.votesA >= tally.votesB;
+    const leader = aLeads ? aName : bName;
+    const [hi, lo] = aLeads ? [tally.votesA, tally.votesB] : [tally.votesB, tally.votesA];
+    const pct = Math.round((hi / total) * 100);
+    return (
+      `The Mythique community currently favours ${leader}, with ${pct}% of ${total} ` +
+      `votes (${hi}–${lo}). Compare their full power stats and cast your own vote.`
+    );
+  }
+  return (
+    `It's an open debate — no community votes yet. Compare ${aName} and ${bName} ` +
+    `stat by stat and cast the first vote on Mythique.`
+  );
 }
 
 // --- Browsable hub pages (categories + universes) -------------------------
@@ -654,16 +684,18 @@ export function buildCategoryBotPage(slug: string, heroes: RelatedLite[]): strin
 }
 
 /**
- * Crawlable universe hub (e.g. /universe/Marvel Comics): every catalogue
- * character from one publisher/studio, linked into the graph. `name` is the raw
- * (decoded) publisher term; the canonical re-encodes it to match universePath().
+ * Crawlable universe hub (e.g. /universe/marvel): every catalogue character from
+ * one publisher/studio, linked into the graph. `name` is the display name (brand
+ * name for a registered universe, else the raw publisher); `slug` is the canonical
+ * path segment (stable brand slug, else the raw name) — the handler resolves both
+ * so /universe/<slug> and /universe/<raw> collapse to one canonical URL.
  */
-export function buildUniverseBotPage(name: string, heroes: RelatedLite[]): string {
+export function buildUniverseBotPage(name: string, slug: string, heroes: RelatedLite[]): string {
   const label = `${name} Characters`;
   const blurb =
     `Every character from ${name} on Mythique — heroes, villains, powers, stats and ` +
     `who-would-win matchups, ranked by fame.`;
-  const path = `/universe/${encodeURIComponent(name)}`;
+  const path = `/universe/${encodeURIComponent(slug)}`;
   const body = [
     `<header><h1>${escapeHtml(label)}</h1><p>${escapeHtml(blurb)}</p></header>`,
     section('Characters', characterOrderedList(heroes)),

--- a/api/_lib/botPage.ts
+++ b/api/_lib/botPage.ts
@@ -713,6 +713,35 @@ export function buildUniverseBotPage(name: string, slug: string, heroes: Related
   });
 }
 
+/**
+ * Crawlable franchise hub (e.g. /franchise/Star Wars): every catalogue character
+ * whose `franchise` exactly equals `name`, linked into the graph. Franchises have
+ * no brand registry, so the canonical is always the URL-encoded raw name — which
+ * is exactly how the app's /franchise/[slug] route resolves it.
+ */
+export function buildFranchiseBotPage(name: string, heroes: RelatedLite[]): string {
+  const label = `${name} Characters`;
+  const blurb =
+    `Every character from the ${name} franchise on Mythique — heroes, villains, ` +
+    `powers, stats and who-would-win matchups, ranked by fame.`;
+  const path = `/franchise/${encodeURIComponent(name)}`;
+  const body = [
+    `<header><h1>${escapeHtml(label)}</h1><p>${escapeHtml(blurb)}</p></header>`,
+    section('Characters', characterOrderedList(heroes)),
+    hubNav(),
+    FOOTER,
+  ].join('\n');
+  return buildDoc({
+    title: `${name} Characters — Full List, Powers & Stats | Mythique`,
+    description: blurb,
+    path,
+    ogImage: `${SITE_URL}/og.png`,
+    ogType: 'website',
+    jsonLd: hubJsonLd(label, path, blurb, heroes),
+    body,
+  });
+}
+
 /** Unknown-id response — noindex so crawlers drop dead URLs instead of
  *  indexing an empty shell. Served with a 404 status by the handler. */
 export function buildNotFoundPage(): string {

--- a/api/bot-page.ts
+++ b/api/bot-page.ts
@@ -6,6 +6,7 @@
 import {
   buildCategoryBotPage,
   buildCharacterBotPage,
+  buildFranchiseBotPage,
   buildNotFoundPage,
   buildTeamBotPage,
   buildTitleBotPage,
@@ -317,6 +318,19 @@ async function render(query: Req['query']): Promise<string | null> {
     });
     if (heroes.length === 0) return null;
     return buildUniverseBotPage(name, slug, heroes);
+  }
+  if (kind === 'franchise') {
+    // Franchise is an exact `franchise` value (no registry); the param is the
+    // URL-encoded raw name, matching how /franchise/[slug] resolves it.
+    const name = str(query.slug).trim();
+    if (!name) return null;
+    const heroes = await fetchHubHeroes({
+      select: 'id,name',
+      params: [['franchise', `eq.${name}`]],
+      order: 'fame_score.desc.nullslast',
+    });
+    if (heroes.length === 0) return null;
+    return buildFranchiseBotPage(name, heroes);
   }
   return null;
 }

--- a/api/bot-page.ts
+++ b/api/bot-page.ts
@@ -4,11 +4,14 @@
 // nothing without JS, so this route is what makes the catalogue indexable.
 // Social preview bots stay on /api/share-meta; humans never hit either.
 import {
+  buildCategoryBotPage,
   buildCharacterBotPage,
   buildNotFoundPage,
   buildTeamBotPage,
   buildTitleBotPage,
+  buildUniverseBotPage,
   buildVsBotPage,
+  CATEGORY_SEO,
   type BotHero,
   type BotTeam,
   type BotTitle,
@@ -134,6 +137,119 @@ async function fetchTally(a: string, b: string): Promise<{ votesA: number; votes
   }
 }
 
+// Number of characters listed on a hub page — enough dense internal linking to
+// be crawl-valuable, bounded so a page never balloons.
+const HUB_LIMIT = 100;
+
+// PostgREST query per category slug. Mirrors the predicates in
+// getAllHeroesBySlug (src/lib/db/heroes/categories.ts) — this RN-free bundle
+// can't import that module, so keep the two in sync when categories change.
+// Values are raw PostgREST filter expressions; URLSearchParams percent-encodes
+// them (parens, quotes, `*` wildcards, spaces all decode correctly server-side).
+type CatQuery = { select: string; params: Array<[string, string]>; order: string };
+const TAG_SELECT = 'id,name,hero_tags!inner(tag)';
+const CATEGORY_QUERY: Record<string, CatQuery> = {
+  popular: {
+    select: 'id,name',
+    params: [['category', 'eq.popular']],
+    order: 'fame_score.desc.nullslast',
+  },
+  villain: {
+    select: 'id,name',
+    params: [
+      ['alignment', 'eq.bad'],
+      ['publisher', 'not.in.("Non-Fictional","In the Public Domain")'],
+    ],
+    order: 'fame_score.desc.nullslast',
+  },
+  xmen: {
+    select: 'id,name',
+    params: [['or', '(group_affiliation.ilike.*x-men*,group_affiliation.ilike.*xmen*)']],
+    order: 'fame_score.desc.nullslast',
+  },
+  'anti-heroes': {
+    select: 'id,name',
+    params: [['alignment', 'ilike.*neutral*']],
+    order: 'fame_score.desc.nullslast',
+  },
+  marvel: {
+    select: 'id,name',
+    params: [['publisher', 'ilike.*marvel*']],
+    order: 'fame_score.desc.nullslast',
+  },
+  dc: {
+    select: 'id,name',
+    params: [['publisher', 'ilike.*dc*']],
+    order: 'fame_score.desc.nullslast',
+  },
+  image: {
+    select: 'id,name',
+    params: [['publisher', 'ilike.*image*']],
+    order: 'fame_score.desc.nullslast',
+  },
+  'dark-horse': {
+    select: 'id,name',
+    params: [['publisher', 'ilike.*dark horse*']],
+    order: 'fame_score.desc.nullslast',
+  },
+  strongest: {
+    select: 'id,name',
+    params: [['strength', 'not.is.null']],
+    order: 'strength.desc.nullslast',
+  },
+  'most-intelligent': {
+    select: 'id,name',
+    params: [['intelligence', 'not.is.null']],
+    order: 'intelligence.desc.nullslast',
+  },
+  'most-iconic': {
+    select: 'id,name',
+    params: [['publisher', 'not.in.("Non-Fictional","In the Public Domain","Company-Licensed")']],
+    order: 'fame_score.desc.nullslast',
+  },
+  'franchise-icons': {
+    select: 'id,name',
+    params: [['franchise', 'not.is.null']],
+    order: 'issue_count.desc.nullslast',
+  },
+  anime: {
+    select: TAG_SELECT,
+    params: [['hero_tags.tag', 'eq.anime']],
+    order: 'issue_count.desc.nullslast',
+  },
+  'video-games': {
+    select: TAG_SELECT,
+    params: [['hero_tags.tag', 'eq.video-game']],
+    order: 'issue_count.desc.nullslast',
+  },
+  horror: {
+    select: TAG_SELECT,
+    params: [['hero_tags.tag', 'eq.horror-icon']],
+    order: 'issue_count.desc.nullslast',
+  },
+};
+
+/** Fetch the top HUB_LIMIT heroes for a hub query, id+name only. Fail-soft to
+ *  [] so a hub with no results (or a transient error) becomes a noindex 404
+ *  rather than a served 500. */
+async function fetchHubHeroes(spec: CatQuery): Promise<RelatedLite[]> {
+  try {
+    const sp = new URLSearchParams();
+    sp.set('select', spec.select);
+    for (const [k, v] of spec.params) sp.append(k, v);
+    sp.set('order', spec.order);
+    sp.set('limit', String(HUB_LIMIT));
+    const r = await fetch(`${SUPABASE_URL}/rest/v1/heroes?${sp.toString()}`, {
+      headers: { apikey: SUPABASE_KEY },
+    });
+    if (!r.ok) return [];
+    const rows = (await r.json()) as Array<{ id?: string; name?: string }>;
+    return rows.filter((h): h is RelatedLite => !!h.id && !!h.name);
+  } catch {
+    return [];
+  }
+}
+
 function str(v: string | string[] | undefined): string {
   return typeof v === 'string' ? v : '';
 }
@@ -171,6 +287,28 @@ async function render(query: Req['query']): Promise<string | null> {
       fetchRelated(b.id, 'enemy'),
     ]);
     return buildVsBotPage(a, b, tally, { forA, forB });
+  }
+  if (kind === 'category') {
+    const slug = str(query.slug);
+    const spec = CATEGORY_QUERY[slug];
+    // Only render known slugs (CATEGORY_QUERY and CATEGORY_SEO share the set) —
+    // an unknown slug becomes a noindex 404 instead of an empty hub.
+    if (!spec || !CATEGORY_SEO[slug]) return null;
+    const heroes = await fetchHubHeroes(spec);
+    if (heroes.length === 0) return null;
+    return buildCategoryBotPage(slug, heroes);
+  }
+  if (kind === 'universe') {
+    // The slug is the raw publisher term (Vercel decodes the path segment).
+    const name = str(query.slug).trim();
+    if (!name) return null;
+    const heroes = await fetchHubHeroes({
+      select: 'id,name',
+      params: [['publisher', `ilike.*${name}*`]],
+      order: 'fame_score.desc.nullslast',
+    });
+    if (heroes.length === 0) return null;
+    return buildUniverseBotPage(name, heroes);
   }
   return null;
 }

--- a/api/bot-page.ts
+++ b/api/bot-page.ts
@@ -17,6 +17,7 @@ import {
   type BotTitle,
   type RelatedLite,
 } from './_lib/botPage';
+import { universeBrandBySlug, universeBrandForPublisher } from '../src/constants/universeBrands';
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
 const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY ?? '';
@@ -299,16 +300,23 @@ async function render(query: Req['query']): Promise<string | null> {
     return buildCategoryBotPage(slug, heroes);
   }
   if (kind === 'universe') {
-    // The slug is the raw publisher term (Vercel decodes the path segment).
-    const name = str(query.slug).trim();
-    if (!name) return null;
+    // The param may arrive as a registry slug (app links: /universe/marvel) or a
+    // raw publisher name (older/character-page links: /universe/Marvel Comics).
+    // Resolve both to ONE canonical brand so the two forms collapse to a single
+    // indexable URL (registered → stable slug; unregistered → the raw name).
+    const param = str(query.slug).trim();
+    if (!param) return null;
+    const brand = universeBrandBySlug(param) ?? universeBrandForPublisher(param);
+    const term = brand ? brand.query : param; // ILIKE term against `publisher`
+    const name = brand ? brand.name : param; // display name / H1
+    const slug = brand ? brand.slug : param; // canonical path segment
     const heroes = await fetchHubHeroes({
       select: 'id,name',
-      params: [['publisher', `ilike.*${name}*`]],
+      params: [['publisher', `ilike.*${term}*`]],
       order: 'fame_score.desc.nullslast',
     });
     if (heroes.length === 0) return null;
-    return buildUniverseBotPage(name, heroes);
+    return buildUniverseBotPage(name, slug, heroes);
   }
   return null;
 }

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -62,6 +62,10 @@ export default function Root({ children }: PropsWithChildren) {
           content="Explore every fictional universe — characters, teams and films from Marvel to anime — and settle who'd win."
         />
         <meta name="twitter:image" content={`${SITE_URL}/og.png`} />
+        {/* Site-level structured data: identifies Mythique as an Organization and
+            declares the sitelinks search box (SearchAction → /search?q=). The
+            deep content pages carry their own richer JSON-LD via /api/bot-page. */}
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: structuredData }} />
         <link rel="manifest" href="/manifest.json" />
         <link rel="apple-touch-icon" href="/icon-192.png" />
         {/* Standalone web-app capability. When the site is added to the iOS Home
@@ -82,6 +86,33 @@ export default function Root({ children }: PropsWithChildren) {
     </html>
   );
 }
+
+// Site-wide JSON-LD (WebSite + SearchAction + Organization). `<` is escaped so
+// no field value can prematurely close the <script> tag.
+const structuredData = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      name: 'Mythique',
+      url: SITE_URL,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
+        },
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@type': 'Organization',
+      name: 'Mythique',
+      url: SITE_URL,
+      logo: `${SITE_URL}/icon-512.png`,
+    },
+  ],
+}).replace(/</g, '\\u003c');
 
 const rootStyle = `
 /* Fill the FULL viewport — including behind the iOS status bar, home indicator

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -27,6 +27,16 @@ const SITEMAP_DIR = join(OUT_DIR, 'sitemaps');
 const PAGE_SIZE = 1000; // PostgREST default cap
 const URLS_PER_FILE = 40_000; // under the 50k-per-sitemap limit, with headroom
 
+// Franchise pages thinner than this (member count) are skipped — a 1–2 hero
+// franchise page has too little unique content to be worth indexing.
+const MIN_FRANCHISE_HEROES = 3;
+// Curated matchup coverage: the top N popular heroes × their top K rivals →
+// /compare pages. Bounded so the RPC fan-out and URL count stay sane; the rest
+// of the matchup space stays discoverable via in-page "who wins?" links.
+const MATCHUP_HEROES = 150;
+const MATCHUP_PER_HERO = 5;
+const MATCHUP_CONCURRENCY = 6;
+
 // Static, hand-maintained routes (priority + changefreq matter for these).
 const STATIC_ROUTES = [
   { loc: '/', changefreq: 'daily', priority: '1.0' },
@@ -123,17 +133,28 @@ function xmlEscape(s) {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function urlEntry({ loc, changefreq, priority }) {
+function urlEntry({ loc, changefreq, priority, images }) {
   const parts = [`    <loc>${xmlEscape(BASE_URL + loc)}</loc>`];
   if (changefreq) parts.push(`    <changefreq>${changefreq}</changefreq>`);
   if (priority) parts.push(`    <priority>${priority}</priority>`);
+  // Image extension (Google Images): image locs are absolute CDN URLs, so they
+  // are NOT prefixed with BASE_URL. Surfaces the hero-portrait catalogue in the
+  // Images vertical — a real traffic channel for a visual encyclopedia.
+  if (images && images.length) {
+    for (const img of images) {
+      parts.push(
+        `    <image:image>\n      <image:loc>${xmlEscape(img)}</image:loc>\n    </image:image>`,
+      );
+    }
+  }
   return `  <url>\n${parts.join('\n')}\n  </url>`;
 }
 
-function urlSet(entries) {
+function urlSet(entries, { images = false } = {}) {
+  const imageNs = images ? ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"' : '';
   return (
     '<?xml version="1.0" encoding="UTF-8"?>\n' +
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"${imageNs}>\n` +
     entries.map(urlEntry).join('\n') +
     '\n</urlset>\n'
   );
@@ -155,41 +176,88 @@ function sitemapIndex(files) {
   );
 }
 
-// Page through a PostgREST table, returning every id. Throws on a non-OK
-// response so the caller can decide to fail-soft.
-async function fetchIds(table, query = '') {
-  const ids = [];
+// Page through a PostgREST table, returning full rows for `select`. Throws on a
+// non-OK response so the caller can decide to fail-soft. `order` must be a valid
+// PostgREST order expression (keyset paging relies on a stable sort).
+async function fetchRows(table, select, query = '', order = 'id') {
+  const rows = [];
   for (let offset = 0; ; offset += PAGE_SIZE) {
     const url =
-      `${SUPABASE_URL}/rest/v1/${table}?select=id${query ? `&${query}` : ''}` +
-      `&order=id&limit=${PAGE_SIZE}&offset=${offset}`;
+      `${SUPABASE_URL}/rest/v1/${table}?select=${select}${query ? `&${query}` : ''}` +
+      `&order=${order}&limit=${PAGE_SIZE}&offset=${offset}`;
     const res = await fetch(url, {
       headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
     });
     if (!res.ok) throw new Error(`${table} fetch ${res.status}: ${await res.text()}`);
-    const rows = await res.json();
-    for (const r of rows) ids.push(r.id);
-    if (rows.length < PAGE_SIZE) break;
+    const page = await res.json();
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
   }
-  return ids;
+  return rows;
 }
 
-// Emit one or more chunked child sitemaps for a route prefix; returns the
-// filenames written so they can be added to the index.
-async function writeChunked(name, prefix, ids) {
+// Page through a table returning every id (thin wrapper over fetchRows).
+async function fetchIds(table, query = '') {
+  return (await fetchRows(table, 'id', query)).map((r) => r.id);
+}
+
+// A hero's top related heroes of one kind (enemy/ally/teammate) via the same RPC
+// the app and bot pages use. Fail-soft to [] so one hero can't break the batch.
+async function fetchRelated(heroId, kind, limit) {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/get_related_heroes`, {
+      method: 'POST',
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        p_hero_id: heroId,
+        p_kind: kind,
+        p_limit: limit,
+        p_same_universe: false,
+      }),
+    });
+    if (!res.ok) return [];
+    return (await res.json()).filter((r) => r && r.id);
+  } catch {
+    return [];
+  }
+}
+
+// Run async `fn` over `items` with bounded concurrency — keeps the matchup RPC
+// fan-out fast without hammering PostgREST with hundreds of parallel requests.
+async function mapLimit(items, limit, fn) {
+  const out = [];
+  for (let i = 0; i < items.length; i += limit) {
+    out.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
+  }
+  return out;
+}
+
+// Emit one or more chunked child sitemaps from pre-built entries; returns the
+// filenames written so they can be added to the index. `images` toggles the
+// Google image-sitemap namespace on the urlset.
+async function writeEntriesChunked(name, entries, { images = false } = {}) {
   const files = [];
-  for (let i = 0; i < ids.length; i += URLS_PER_FILE) {
-    const slice = ids.slice(i, i + URLS_PER_FILE);
+  for (let i = 0; i < entries.length; i += URLS_PER_FILE) {
+    const slice = entries.slice(i, i + URLS_PER_FILE);
     const file =
-      ids.length > URLS_PER_FILE ? `${name}-${i / URLS_PER_FILE + 1}.xml` : `${name}.xml`;
-    const entries = slice.map((id) => ({
-      loc: `${prefix}/${encodeURIComponent(String(id))}`,
-      changefreq: 'weekly',
-    }));
-    await writeFile(join(SITEMAP_DIR, file), urlSet(entries), 'utf8');
+      entries.length > URLS_PER_FILE ? `${name}-${i / URLS_PER_FILE + 1}.xml` : `${name}.xml`;
+    await writeFile(join(SITEMAP_DIR, file), urlSet(slice, { images }), 'utf8');
     files.push(file);
   }
   return files;
+}
+
+// Chunked child sitemaps for a route prefix over a list of ids.
+async function writeChunked(name, prefix, ids) {
+  const entries = ids.map((id) => ({
+    loc: `${prefix}/${encodeURIComponent(String(id))}`,
+    changefreq: 'weekly',
+  }));
+  return writeEntriesChunked(name, entries);
 }
 
 async function main() {
@@ -218,23 +286,100 @@ async function main() {
   );
   indexFiles.push('universes.xml');
 
-  // Dynamic content — fail-soft so a Supabase blip can't break the deploy.
+  // Dynamic content — each source is independently fail-soft so one Supabase
+  // blip can't wipe the others (or break the deploy).
   if (SUPABASE_URL && SUPABASE_KEY) {
+    // Characters, WITH portrait images for the Google Images vertical. Quality
+    // gate: only heroes with real content (a summary) — ~16k of 34k.
     try {
-      const sources = [
-        // Quality gate: only heroes with real content (a summary) — ~16k of 34k.
-        ['characters', '/character', 'heroes', 'summary=not.is.null'],
-        ['titles', '/title', 'titles', ''],
-        ['teams', '/team', 'teams', ''],
-      ];
-      for (const [name, prefix, table, q] of sources) {
+      const rows = await fetchRows('heroes', 'id,portrait_url,image_url', 'summary=not.is.null');
+      const entries = rows.map((h) => {
+        const img = h.portrait_url || h.image_url;
+        return {
+          loc: `/character/${encodeURIComponent(String(h.id))}`,
+          changefreq: 'weekly',
+          images: img ? [img] : undefined,
+        };
+      });
+      const written = await writeEntriesChunked('characters', entries, { images: true });
+      indexFiles.push(...written);
+      console.log(`[sitemap] characters: ${entries.length} urls → ${written.join(', ')}`);
+    } catch (err) {
+      console.error(`[sitemap] characters failed: ${err.message}`);
+    }
+
+    // Titles + teams (id-based, no images).
+    for (const [name, prefix, table, q] of [
+      ['titles', '/title', 'titles', ''],
+      ['teams', '/team', 'teams', ''],
+    ]) {
+      try {
         const ids = await fetchIds(table, q);
         const written = await writeChunked(name, prefix, ids);
         indexFiles.push(...written);
         console.log(`[sitemap] ${name}: ${ids.length} urls → ${written.join(', ')}`);
+      } catch (err) {
+        console.error(`[sitemap] ${name} failed: ${err.message}`);
       }
+    }
+
+    // Franchises: distinct `franchise` values with enough members to be worth a
+    // page. Canonical is the encoded raw name, matching /franchise/[slug].
+    try {
+      const rows = await fetchRows('heroes', 'franchise', 'franchise=not.is.null', 'franchise');
+      const counts = new Map();
+      for (const r of rows) {
+        if (r.franchise) counts.set(r.franchise, (counts.get(r.franchise) ?? 0) + 1);
+      }
+      const franchises = [...counts.entries()]
+        .filter(([, n]) => n >= MIN_FRANCHISE_HEROES)
+        .map(([f]) => f)
+        .sort();
+      const entries = franchises.map((f) => ({
+        loc: `/franchise/${encodeURIComponent(f)}`,
+        changefreq: 'weekly',
+      }));
+      const written = await writeEntriesChunked('franchises', entries);
+      indexFiles.push(...written);
+      console.log(`[sitemap] franchises: ${entries.length} urls → ${written.join(', ')}`);
     } catch (err) {
-      console.error(`[sitemap] dynamic generation failed, keeping static only: ${err.message}`);
+      console.error(`[sitemap] franchises failed: ${err.message}`);
+    }
+
+    // Matchups: top popular heroes × their top rivals → /compare pages. This is
+    // content unique to Mythique ("X vs Y who would win"). URLs use the same
+    // sorted-id canonical the bot page emits, and are deduped across heroes.
+    try {
+      const popular = await fetchRows(
+        'heroes',
+        'id',
+        'category=eq.popular',
+        'fame_score.desc.nullslast',
+      );
+      const top = popular.slice(0, MATCHUP_HEROES);
+      const seen = new Set();
+      const entries = [];
+      const rivalLists = await mapLimit(top, MATCHUP_CONCURRENCY, (h) =>
+        fetchRelated(h.id, 'enemy', MATCHUP_PER_HERO).then((rivals) => ({ id: h.id, rivals })),
+      );
+      for (const { id, rivals } of rivalLists) {
+        for (const rival of rivals) {
+          const [x, y] = [String(id), String(rival.id)].sort();
+          if (x === y) continue;
+          const key = `${x}|${y}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          entries.push({
+            loc: `/compare/${encodeURIComponent(x)}/${encodeURIComponent(y)}`,
+            changefreq: 'monthly',
+          });
+        }
+      }
+      const written = await writeEntriesChunked('matchups', entries);
+      indexFiles.push(...written);
+      console.log(`[sitemap] matchups: ${entries.length} urls → ${written.join(', ')}`);
+    } catch (err) {
+      console.error(`[sitemap] matchups failed: ${err.message}`);
     }
   } else {
     console.warn('[sitemap] EXPO_PUBLIC_SUPABASE_URL/KEY not set — static sitemap only.');

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -18,10 +18,7 @@ import { join } from 'node:path';
 // Mirrors SITE_URL in src/constants/site.ts (this standalone build script can't
 // import TS). Override at build time with SITEMAP_BASE_URL. Keep in sync with
 // SITE_URL if the origin ever changes.
-const BASE_URL = (process.env.SITEMAP_BASE_URL || 'https://mythique.app').replace(
-  /\/$/,
-  '',
-);
+const BASE_URL = (process.env.SITEMAP_BASE_URL || 'https://mythique.app').replace(/\/$/, '');
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY;
 
@@ -38,6 +35,69 @@ const STATIC_ROUTES = [
   { loc: '/search', changefreq: 'weekly', priority: '0.7' },
   { loc: '/privacy', changefreq: 'yearly', priority: '0.3' },
   { loc: '/terms', changefreq: 'yearly', priority: '0.3' },
+];
+
+// Registered universe (publisher/studio) slugs — mirrors the slug set of
+// UNIVERSE_BRANDS in src/constants/universeBrands.ts (this standalone build
+// script can't import TS). These are the canonical /universe/<slug> URLs the app
+// and the crawler bot pages both link to; unregistered universes stay
+// discoverable via character-page links rather than the sitemap.
+// __tests__/constants/universeBrands.test.ts guards this list against drift.
+const UNIVERSE_SLUGS = [
+  'marvel',
+  'dc',
+  'dark-horse',
+  'star-wars',
+  'image',
+  'netherrealm',
+  'babylon-5',
+  'avatar-last-airbender',
+  'snk',
+  'the-boys',
+  'sin-city',
+  'pokemon',
+  'gatchaman',
+  'hanna-barbera',
+  'looney-tunes',
+  'cd-projekt-red',
+  'rocky-bullwinkle',
+  'insomniac',
+  'star-trek',
+  'green-hornet',
+  'tmnt',
+  'conan',
+  'ben-10',
+  'buffy',
+  'harvey',
+  'terminator',
+  'bungie',
+  'crystal-dynamics',
+  'playstation-studios',
+  'xbox-game-studios',
+  'god-of-war',
+  'halo',
+  'santa-monica-studio',
+  'namco',
+  'radical-entertainment',
+  'alien',
+  'predator',
+  'indiana-jones',
+  'jurassic-park',
+  'nintendo',
+  'shueisha',
+  'warp-graphics',
+  'archie',
+  'disney',
+  'valiant',
+  'top-cow',
+  'malibu',
+  'rebellion',
+  'capcom',
+  'sega',
+  'mattel',
+  'hasbro',
+  'kodansha',
+  'warner-bros',
 ];
 
 // Fixed category taxonomy — mirrors CategorySlug in src/lib/db/heroes/types.ts.
@@ -151,6 +211,12 @@ async function main() {
     'utf8',
   );
   indexFiles.push('categories.xml');
+  await writeFile(
+    join(SITEMAP_DIR, 'universes.xml'),
+    urlSet(UNIVERSE_SLUGS.map((slug) => ({ loc: `/universe/${slug}`, changefreq: 'weekly' }))),
+    'utf8',
+  );
+  indexFiles.push('universes.xml');
 
   // Dynamic content — fail-soft so a Supabase blip can't break the deploy.
   if (SUPABASE_URL && SUPABASE_KEY) {

--- a/src/constants/universeBrands.ts
+++ b/src/constants/universeBrands.ts
@@ -1,0 +1,184 @@
+// Pure, asset-free projection of PUBLISHER_BRANDS (src/constants/publishers.ts)
+// — slug / name / query / match only. The RN-free crawler bundle
+// (api/_lib/botPage.ts) and the standalone sitemap script (scripts/…) resolve a
+// raw `publisher` string to its canonical universe slug through this module,
+// without importing the SVG/PNG logos that make publishers.ts un-importable
+// outside React Native (and outside the Vercel functions in api/).
+//
+// This is a MIRROR, not the source of truth: PUBLISHER_BRANDS stays canonical.
+// __tests__/constants/universeBrands.test.ts asserts the two never drift —
+// slug/name/query/match must equal PUBLISHER_BRANDS exactly, in registry order —
+// so a brand added or renamed there fails CI until mirrored here.
+
+export type UniverseBrand = { slug: string; name: string; query: string; match: string[] };
+
+/** Mirror of PUBLISHER_BRANDS (slug/name/query/match), in registry (detection)
+ *  order — `match` is checked in order, so ordering is load-bearing. */
+export const UNIVERSE_BRANDS: UniverseBrand[] = [
+  { slug: 'marvel', name: 'Marvel', query: 'marvel', match: ['marvel'] },
+  { slug: 'dc', name: 'DC', query: 'dc comics', match: ['dc comics', 'dc'] },
+  { slug: 'dark-horse', name: 'Dark Horse', query: 'dark horse', match: ['dark horse'] },
+  {
+    slug: 'star-wars',
+    name: 'Star Wars',
+    query: 'star wars',
+    match: ['star wars', 'george lucas'],
+  },
+  { slug: 'image', name: 'Image', query: 'image', match: ['image'] },
+  {
+    slug: 'netherrealm',
+    name: 'NetherRealm Studios',
+    query: 'netherrealm',
+    match: ['netherrealm'],
+  },
+  { slug: 'babylon-5', name: 'Babylon 5', query: 'babylon 5', match: ['babylon 5'] },
+  {
+    slug: 'avatar-last-airbender',
+    name: 'Avatar: The Last Airbender',
+    query: 'last airbender',
+    match: ['last airbender'],
+  },
+  { slug: 'snk', name: 'SNK', query: 'snk', match: ['snk'] },
+  { slug: 'the-boys', name: 'The Boys', query: 'The Boys', match: ['the boys'] },
+  { slug: 'sin-city', name: 'Sin City', query: 'Sin City', match: ['sin city'] },
+  { slug: 'pokemon', name: 'Pokémon', query: 'Pokémon', match: ['pokémon', 'pokemon'] },
+  { slug: 'gatchaman', name: 'Gatchaman', query: 'gatchaman', match: ['gatchaman'] },
+  {
+    slug: 'hanna-barbera',
+    name: 'Hanna-Barbera',
+    query: 'hanna-barbera',
+    match: ['hanna-barbera', 'hanna barbera'],
+  },
+  { slug: 'looney-tunes', name: 'Looney Tunes', query: 'looney tunes', match: ['looney tunes'] },
+  { slug: 'cd-projekt-red', name: 'CD Projekt Red', query: 'cd projekt', match: ['cd projekt'] },
+  {
+    slug: 'rocky-bullwinkle',
+    name: 'Rocky & Bullwinkle',
+    query: 'bullwinkle',
+    match: ['bullwinkle', 'rocky & bullwinkle'],
+  },
+  { slug: 'insomniac', name: 'Insomniac Games', query: 'insomniac', match: ['insomniac'] },
+  { slug: 'star-trek', name: 'Star Trek', query: 'star trek', match: ['star trek'] },
+  {
+    slug: 'green-hornet',
+    name: 'The Green Hornet',
+    query: 'green hornet',
+    match: ['green hornet'],
+  },
+  {
+    slug: 'tmnt',
+    name: 'Teenage Mutant Ninja Turtles',
+    query: 'ninja turtles',
+    match: ['teenage mutant', 'ninja turtles'],
+  },
+  { slug: 'conan', name: 'Conan', query: 'conan', match: ['conan'] },
+  { slug: 'ben-10', name: 'Ben 10', query: 'ben 10', match: ['ben 10'] },
+  { slug: 'buffy', name: 'Buffy the Vampire Slayer', query: 'buffy', match: ['buffy'] },
+  { slug: 'harvey', name: 'Harvey Comics', query: 'harvey', match: ['harvey'] },
+  { slug: 'terminator', name: 'The Terminator', query: 'terminator', match: ['terminator'] },
+  { slug: 'bungie', name: 'Bungie', query: 'bungie', match: ['bungie'] },
+  {
+    slug: 'crystal-dynamics',
+    name: 'Crystal Dynamics',
+    query: 'crystal dynamics',
+    match: ['crystal dynamics'],
+  },
+  {
+    slug: 'playstation-studios',
+    name: 'PlayStation Studios',
+    query: 'playstation studios',
+    match: ['playstation studios', 'playstation'],
+  },
+  {
+    slug: 'xbox-game-studios',
+    name: 'Xbox Game Studios',
+    query: 'xbox game studios',
+    match: ['xbox game studios', 'xbox game'],
+  },
+  { slug: 'god-of-war', name: 'God of War', query: 'god of war', match: ['god of war'] },
+  { slug: 'halo', name: 'Halo', query: 'halo', match: ['halo'] },
+  {
+    slug: 'santa-monica-studio',
+    name: 'Santa Monica Studio',
+    query: 'santa monica',
+    match: ['santa monica'],
+  },
+  { slug: 'namco', name: 'Namco', query: 'namco', match: ['namco'] },
+  {
+    slug: 'radical-entertainment',
+    name: 'Radical Entertainment',
+    query: 'radical entertainment',
+    match: ['radical entertainment'],
+  },
+  { slug: 'alien', name: 'Alien', query: 'alien', match: ['alien'] },
+  { slug: 'predator', name: 'Predator', query: 'predator', match: ['predator'] },
+  {
+    slug: 'indiana-jones',
+    name: 'Indiana Jones',
+    query: 'indiana jones',
+    match: ['indiana jones'],
+  },
+  { slug: 'jurassic-park', name: 'Jurassic Park', query: 'jurassic', match: ['jurassic'] },
+  { slug: 'nintendo', name: 'Nintendo', query: 'nintendo', match: ['nintendo'] },
+  { slug: 'shueisha', name: 'Shueisha', query: 'shueisha', match: ['shueisha'] },
+  {
+    slug: 'warp-graphics',
+    name: 'Warp Graphics',
+    query: 'warp graphics',
+    match: ['warp graphics'],
+  },
+  { slug: 'archie', name: 'Archie Comics', query: 'archie', match: ['archie'] },
+  { slug: 'disney', name: 'Disney', query: 'disney', match: ['disney'] },
+  { slug: 'valiant', name: 'Valiant', query: 'valiant', match: ['valiant'] },
+  { slug: 'top-cow', name: 'Top Cow', query: 'top cow', match: ['top cow'] },
+  { slug: 'malibu', name: 'Malibu Comics', query: 'malibu', match: ['malibu'] },
+  { slug: 'rebellion', name: '2000 AD', query: 'rebellion', match: ['rebellion'] },
+  { slug: 'capcom', name: 'Capcom', query: 'capcom', match: ['capcom'] },
+  { slug: 'sega', name: 'Sega', query: 'sega', match: ['sega'] },
+  { slug: 'mattel', name: 'Mattel', query: 'mattel', match: ['mattel'] },
+  { slug: 'hasbro', name: 'Hasbro', query: 'hasbro', match: ['hasbro'] },
+  { slug: 'kodansha', name: 'Kodansha', query: 'kodansha', match: ['kodansha'] },
+  {
+    slug: 'warner-bros',
+    name: 'Warner Bros',
+    query: 'warner bros',
+    match: ['warner bros', 'warner brothers'],
+  },
+];
+
+/** Raw `publisher` values that are SuperheroAPI category buckets, not universes —
+ *  never linked as a browsable universe. Mirrors NON_UNIVERSE_PUBLISHERS in
+ *  publishers.ts. */
+export const NON_UNIVERSE_PUBLISHERS = new Set<string>([
+  'Non-Fictional',
+  'Creator-Owned',
+  'Company-Licensed',
+  'In the Public Domain',
+]);
+
+/** Resolve a raw DB `publisher` to its brand by substring match, in registry
+ *  order. Mirrors brandForPublisher() in publishers.ts. */
+export function universeBrandForPublisher(
+  publisher: string | null | undefined,
+): UniverseBrand | undefined {
+  if (!publisher) return undefined;
+  const p = publisher.toLowerCase();
+  return UNIVERSE_BRANDS.find((brand) => brand.match.some((m) => p.includes(m)));
+}
+
+/** Resolve a URL slug to its registered brand, or undefined. */
+export function universeBrandBySlug(slug: string | null | undefined): UniverseBrand | undefined {
+  if (!slug) return undefined;
+  return UNIVERSE_BRANDS.find((brand) => brand.slug === slug);
+}
+
+/** The canonical `/universe/*` href for a publisher, or null when it isn't a
+ *  browsable universe (absent, or a category bucket). Registered brands route by
+ *  their stable slug; every other universe by its URL-encoded raw name. Mirrors
+ *  publisherHref() in publishers.ts — the single canonical universe URL that the
+ *  sitemap, character bot pages, and universe bot page all agree on. */
+export function universeHref(publisher: string | null | undefined): string | null {
+  if (!publisher || NON_UNIVERSE_PUBLISHERS.has(publisher)) return null;
+  const slug = universeBrandForPublisher(publisher)?.slug ?? encodeURIComponent(publisher);
+  return `/universe/${slug}`;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -90,6 +90,17 @@
       ],
       "destination": "/api/bot-page?kind=universe&slug=:slug"
     },
+    {
+      "source": "/franchise/:slug",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+        }
+      ],
+      "destination": "/api/bot-page?kind=franchise&slug=:slug"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -68,6 +68,28 @@
       ],
       "destination": "/api/bot-page?kind=vs&a=:hero&b=:opponent"
     },
+    {
+      "source": "/category/:slug",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+        }
+      ],
+      "destination": "/api/bot-page?kind=category&slug=:slug"
+    },
+    {
+      "source": "/universe/:slug",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+        }
+      ],
+      "destination": "/api/bot-page?kind=universe&slug=:slug"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Why

Search Console shows Mythique getting **26.8K impressions but ~17 clicks (0.1% CTR)** over its first ~week of indexing. The technical foundation was already strong (static export, per-page meta, a crawler-prerender pipeline, a chunked ~22K-URL sitemap), so this isn't an "add SEO" problem — it's **crawl-coverage gaps** plus a new domain with no authority yet. This PR closes the on-site gaps so every content type Mythique has is crawlable, canonical, and richly marked up. (The authority half — backlinks, a launch, time — is off-site and out of scope here.)

## What changed

**New crawlable content types** (were served the empty SPA shell to bots)
- **Category hubs** (`/category/:slug`) — the sitemap already advertised these, but bots got nothing. Now bot-rendered with keyword-targeted H1/intro, an ordered linked character list, sibling-hub cross-links, and `CollectionPage` + `ItemList` + `BreadcrumbList` JSON-LD. Targets head terms ("strongest characters", "marvel villains").
- **Universe hubs** (`/universe/:slug`) and **Franchise hubs** (`/franchise/:slug`) — same treatment, funnelling crawl equity into the character graph.

**One canonical URL per universe** (was splitting ranking signals)
- The app links universes by clean slug (`/universe/marvel`) but the character/team bot pages linked by raw name (`/universe/Marvel%20Comics`) — two URLs for identical content. New `src/constants/universeBrands.ts` is an asset-free mirror of `PUBLISHER_BRANDS` (the real registry can't be imported into the RN-free `api/` bundle because it pulls in SVG/PNG logos). `universePath()` and the `/universe` route now resolve **both** forms to the same canonical slug. A drift test locks the mirror and the sitemap's slug list to the registry so they can't silently diverge.

**Richer structured data**
- Homepage: `WebSite` + `SearchAction` (sitelinks search box → `/search?q=`) + `Organization`.
- Versus pages: `FAQPage` ("Who would win, X vs Y?") with a factual, tally-backed answer — targets People-Also-Ask / featured snippets for the who-would-win query space, which is content unique to Mythique.

**Expanded sitemap + new discovery channels**
- **Universe** and **franchise** chunks (franchises with ≥3 members; thin ones skipped).
- **Google Images**: character entries now carry the hero portrait via the image-sitemap extension — opens the Images vertical for a visual encyclopedia.
- **Matchups**: top popular heroes × their top rivals as `/compare` URLs (deduped, canonical sorted-id order, bounded RPC fan-out) — gets the unique matchup content crawled directly.
- Each dynamic source is now independently fail-soft, so one Supabase blip can't wipe the others.

## Testing

- `yarn test:ci` — **736 passing** (added coverage for the category/universe/franchise builders, the versus FAQ, the canonicalization, and the registry/sitemap drift guard).
- `yarn tsc --noEmit` clean for both the app project and the `api/` bundle; Prettier clean.
- Sitemap generator exercised end-to-end against a mocked PostgREST/RPC harness — image, franchise, and matchup XML all verified well-formed (image locs absolute, thin franchises filtered, matchups deduped).

## Notes / follow-ups (out of scope)

- The remaining lever for the low CTR is **off-site**: domain authority (backlinks, a launch) and time. The code is no longer the bottleneck.
- Bot pages use dynamic rendering (serving crawlers prerendered HTML). It's working and Google-tolerated; a future `generateStaticParams` pass could pre-render the top pages as true static HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU)_