### PR TITLE
First-touch UTM attribution for paid-social measurement

### DIFF
--- a/__tests__/lib/attribution.test.ts
+++ b/__tests__/lib/attribution.test.ts
@@ -8,7 +8,9 @@ import {
 describe('parseUtm', () => {
   it('pulls all five UTM params from a query string', () => {
     expect(
-      parseUtm('?utm_source=tiktok&utm_medium=social&utm_campaign=bio&utm_content=v1&utm_term=goku'),
+      parseUtm(
+        '?utm_source=tiktok&utm_medium=social&utm_campaign=bio&utm_content=v1&utm_term=goku',
+      ),
     ).toEqual({
       source: 'tiktok',
       medium: 'social',

--- a/__tests__/lib/attribution.test.ts
+++ b/__tests__/lib/attribution.test.ts
@@ -1,0 +1,107 @@
+import {
+  parseUtm,
+  deriveAttribution,
+  attributionEventProps,
+  type Attribution,
+} from '../../src/lib/attribution';
+
+describe('parseUtm', () => {
+  it('pulls all five UTM params from a query string', () => {
+    expect(
+      parseUtm('?utm_source=tiktok&utm_medium=social&utm_campaign=bio&utm_content=v1&utm_term=goku'),
+    ).toEqual({
+      source: 'tiktok',
+      medium: 'social',
+      campaign: 'bio',
+      content: 'v1',
+      term: 'goku',
+    });
+  });
+
+  it('returns nulls for a query string with no UTM params', () => {
+    expect(parseUtm('?foo=bar')).toEqual({
+      source: null,
+      medium: null,
+      campaign: null,
+      content: null,
+      term: null,
+    });
+  });
+
+  it('is null-safe on an empty query', () => {
+    expect(parseUtm('').source).toBeNull();
+  });
+
+  it('trims whitespace and treats blank values as absent', () => {
+    expect(parseUtm('?utm_source=%20%20&utm_campaign=%20villains%20').source).toBeNull();
+    expect(parseUtm('?utm_campaign=%20villains%20').campaign).toBe('villains');
+  });
+
+  it('caps overly long values to 120 chars', () => {
+    const long = 'x'.repeat(300);
+    expect(parseUtm(`?utm_campaign=${long}`).campaign).toHaveLength(120);
+  });
+});
+
+describe('deriveAttribution', () => {
+  it('uses an explicit utm_source over the referrer', () => {
+    const a = deriveAttribution('?utm_source=tiktok&utm_campaign=bio', 'l.instagram.com', '/');
+    expect(a).toMatchObject({ source: 'tiktok', campaign: 'bio', referrer: 'l.instagram.com' });
+  });
+
+  it('leaves medium null when a utm_source has no explicit medium', () => {
+    expect(deriveAttribution('?utm_source=tiktok', null, '/')?.medium).toBeNull();
+  });
+
+  it('falls back to the referrer host as a referral source when no UTM', () => {
+    const a = deriveAttribution('', 'www.google.com', '/explore');
+    expect(a).toMatchObject({ source: 'www.google.com', medium: 'referral', landing: '/explore' });
+  });
+
+  it('returns null for direct, untagged visits (no UTM, no referrer)', () => {
+    expect(deriveAttribution('?foo=bar', null, '/')).toBeNull();
+  });
+
+  it('attributes on campaign alone even without a source', () => {
+    expect(deriveAttribution('?utm_campaign=aquaman', null, '/')?.campaign).toBe('aquaman');
+  });
+});
+
+describe('attributionEventProps', () => {
+  it('is empty for null (direct) attribution', () => {
+    expect(attributionEventProps(null)).toEqual({});
+  });
+
+  it('emits only the present, flat props', () => {
+    const a: Attribution = {
+      source: 'tiktok',
+      medium: 'social',
+      campaign: 'bio',
+      content: null,
+      term: null,
+      referrer: null,
+      landing: '/',
+    };
+    expect(attributionEventProps(a)).toEqual({
+      utm_source: 'tiktok',
+      utm_medium: 'social',
+      utm_campaign: 'bio',
+    });
+  });
+
+  it('omits keys whose values are null', () => {
+    const a: Attribution = {
+      source: 'www.google.com',
+      medium: 'referral',
+      campaign: null,
+      content: null,
+      term: null,
+      referrer: 'www.google.com',
+      landing: '/',
+    };
+    expect(attributionEventProps(a)).toEqual({
+      utm_source: 'www.google.com',
+      utm_medium: 'referral',
+    });
+  });
+});

--- a/docs/marketing/utm-attribution.md
+++ b/docs/marketing/utm-attribution.md
@@ -71,18 +71,18 @@ for organic posts — so you can separate paid from organic acquisition at a gla
 
 ### Parameter cheatsheet
 
-| Param          | Use                          | Examples                              |
-| -------------- | ---------------------------- | ------------------------------------- |
-| `utm_source`   | the platform                 | `tiktok`, `instagram`, `reddit`       |
-| `utm_medium`   | paid vs organic              | `paid`, `social`, `referral`          |
-| `utm_campaign` | the creative / initiative    | `bio`, `aquaman-challenge`, `villains-top10` |
-| `utm_content`  | A/B variant (optional)       | `hook-a`, `hook-b`                     |
+| Param          | Use                       | Examples                                     |
+| -------------- | ------------------------- | -------------------------------------------- |
+| `utm_source`   | the platform              | `tiktok`, `instagram`, `reddit`              |
+| `utm_medium`   | paid vs organic           | `paid`, `social`, `referral`                 |
+| `utm_campaign` | the creative / initiative | `bio`, `aquaman-challenge`, `villains-top10` |
+| `utm_content`  | A/B variant (optional)    | `hook-a`, `hook-b`                           |
 
 ## Reading the results
 
 - **Admin → Traffic → Acquisition** — first-touch visitors and how many signed in,
   per campaign. This is the money view: `aquaman-challenge → 120 visitors, 14
-  signed in`.
+signed in`.
 - **Top referrers** (same tab) still catches untagged organic clicks by host.
 - Keep the campaign vocabulary small and consistent — every distinct spelling is
   a separate row.

--- a/docs/marketing/utm-attribution.md
+++ b/docs/marketing/utm-attribution.md
@@ -1,0 +1,96 @@
+# UTM attribution — measuring what paid social actually does for the app
+
+TikTok Promote tells you views, likes, comments, followers and **profile views**.
+What it can't tell you is the step that matters: of the people who tapped your
+profile, how many reached the app and signed up. That step happens on
+**mythique.app**, off TikTok — so we measure it ourselves.
+
+This doc is the link-tagging convention that makes that measurement work. Tag a
+link once and every visit, event and signup it produces is bucketed by campaign
+in the admin **Traffic → Acquisition** panel.
+
+## Why this matters (from the July promotes)
+
+Across ~R690 of Promote spend (28 days): **38.8K views → 409 profile views → 30
+new followers.** Those 409 profile views are the real top-of-funnel — the profile
+is where the bio link lives, and the bio link is the only door to the app. Right
+now that door is **untagged**, so we can't see how many of the 409 walked through
+it. Tagging it turns "409 profile views" into "N app visits, M signups, by
+campaign."
+
+## How it works
+
+- `src/lib/attribution.ts` captures **first-touch** attribution on landing — the
+  `utm_*` params on the URL (or the referring host if untagged) — and pins it for
+  the browser session.
+- Every conversion event (`sign_up`, `log_in`, `matchup_vote`, …) is tagged with
+  that source (`src/lib/analytics.ts`).
+- One row per session is written to `session_attribution` and joined to page
+  views server-side, surfacing in **admin → Traffic → Acquisition**
+  (`admin_traffic_overview`).
+
+First-touch wins: if someone arrives from the TikTok bio today and returns direct
+next week, they stay attributed to `bio`.
+
+> **One-time setup:** apply the migration
+> `supabase/migrations/20260715170000_session_attribution.sql`
+> (`mcp__supabase__apply_migration`), then regenerate `database.generated.ts`.
+> Until it's applied the client degrades cleanly — events still carry UTM tags;
+> the Acquisition panel just stays empty and the write retries harmlessly.
+
+## The links to use
+
+Base everything on the production origin `https://mythique.app`. Convention:
+lowercase, no spaces, hyphens not underscores in values.
+
+### 1. The bio link (most important — do this first)
+
+Every profile view funnels through it. Put this in the TikTok profile's website
+field:
+
+```
+https://mythique.app/?utm_source=tiktok&utm_medium=social&utm_campaign=bio
+```
+
+### 2. Per-post / per-promote links
+
+When a specific post or Promote drives to a specific place, give it its own
+`utm_campaign` so you can compare creatives. Match the campaign name to the
+creative:
+
+```
+# "Name ONE who beats Aquaman" — deep-link straight into the matchup
+https://mythique.app/compare/<aquaman-id>/<opponent-id>?utm_source=tiktok&utm_medium=paid&utm_campaign=aquaman-challenge
+
+# "Top 10 Most Famous Villains" ranking
+https://mythique.app/?utm_source=tiktok&utm_medium=paid&utm_campaign=villains-top10
+```
+
+Use `utm_medium=paid` for anything behind Promote/ad spend and `utm_medium=social`
+for organic posts — so you can separate paid from organic acquisition at a glance.
+
+### Parameter cheatsheet
+
+| Param          | Use                          | Examples                              |
+| -------------- | ---------------------------- | ------------------------------------- |
+| `utm_source`   | the platform                 | `tiktok`, `instagram`, `reddit`       |
+| `utm_medium`   | paid vs organic              | `paid`, `social`, `referral`          |
+| `utm_campaign` | the creative / initiative    | `bio`, `aquaman-challenge`, `villains-top10` |
+| `utm_content`  | A/B variant (optional)       | `hook-a`, `hook-b`                     |
+
+## Reading the results
+
+- **Admin → Traffic → Acquisition** — first-touch visitors and how many signed in,
+  per campaign. This is the money view: `aquaman-challenge → 120 visitors, 14
+  signed in`.
+- **Top referrers** (same tab) still catches untagged organic clicks by host.
+- Keep the campaign vocabulary small and consistent — every distinct spelling is
+  a separate row.
+
+## Tips
+
+- Tag the link **before** the next Promote so the batch is measurable end to end.
+- Shorten the long deep-links with any link shortener for the caption; the `utm_*`
+  params must survive the redirect (most shorteners preserve query strings).
+- Don't tag internal links between app pages — first-touch already covers the
+  whole session, and internal tags would overwrite the real source.

--- a/scripts/social/README.md
+++ b/scripts/social/README.md
@@ -137,6 +137,15 @@ node scripts/social/ads/ad-web-hero.mjs --size all   # 16x9 | og | wide
 node scripts/social/ads/batch-week.mjs               # 4x5 feed; --size 9x16 for stories
 node scripts/social/ads/batch-week.mjs --dry-run     # print the plan only
 open "out/social/week-$(date +%F)/week.html"         # the planner
+
+# Each caption gets a UTM-tagged link (campaign = post label) + a bio link in the
+# planner, so every creative is measurable in admin → Traffic → Acquisition.
+# Defaults suit the organic IG/X track; override when repurposing for paid:
+node scripts/social/ads/batch-week.mjs --utm-source tiktok --utm-medium paid
+#   --site  https://mythique.app   (origin for the links)
+# Note: TikTok/IG-feed captions aren't clickable — the bio link carries their
+# attribution; the per-post link pays off on X and Story link stickers.
+# Playbook: docs/marketing/utm-attribution.md
 ```
 
 Shared: `ads/shell.mjs` (parametric `{w,h}` brand shell + disclaimer) and

--- a/scripts/social/ads/batch-week.mjs
+++ b/scripts/social/ads/batch-week.mjs
@@ -22,6 +22,10 @@ const RANKINGS = [
   ['speed', 'top-10-fastest'],
 ];
 
+// Production origin for the UTM-tagged links appended to each caption. Override
+// with --site if the origin changes. See docs/marketing/utm-attribution.md.
+const SITE = 'https://mythique.app';
+
 // Weekly rotation seed — same week = same plan (idempotent), next week differs.
 const week = Math.floor(Date.now() / 604_800_000);
 
@@ -45,11 +49,32 @@ const GUIDE = {
 };
 
 // Only rivalries whose BOTH names exact-match the heroes table (names drift).
+// Carries the resolved hero ids too, so matchup captions can deep-link straight
+// into the /compare page rather than just the homepage.
 async function resolvableRivalries() {
   const sb = makeSb(loadEnv());
-  const checks = await Promise.all(RIVALRIES.map(async ([a, b]) =>
-    ((await heroByName(sb, a)) && (await heroByName(sb, b))) ? [a, b] : null));
+  const checks = await Promise.all(RIVALRIES.map(async ([a, b]) => {
+    const [ha, hb] = [await heroByName(sb, a), await heroByName(sb, b)];
+    return ha && hb ? { pair: [a, b], ids: [ha.id, hb.id] } : null;
+  }));
   return checks.filter(Boolean);
+}
+
+// /compare orders the pair by hero id (see lib.mjs pickMatchup); mirror that so
+// the deep-link matches the canonical URL and shares vote/OG state.
+function comparePath([ida, idb]) {
+  const [x, y] = ida <= idb ? [ida, idb] : [idb, ida];
+  return `/compare/${x}/${y}`;
+}
+
+// Build a UTM-tagged link. campaign = the post label, so each creative is its
+// own row in admin → Traffic → Acquisition.
+function taggedLink({ site, source, medium, campaign, path = '/' }) {
+  const u = new URL(path, site);
+  u.searchParams.set('utm_source', source);
+  u.searchParams.set('utm_medium', medium);
+  u.searchParams.set('utm_campaign', campaign);
+  return u.toString();
 }
 
 function buildPlan(pool) {
@@ -59,10 +84,10 @@ function buildPlan(pool) {
   // Mon..Sun: brand / matchup / ranking / brand / matchup / brand / ranking
   return [
     { kind: 'brand', style: bs(0) },
-    { kind: 'matchup', pair: riv(0) },
+    { kind: 'matchup', pair: riv(0).pair, ids: riv(0).ids },
     { kind: 'ranking', by: rank(0)[0], slug: rank(0)[1] },
     { kind: 'brand', style: bs(1) },
-    { kind: 'matchup', pair: riv(1) },
+    { kind: 'matchup', pair: riv(1).pair, ids: riv(1).ids },
     { kind: 'brand', style: bs(2) },
     { kind: 'ranking', by: rank(1)[0], slug: rank(1)[1] },
   ];
@@ -106,7 +131,7 @@ const label = (post) =>
 // Self-contained visual planner written next to the images — open week.html in a
 // browser: previews, where/when/how per post, one-click caption copy, and a
 // "posted" checkbox persisted in localStorage. No server, no dependencies.
-function dashboard(stamp, size, entries) {
+function dashboard(stamp, size, entries, bioLink) {
   const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const cards = entries.map((e) => {
     const g = GUIDE[e.kind];
@@ -129,7 +154,9 @@ body{background:linear-gradient(#0d1f2b,var(--navy) 40%);color:var(--cream);font
 .wrap{max-width:1180px;margin:0 auto}
 h1{font-size:24px;font-weight:650;letter-spacing:.2px}
 h1 span{color:var(--gold)}
-.sub{color:var(--muted);font-size:13.5px;margin:6px 0 26px}
+.sub{color:var(--muted);font-size:13.5px;margin:6px 0 14px}
+.bio{background:rgba(224,168,62,.08);border:1px solid var(--line);border-radius:10px;padding:11px 14px;margin:0 0 26px;font-size:12.5px;color:var(--cream);word-break:break-all}
+.bio b{color:var(--gold)}.bio a{color:var(--gold)}.bio span{color:var(--muted)}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:20px}
 .card{background:linear-gradient(180deg,var(--panel),#0b1c27);border:1px solid var(--line);border-radius:14px;overflow:hidden;display:flex;flex-direction:column}
 .card.is-done{opacity:.45}
@@ -148,6 +175,7 @@ h1 span{color:var(--gold)}
 </style></head><body><div class="wrap">
 <h1>mythique<span>.</span> — content week ${stamp}</h1>
 <div class="sub">${entries.length} posts · ${size} · one per day · stories: re-run with --size 9x16 (matchups → poll sticker)</div>
+<div class="bio"><b>Bio link</b> — set as your profile link; carries feed/TikTok attribution: <a href="${esc(bioLink)}">${esc(bioLink)}</a><br><span>Feed/TikTok captions aren’t clickable — the per-post 🔗 pays off on X and Story link stickers.</span></div>
 <div class="grid">${cards}</div>
 <div class="foot">Consistency beats timing — one post a day, reply to every comment. · Unofficial fan encyclopedia. Characters © their respective owners.</div>
 </div><script>
@@ -170,6 +198,13 @@ async function main() {
   const get = (f, d) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : d; };
   const size = get('--size', '4x5');
   const dry = args.includes('--dry-run');
+  // UTM tagging for the links appended to each caption. Defaults suit the organic
+  // Instagram/X track this batch targets; pass --utm-source tiktok / --utm-medium
+  // paid when repurposing for a paid run.
+  const site = get('--site', SITE);
+  const utmSource = get('--utm-source', 'instagram');
+  const utmMedium = get('--utm-medium', 'social');
+  const bioLink = taggedLink({ site, source: utmSource, medium: 'social', campaign: 'bio' });
 
   const pool = await resolvableRivalries();
   if (!pool.length) { console.error('No rivalry pair resolves against the heroes table.'); process.exit(1); }
@@ -182,7 +217,18 @@ async function main() {
   const weekDir = join(OUT_DIR, `week-${stamp}`);
   mkdirSync(weekDir, { recursive: true });
 
-  const lines = [`# Mythique — content week ${stamp}`, '', `Size: ${size} · rotation #${week}`, ''];
+  const lines = [
+    `# Mythique — content week ${stamp}`,
+    '',
+    `Size: ${size} · rotation #${week}`,
+    '',
+    `**Bio link** (set this as your profile link — carries feed/TikTok attribution): ${bioLink}`,
+    '',
+    '> Captions on TikTok & the Instagram feed are **not clickable** — the tagged',
+    '> link there is a reference; attribution for those comes from the bio link.',
+    '> The per-post link pays off on **X** and **Instagram Story link stickers**.',
+    '',
+  ];
   const entries = [];
   for (let i = 0; i < plan.length; i++) {
     const post = plan[i];
@@ -195,15 +241,22 @@ async function main() {
     const base = `${String(i + 1).padStart(2, '0')}-${DAYS[i]}-${label(post)}`;
     if (!existsSync(img)) { console.error(`  !! expected output missing: ${img}`); continue; }
     copyFileSync(img, join(weekDir, `${base}.png`));
-    const caption = existsSync(cap) ? readFileSync(cap, 'utf8') : '';
-    if (caption) writeFileSync(join(weekDir, `${base}.caption.txt`), caption);
+    // Append a UTM-tagged link (campaign = post label). Matchups deep-link into
+    // the /compare page; everything else lands on the homepage. This makes each
+    // creative measurable in admin → Traffic → Acquisition — see
+    // docs/marketing/utm-attribution.md.
+    const rawCaption = existsSync(cap) ? readFileSync(cap, 'utf8') : '';
+    const path = post.kind === 'matchup' && post.ids ? comparePath(post.ids) : '/';
+    const link = taggedLink({ site, source: utmSource, medium: utmMedium, campaign: label(post), path });
+    const caption = rawCaption ? `${rawCaption.trimEnd()}\n\n🔗 ${link}` : `🔗 ${link}`;
+    writeFileSync(join(weekDir, `${base}.caption.txt`), caption);
     const g = GUIDE[post.kind];
     lines.push(`- **${DAYS[i]}** — ${label(post)} (\`${base}.png\`) · ${g.where} · ${g.when}`);
     entries.push({ day: DAYS[i], base, kind: post.kind, name: label(post), caption });
   }
   lines.push('', 'Post one per day; paste the matching `.caption.txt`. Stories: re-run with `--size 9x16`.');
   writeFileSync(join(weekDir, 'PLAN.md'), lines.join('\n') + '\n');
-  writeFileSync(join(weekDir, 'week.html'), dashboard(stamp, size, entries));
+  writeFileSync(join(weekDir, 'week.html'), dashboard(stamp, size, entries, bioLink));
   console.log(`\nWeek ready → ${weekDir}`);
   console.log(`Open the visual planner:  open "${join(weekDir, 'week.html')}"`);
 }

--- a/scripts/social/ads/batch-week.mjs
+++ b/scripts/social/ads/batch-week.mjs
@@ -53,10 +53,12 @@ const GUIDE = {
 // into the /compare page rather than just the homepage.
 async function resolvableRivalries() {
   const sb = makeSb(loadEnv());
-  const checks = await Promise.all(RIVALRIES.map(async ([a, b]) => {
-    const [ha, hb] = [await heroByName(sb, a), await heroByName(sb, b)];
-    return ha && hb ? { pair: [a, b], ids: [ha.id, hb.id] } : null;
-  }));
+  const checks = await Promise.all(
+    RIVALRIES.map(async ([a, b]) => {
+      const [ha, hb] = [await heroByName(sb, a), await heroByName(sb, b)];
+      return ha && hb ? { pair: [a, b], ids: [ha.id, hb.id] } : null;
+    }),
+  );
   return checks.filter(Boolean);
 }
 
@@ -96,8 +98,9 @@ function buildPlan(pool) {
 // Chrome launches flake occasionally — retry each generator before giving up.
 function run(script, args, tries = 3) {
   for (let t = 1; ; t++) {
-    try { return execFileSync(process.execPath, [join(ADS, script), ...args], { stdio: 'inherit' }); }
-    catch (e) {
+    try {
+      return execFileSync(process.execPath, [join(ADS, script), ...args], { stdio: 'inherit' });
+    } catch (e) {
       if (t >= tries) throw e;
       console.warn(`  retry ${t}/${tries - 1} for ${script}…`);
     }
@@ -124,8 +127,10 @@ function sources(post, size) {
 }
 
 const label = (post) =>
-  post.kind === 'brand' ? `brand-${post.style}`
-    : post.kind === 'matchup' ? `matchup-${slugPair(post.pair)}`
+  post.kind === 'brand'
+    ? `brand-${post.style}`
+    : post.kind === 'matchup'
+      ? `matchup-${slugPair(post.pair)}`
       : `ranking-${post.slug}`;
 
 // Self-contained visual planner written next to the images — open week.html in a
@@ -133,9 +138,10 @@ const label = (post) =>
 // "posted" checkbox persisted in localStorage. No server, no dependencies.
 function dashboard(stamp, size, entries, bioLink) {
   const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  const cards = entries.map((e) => {
-    const g = GUIDE[e.kind];
-    return `<div class="card" data-id="${e.base}">
+  const cards = entries
+    .map((e) => {
+      const g = GUIDE[e.kind];
+      return `<div class="card" data-id="${e.base}">
       <div class="imgwrap"><img src="${e.base}.png" alt="${esc(e.name)}" loading="lazy"></div>
       <div class="body">
         <div class="row"><span class="day">${e.day.toUpperCase()}</span><span class="name">${esc(e.name)}</span>
@@ -145,7 +151,8 @@ function dashboard(stamp, size, entries, bioLink) {
         <pre class="cap">${esc(e.caption.trim())}</pre>
         <button class="copy">Copy caption</button>
       </div></div>`;
-  }).join('\n');
+    })
+    .join('\n');
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Mythique — week ${stamp}</title><style>
 :root{--navy:#06121a;--panel:#0f2231;--gold:#e0a83e;--cream:#f6eddd;--muted:#9db4c4;--line:rgba(246,237,221,.09)}
@@ -195,7 +202,10 @@ document.querySelectorAll('.card').forEach(card=>{
 
 async function main() {
   const args = process.argv.slice(2);
-  const get = (f, d) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : d; };
+  const get = (f, d) => {
+    const i = args.indexOf(f);
+    return i >= 0 ? args[i + 1] : d;
+  };
   const size = get('--size', '4x5');
   const dry = args.includes('--dry-run');
   // UTM tagging for the links appended to each caption. Defaults suit the organic
@@ -207,7 +217,10 @@ async function main() {
   const bioLink = taggedLink({ site, source: utmSource, medium: 'social', campaign: 'bio' });
 
   const pool = await resolvableRivalries();
-  if (!pool.length) { console.error('No rivalry pair resolves against the heroes table.'); process.exit(1); }
+  if (!pool.length) {
+    console.error('No rivalry pair resolves against the heroes table.');
+    process.exit(1);
+  }
   const plan = buildPlan(pool);
   console.log(`Week plan (rotation #${week}, size ${size}):`);
   plan.forEach((p, i) => console.log(`  ${DAYS[i]}  ${label(p)}`));
@@ -234,12 +247,16 @@ async function main() {
     const post = plan[i];
     console.log(`\n[${DAYS[i]}] ${label(post)}`);
     if (post.kind === 'brand') run('ad-brand.mjs', ['--style', post.style, '--size', size]);
-    else if (post.kind === 'matchup') run('ad-matchup.mjs', ['--matchup', post.pair.join(','), '--size', size]);
+    else if (post.kind === 'matchup')
+      run('ad-matchup.mjs', ['--matchup', post.pair.join(','), '--size', size]);
     else run('ad-ranking.mjs', ['--by', post.by, '--size', size]);
 
     const [img, cap] = sources(post, size);
     const base = `${String(i + 1).padStart(2, '0')}-${DAYS[i]}-${label(post)}`;
-    if (!existsSync(img)) { console.error(`  !! expected output missing: ${img}`); continue; }
+    if (!existsSync(img)) {
+      console.error(`  !! expected output missing: ${img}`);
+      continue;
+    }
     copyFileSync(img, join(weekDir, `${base}.png`));
     // Append a UTM-tagged link (campaign = post label). Matchups deep-link into
     // the /compare page; everything else lands on the homepage. This makes each
@@ -247,18 +264,30 @@ async function main() {
     // docs/marketing/utm-attribution.md.
     const rawCaption = existsSync(cap) ? readFileSync(cap, 'utf8') : '';
     const path = post.kind === 'matchup' && post.ids ? comparePath(post.ids) : '/';
-    const link = taggedLink({ site, source: utmSource, medium: utmMedium, campaign: label(post), path });
+    const link = taggedLink({
+      site,
+      source: utmSource,
+      medium: utmMedium,
+      campaign: label(post),
+      path,
+    });
     const caption = rawCaption ? `${rawCaption.trimEnd()}\n\n🔗 ${link}` : `🔗 ${link}`;
     writeFileSync(join(weekDir, `${base}.caption.txt`), caption);
     const g = GUIDE[post.kind];
     lines.push(`- **${DAYS[i]}** — ${label(post)} (\`${base}.png\`) · ${g.where} · ${g.when}`);
     entries.push({ day: DAYS[i], base, kind: post.kind, name: label(post), caption });
   }
-  lines.push('', 'Post one per day; paste the matching `.caption.txt`. Stories: re-run with `--size 9x16`.');
+  lines.push(
+    '',
+    'Post one per day; paste the matching `.caption.txt`. Stories: re-run with `--size 9x16`.',
+  );
   writeFileSync(join(weekDir, 'PLAN.md'), lines.join('\n') + '\n');
   writeFileSync(join(weekDir, 'week.html'), dashboard(stamp, size, entries, bioLink));
   console.log(`\nWeek ready → ${weekDir}`);
   console.log(`Open the visual planner:  open "${join(weekDir, 'week.html')}"`);
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/Analytics.web.tsx
+++ b/src/components/Analytics.web.tsx
@@ -3,6 +3,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { usePathname, useSegments } from 'expo-router';
 import { recordPageView } from '../lib/db/pageViews';
+import { captureAttribution, recordAttribution } from '../lib/attribution';
 import { setSentryTag } from '../lib/sentry';
 
 export default function AnalyticsProvider() {
@@ -16,6 +17,14 @@ export default function AnalyticsProvider() {
 
   // Mirror the same view into our self-hosted page_views table (command-center
   // Traffic domain). Keyed on path + deduped so a re-render doesn't double-count.
+  // First-touch attribution: capture the landing UTM/referrer once at mount —
+  // before router navigation drops the query string — then persist it. Both
+  // no-op cleanly on repeat visits and off-web.
+  useEffect(() => {
+    captureAttribution();
+    void recordAttribution();
+  }, []);
+
   const lastPath = useRef<string | null>(null);
   useEffect(() => {
     if (!path || lastPath.current === path) return;

--- a/src/components/admin/health/domains/TrafficDomain.tsx
+++ b/src/components/admin/health/domains/TrafficDomain.tsx
@@ -20,6 +20,7 @@ import type {
   ReferrerViews,
   DeviceViews,
   HeroViews,
+  AcquisitionRow,
 } from '../../../../lib/db/traffic';
 
 const RANGES = [
@@ -85,6 +86,28 @@ function SignedSplit({ signedIn, anon }: { signedIn: number; anon: number }) {
   );
 }
 
+// Acquisition row: campaign/source label, a visitor bar, and a "N signed in"
+// caption — the funnel from a marketing source to actual accounts.
+function AcqRow({ row, max }: { row: AcquisitionRow; max: number }) {
+  const pct = max > 0 ? Math.max(4, Math.round((row.visitors / max) * 100)) : 0;
+  return (
+    <View style={s.barRow}>
+      <View style={s.barLabelWrap}>
+        <Text style={s.barLabel} numberOfLines={1}>
+          {row.label}
+        </Text>
+        <Text style={s.barVal}>{row.visitors.toLocaleString()}</Text>
+      </View>
+      <View style={s.barTrack}>
+        <View style={[s.barFill, { width: `${pct}%` }]} />
+      </View>
+      <Text style={s.acqCap} numberOfLines={1}>
+        {row.visitors.toLocaleString()} visitors · {row.signups.toLocaleString()} signed in
+      </Text>
+    </View>
+  );
+}
+
 // Top-hero row: rank thumbnail, name, view count, and a proportional bar.
 function HeroRow({ hero, max, onPress }: { hero: HeroViews; max: number; onPress: () => void }) {
   const pct = max > 0 ? Math.max(4, Math.round((hero.views / max) * 100)) : 0;
@@ -138,7 +161,8 @@ export function TrafficDomain({
     );
   }
 
-  const { totals, prev, audience, series, topHeroes, live, activeNow, today } = data;
+  const { totals, prev, audience, series, topHeroes, live, activeNow, today, acquisition } = data;
+  const acqMax = Math.max(1, ...acquisition.map((a) => a.visitors));
   const seriesViews = series.map((d) => d.views);
   const seriesVisitors = series.map((d) => d.visitors);
   const signedTotal = audience.signedIn + audience.anon;
@@ -220,6 +244,23 @@ export function TrafficDomain({
         </Panel>
       </Bento.Row>
 
+      {/* Acquisition — where visitors (and signups) come from, by tagged campaign */}
+      <Panel
+        title="Acquisition"
+        hint="First-touch by campaign · UTM-tagged links"
+        action={<Text style={s.kpiFoot}>{acquisition.length ? '' : 'tag your links →'}</Text>}
+      >
+        {acquisition.length === 0 ? (
+          <EmptyState text="No tagged campaigns yet. Add UTM tags to your TikTok bio link and post links — see docs/marketing/utm-attribution.md." />
+        ) : (
+          <View style={s.barList}>
+            {acquisition.map((a, i) => (
+              <AcqRow key={i} row={a} max={acqMax} />
+            ))}
+          </View>
+        )}
+      </Panel>
+
       {/* Breakdowns */}
       <Bento.Row narrow={narrow}>
         <Panel title="Top pages" hint="Grouped routes" style={s.flex1}>
@@ -288,6 +329,7 @@ const s = StyleSheet.create({
   barVal: { fontFamily: 'Flame-Regular', fontSize: 13, color: COLORS.navy },
   barTrack: { height: 6, borderRadius: 999, backgroundColor: '#efe6d6', overflow: 'hidden' },
   barFill: { height: '100%', borderRadius: 999, backgroundColor: COLORS.orange },
+  acqCap: { fontFamily: 'Nunito_400Regular', fontSize: 10.5, color: COLORS.grey },
   locked: { alignItems: 'center', gap: 8, paddingVertical: 24 },
   lockedText: {
     fontFamily: 'Nunito_400Regular',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import { track } from '@vercel/analytics';
+import { attributionEventProps, getAttribution } from './attribution';
 
 // Named product events sent to Vercel Web Analytics' custom-events stream, so
 // the dashboard measures the funnel (sign-ups, votes, favourites) — not just
@@ -15,7 +16,10 @@ type EventProps = Record<string, string | number | boolean | null>;
 export function trackEvent(name: AnalyticsEvent, props?: EventProps): void {
   if (Platform.OS !== 'web') return;
   try {
-    track(name, props);
+    // Tag every event with the first-touch marketing source (utm_source/medium/
+    // campaign), so the dashboard can break the funnel down by campaign. Explicit
+    // call-site props win on any key collision.
+    track(name, { ...attributionEventProps(getAttribution()), ...props });
   } catch {
     // Analytics must never break the user action that triggered it.
   }

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,174 @@
+// First-touch marketing attribution (web only). Captures where a visitor first
+// arrived from — UTM tags on the landing URL, else the cross-origin referrer —
+// and pins it for the life of the browser session. Two consumers:
+//
+//   1. trackEvent() (analytics.ts) tags every conversion event (sign_up, vote,
+//      favourite…) with the first-touch source, so the funnel is attributable.
+//   2. recordAttribution() writes one row to `session_attribution`, joined to
+//      page_views server-side by session_id in admin_traffic_overview() — the
+//      command-center "Acquisition" panel.
+//
+// The pure helpers (parseUtm / deriveAttribution / attributionEventProps) hold
+// all the logic and are unit-tested; the storage/network wrappers are thin and
+// no-op cleanly off-web or when storage is unavailable.
+import { supabase } from './supabase';
+import { getReferrerHost, getSessionId } from './db/pageViews';
+
+/** The five standard UTM parameters, trimmed/capped, null when absent. */
+export interface Utm {
+  source: string | null;
+  medium: string | null;
+  campaign: string | null;
+  content: string | null;
+  term: string | null;
+}
+
+/** A resolved first-touch: UTM tags plus the referrer host and landing path. */
+export interface Attribution extends Utm {
+  referrer: string | null;
+  landing: string | null;
+}
+
+const STORE_KEY = 'mythique_attr'; // first-touch JSON
+const SENT_KEY = 'mythique_attr_sent'; // set once the DB row lands, so we write once
+
+// Values land in analytics + a DB row; keep them bounded and trimmed.
+function clean(v: string | null | undefined): string | null {
+  if (!v) return null;
+  const t = v.trim();
+  return t ? t.slice(0, 120) : null;
+}
+
+/** Parse the five UTM params out of a URL query string (`?a=b&…`). Pure. */
+export function parseUtm(search: string): Utm {
+  const p = new URLSearchParams(search || '');
+  return {
+    source: clean(p.get('utm_source')),
+    medium: clean(p.get('utm_medium')),
+    campaign: clean(p.get('utm_campaign')),
+    content: clean(p.get('utm_content')),
+    term: clean(p.get('utm_term')),
+  };
+}
+
+/**
+ * Resolve a first-touch from a landing. Returns null for direct/untagged visits
+ * (no UTM and no cross-origin referrer) — nothing worth attributing, and the
+ * "direct" bucket is simply the absence of a row. Pure.
+ *
+ * - An explicit `utm_source` always wins.
+ * - Otherwise a cross-origin referrer host becomes the source (medium
+ *   `referral`), so organic clicks from social/search still get bucketed.
+ */
+export function deriveAttribution(
+  search: string,
+  referrerHost: string | null,
+  landingPath: string | null,
+): Attribution | null {
+  const utm = parseUtm(search);
+  const hasUtm = Boolean(utm.source || utm.campaign || utm.medium);
+  const ref = clean(referrerHost);
+  if (!hasUtm && !ref) return null;
+  return {
+    source: utm.source ?? ref,
+    medium: utm.medium ?? (utm.source ? null : 'referral'),
+    campaign: utm.campaign,
+    content: utm.content,
+    term: utm.term,
+    referrer: ref,
+    landing: clean(landingPath),
+  };
+}
+
+/** Flat, primitive props for a Vercel custom event. Empty for direct traffic. Pure. */
+export function attributionEventProps(a: Attribution | null): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!a) return out;
+  if (a.source) out.utm_source = a.source;
+  if (a.medium) out.utm_medium = a.medium;
+  if (a.campaign) out.utm_campaign = a.campaign;
+  return out;
+}
+
+/** The stored first-touch for this browser, or null. No-ops off-web. */
+export function getAttribution(): Attribution | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    return raw ? (JSON.parse(raw) as Attribution) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Capture first-touch on load — call once, as early as possible, before SPA
+ * navigation drops the landing query/referrer. Never overwrites an existing
+ * first-touch (first wins), and never records direct/untagged visits.
+ */
+export function captureAttribution(): Attribution | null {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return getAttribution();
+  const existing = getAttribution();
+  if (existing) return existing;
+  const derived = deriveAttribution(
+    window.location.search,
+    getReferrerHost(),
+    window.location.pathname,
+  );
+  if (!derived) return null;
+  try {
+    localStorage.setItem(STORE_KEY, JSON.stringify(derived));
+  } catch {
+    // storage disabled (private mode) — attribution stays in-memory only for this call
+  }
+  return derived;
+}
+
+/**
+ * Persist the first-touch to `session_attribution` (once per browser). Uses a
+ * raw PostgREST insert rather than the typed client so it degrades gracefully
+ * before the migration lands — a missing table just 404s, is swallowed, and the
+ * write retries on a later load once the table exists. Fire-and-forget: it never
+ * touches the page_views pipeline and never throws into the caller.
+ */
+export async function recordAttribution(): Promise<void> {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return;
+  try {
+    if (localStorage.getItem(SENT_KEY)) return;
+    const a = getAttribution();
+    if (!a || (!a.source && !a.referrer)) return;
+    const sid = getSessionId();
+    if (!sid) return;
+    const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
+    const key = process.env.EXPO_PUBLIC_SUPABASE_KEY;
+    if (!url || !key) return;
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    const res = await fetch(`${url}/rest/v1/session_attribution`, {
+      method: 'POST',
+      headers: {
+        apikey: key,
+        authorization: `Bearer ${session?.access_token ?? key}`,
+        'content-type': 'application/json',
+        // Dedup on session_id if this ever runs twice for the same browser.
+        prefer: 'resolution=ignore-duplicates,return=minimal',
+      },
+      body: JSON.stringify({
+        session_id: sid,
+        utm_source: a.source,
+        utm_medium: a.medium,
+        utm_campaign: a.campaign,
+        utm_content: a.content,
+        utm_term: a.term,
+        referrer: a.referrer,
+        landing_path: a.landing,
+      }),
+    });
+    // Only mark done on success, so pre-migration 404s retry until the table lands.
+    if (res.ok) localStorage.setItem(SENT_KEY, '1');
+  } catch {
+    // fire-and-forget — attribution must never break the page
+  }
+}

--- a/src/lib/db/pageViews.ts
+++ b/src/lib/db/pageViews.ts
@@ -7,7 +7,9 @@ import { supabase } from '../supabase';
 const SESSION_KEY = 'mythique_sid';
 
 // Stable per-browser id so we can count unique visitors without identifying them.
-function getSessionId(): string | null {
+// Exported so attribution writes (session_attribution) key off the SAME id — the
+// server join between a campaign touch and later page views depends on it.
+export function getSessionId(): string | null {
   if (typeof localStorage === 'undefined') return null;
   try {
     let sid = localStorage.getItem(SESSION_KEY);
@@ -35,7 +37,7 @@ function getDevice(): string {
 }
 
 // Referring host, only when it's a different origin (skip internal navigation).
-function getReferrerHost(): string | null {
+export function getReferrerHost(): string | null {
   if (typeof document === 'undefined' || !document.referrer) return null;
   try {
     const ref = new URL(document.referrer);

--- a/src/lib/db/traffic.ts
+++ b/src/lib/db/traffic.ts
@@ -28,6 +28,17 @@ export interface HeroViews {
   image: string | null;
   views: number;
 }
+/** A first-touch acquisition bucket: campaign/source → visitors + sign-ins. */
+export interface AcquisitionRow {
+  /** Display label — campaign, else source, else referrer, else 'direct'. */
+  label: string;
+  source: string | null;
+  campaign: string | null;
+  /** Distinct sessions first seen in the window from this bucket. */
+  visitors: number;
+  /** How many of those sessions were signed in on any page view. */
+  signups: number;
+}
 /** One recent page view for the live activity feed. `name` is set when the path
  *  is a character route that resolves to a hero. */
 export interface LiveHit {
@@ -56,6 +67,8 @@ export interface TrafficOverview {
   topHeroes: HeroViews[];
   /** Most recent views for the live feed, newest first. */
   live: LiveHit[];
+  /** First-touch acquisition by campaign/source. Empty until links are tagged. */
+  acquisition: AcquisitionRow[];
 }
 
 type OverviewJson = ({ authorized: false } | ({ authorized: true } & TrafficOverview)) | null;
@@ -87,5 +100,6 @@ export async function fetchTrafficOverview(days = 28): Promise<TrafficOverview |
     devices: json.devices,
     topHeroes: json.topHeroes ?? [],
     live: json.live ?? [],
+    acquisition: json.acquisition ?? [],
   };
 }

--- a/supabase/migrations/20260715170000_session_attribution.sql
+++ b/supabase/migrations/20260715170000_session_attribution.sql
@@ -1,0 +1,174 @@
+-- Marketing attribution — the collection + read side of the command-center
+-- "Acquisition" panel. One first-touch row per browser session (where the
+-- visitor first arrived from: UTM tags on the landing URL, else the referrer),
+-- joined to page_views by session_id so we can answer "which campaign drove
+-- these visitors, and how many signed in?".
+--
+-- Written client-side from Analytics.web.tsx via recordAttribution() (a raw
+-- PostgREST insert). Same privacy model as page_views: insert-only, RLS-locked,
+-- readable only through the admin-guarded admin_traffic_overview() RPC. No PII —
+-- session_id is the same random, client-persisted id page_views uses.
+create table if not exists public.session_attribution (
+  session_id   text primary key,          -- matches page_views.session_id (the join key)
+  utm_source   text,
+  utm_medium   text,
+  utm_campaign text,
+  utm_content  text,
+  utm_term     text,
+  referrer     text,                       -- cross-origin referring host, when present
+  landing_path text,                       -- first path seen, e.g. /compare/a/b
+  first_seen   timestamptz not null default now()
+);
+create index if not exists session_attribution_first_seen_idx
+  on public.session_attribution (first_seen desc);
+create index if not exists session_attribution_campaign_idx
+  on public.session_attribution (utm_campaign);
+
+alter table public.session_attribution enable row level security;
+
+-- Anyone may record their own first-touch; nobody may read directly.
+-- (`resolution=ignore-duplicates` on the client relies on the session_id PK.)
+drop policy if exists session_attribution_insert on public.session_attribution;
+create policy session_attribution_insert on public.session_attribution
+  for insert to anon, authenticated with check (true);
+-- (Intentionally no select policy → reads only via admin_traffic_overview.)
+
+-- ABUSE NOTE: like page_views, `with check (true)` lets anyone insert. Acceptable
+-- pre-launch; the PK caps one row per session_id. Rate-limit before scaling.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- admin_traffic_overview v3 — additive: every field v2 returned is preserved;
+-- new field `acquisition` groups first-touch sessions by campaign/source with
+-- visitor and signed-in counts. Left join to session_attribution keeps this a
+-- no-op when the table is empty.
+create or replace function public.admin_traffic_overview(p_days integer default 28)
+returns json
+language plpgsql
+stable
+security definer
+set search_path to 'public'
+as $function$
+declare
+  is_admin boolean := exists (
+    select 1 from public.user_profiles up where up.id = auth.uid() and up.is_admin
+  );
+  v_days int := greatest(p_days, 1);
+  v_since timestamptz := (current_date - make_interval(days => v_days - 1));
+  v_prev_since timestamptz := (current_date - make_interval(days => v_days * 2 - 1));
+begin
+  if not is_admin then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'rangeDays', v_days,
+    'totals', (select json_build_object(
+      'pageViews', count(*),
+      'visitors',  count(distinct coalesce(user_id::text, session_id))
+    ) from public.page_views where created_at >= v_since),
+    -- Previous equal-length window, for period-over-period deltas.
+    'prev', (select json_build_object(
+      'pageViews', count(*),
+      'visitors',  count(distinct coalesce(user_id::text, session_id))
+    ) from public.page_views where created_at >= v_prev_since and created_at < v_since),
+    -- Signed-in vs anonymous visitors over the window.
+    'audience', (select json_build_object(
+      'signedIn', count(distinct user_id) filter (where user_id is not null),
+      'anon',     count(distinct session_id) filter (where user_id is null)
+    ) from public.page_views where created_at >= v_since),
+    'today', (select json_build_object(
+      'views',    count(*),
+      'visitors', count(distinct coalesce(user_id::text, session_id))
+    ) from public.page_views where created_at >= current_date),
+    'yesterday', (select json_build_object(
+      'views', count(*)
+    ) from public.page_views where created_at >= current_date - 1 and created_at < current_date),
+    -- Live: unique visitors (signed-in or anon) seen in the last 5 minutes.
+    'activeNow', (select count(distinct coalesce(user_id::text, session_id))::int
+                    from public.page_views where created_at > now() - interval '5 minutes'),
+    -- Daily trend, gap-filled across the window so the chart has one point/day.
+    'series', (select coalesce(json_agg(r), '[]'::json) from (
+      select to_char(d.day, 'YYYY-MM-DD') as day,
+             count(pv.id)::int as views,
+             count(distinct coalesce(pv.user_id::text, pv.session_id))::int as visitors
+      from generate_series(v_since, current_date, interval '1 day') as d(day)
+      left join public.page_views pv
+        on pv.created_at >= d.day and pv.created_at < d.day + interval '1 day'
+      group by d.day
+      order by d.day
+    ) r),
+    'topPages', (select coalesce(json_agg(r), '[]'::json) from (
+      select route, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since
+      group by route
+      order by count(*) desc
+      limit 8
+    ) r),
+    'topReferrers', (select coalesce(json_agg(r), '[]'::json) from (
+      select referrer as source, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since and referrer is not null and referrer <> ''
+      group by referrer
+      order by count(*) desc
+      limit 8
+    ) r),
+    'devices', (select coalesce(json_agg(r), '[]'::json) from (
+      select coalesce(nullif(device, ''), 'unknown') as label, count(*)::int as views
+      from public.page_views
+      where created_at >= v_since
+      group by coalesce(nullif(device, ''), 'unknown')
+      order by count(*) desc
+    ) r),
+    -- What's hot: character routes resolved to real hero names (+ art).
+    'topHeroes', (select coalesce(json_agg(r), '[]'::json) from (
+      select h.id, h.name, coalesce(h.portrait_url, h.image_url) as image, pv.cnt::int as views
+      from (
+        select split_part(path, '/', 3) as hid, count(*) as cnt
+        from public.page_views
+        where created_at >= v_since and path like '/character/%'
+        group by split_part(path, '/', 3)
+      ) pv
+      join public.heroes h on h.id = pv.hid
+      order by pv.cnt desc
+      limit 8
+    ) r),
+    -- Live activity feed: the most recent views, hero name resolved where the path
+    -- is a character route.
+    'live', (select coalesce(json_agg(r), '[]'::json) from (
+      select pv.route,
+             pv.path,
+             h.name as name,
+             pv.created_at as at
+      from public.page_views pv
+      left join public.heroes h
+        on pv.path like '/character/%' and h.id = split_part(pv.path, '/', 3)
+      order by pv.created_at desc
+      limit 12
+    ) r),
+    -- Acquisition: first-touch sessions in the window, bucketed by campaign
+    -- (falling back to source, then referrer, then 'direct'). `visitors` counts
+    -- distinct sessions; `signups` counts those that were signed in on any view.
+    'acquisition', (select coalesce(json_agg(r), '[]'::json) from (
+      select
+        coalesce(nullif(sa.utm_campaign, ''), nullif(sa.utm_source, ''),
+                 nullif(sa.referrer, ''), 'direct') as label,
+        sa.utm_source   as source,
+        sa.utm_campaign as campaign,
+        count(distinct sa.session_id)::int          as visitors,
+        count(distinct pv.user_id)::int             as signups
+      from public.session_attribution sa
+      left join public.page_views pv
+        on pv.session_id = sa.session_id and pv.user_id is not null
+      where sa.first_seen >= v_since
+      group by 1, 2, 3
+      order by count(distinct sa.session_id) desc
+      limit 10
+    ) r)
+  );
+end;
+$function$;
+
+revoke all on function public.admin_traffic_overview(int) from public, anon;
+grant execute on function public.admin_traffic_overview(int) to authenticated, service_role;


### PR DESCRIPTION
## Why

Paid social (TikTok Promote et al.) reports views, likes, comments, followers and **profile views** — but not the step that matters: of the people who reach the profile/bio link, how many actually reach the app and sign up. That step happens on mythique.app, off-platform, so we measure it ourselves.

Across ~R690 of recent Promote spend: 38.8K views → **409 profile views** → 30 followers. Those 409 profile views funnel through the bio link (the only door to the app), which was untagged — so their app-side impact was invisible. This makes it visible.

## What

First-touch attribution built onto the existing self-hosted analytics pipeline (not a bolt-on):

- **`src/lib/attribution.ts`** — captures the campaign a visitor first arrived from (UTM params, else referrer host) and pins it for the browser session. Pure helpers (`parseUtm` / `deriveAttribution` / `attributionEventProps`) hold the logic and are unit-tested.
- **`analytics.ts`** — every conversion event (`sign_up`, `log_in`, `matchup_vote`, `favourite_add`, `search`) is tagged with the first-touch source, so the funnel breaks down by campaign.
- **`Analytics.web.tsx`** — captures + persists attribution once at mount, before router navigation drops the landing query/referrer.
- **`session_attribution` migration + `admin_traffic_overview` v3** — one first-touch row per session, joined to `page_views` by `session_id`, surfaced as a new **Acquisition** panel in the command-center Traffic tab (visitors + sign-ins per campaign). Fully additive; same insert-only, RLS-locked privacy model as `page_views`.
- **`batch-week.mjs`** — every generated caption now carries a UTM-tagged link (campaign = post label); matchup posts deep-link into the canonical `/compare` page. New `--utm-source` / `--utm-medium` / `--site` flags. The planner surfaces the bio link and notes that TikTok/IG-feed captions aren't clickable (bio link carries that attribution; the per-post link pays off on X and Story stickers).
- **`docs/marketing/utm-attribution.md`** — the link-tagging playbook and how to read the results.

## Safe rollout

The client degrades cleanly **before** the migration is applied: conversion events still carry UTM tags, the Acquisition panel just stays empty, and the attribution write (a raw PostgREST insert) 404s harmlessly and retries on a later load once the table exists. The `page_views` pipeline is never touched.

## Follow-up for the owner

1. Apply `supabase/migrations/20260715170000_session_attribution.sql` via the Supabase MCP tool, then regenerate `database.generated.ts` — lights up the Acquisition panel.
2. Set the bio link on the TikTok profile: `https://mythique.app/?utm_source=tiktok&utm_medium=social&utm_campaign=bio`

## Testing

- 13 new unit tests for the attribution logic; full suite **730/730 passing**.
- `tsc --noEmit` clean, eslint clean on all touched files.
- `batch-week.mjs` syntax-checked, lint-clean, link output verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF)_