### PR TITLE
SEO: entity linking (sameAs), answer-engine crawlers, vote engagement markup

### DIFF
--- a/__tests__/api/botPage.test.ts
+++ b/__tests__/api/botPage.test.ts
@@ -8,6 +8,7 @@ import {
   buildUniverseBotPage,
   buildVsBotPage,
   CATEGORY_SEO,
+  entitySameAs,
   metaDescription,
   stripHtml,
   universePath,
@@ -45,6 +46,8 @@ const hero = (overrides: Partial<BotHero> = {}): BotHero => ({
   combat: 85,
   portrait_url: 'https://img.example/superman.jpg',
   image_url: null,
+  wikidata_qid: 'Q79015',
+  enwiki_title: 'Superman',
   ...overrides,
 });
 
@@ -67,6 +70,19 @@ describe('universePath', () => {
   it('never links category buckets', () => {
     expect(universePath('Creator-Owned')).toBeNull();
     expect(universePath(null)).toBeNull();
+  });
+});
+
+describe('entitySameAs', () => {
+  it('builds Wikidata + Wikipedia URLs, encoding the article title', () => {
+    expect(entitySameAs({ wikidata_qid: 'Q2', enwiki_title: 'Iron Man' })).toEqual([
+      'https://www.wikidata.org/wiki/Q2',
+      'https://en.wikipedia.org/wiki/Iron_Man',
+    ]);
+  });
+  it('ignores a malformed QID and missing title', () => {
+    expect(entitySameAs({ wikidata_qid: 'not-a-qid', enwiki_title: null })).toEqual([]);
+    expect(entitySameAs({ wikidata_qid: null, enwiki_title: '  ' })).toEqual([]);
   });
 });
 
@@ -111,6 +127,21 @@ describe('buildCharacterBotPage', () => {
     expect(html).toContain('"@type":"ProfilePage"');
     expect(html).toContain('"name":"Superman"');
     expect(html).toContain('"alternateName":["Clark Kent","Man of Steel"]');
+  });
+
+  it('links the character to its Knowledge-Graph entity via sameAs', () => {
+    expect(html).toContain(
+      '"sameAs":["https://www.wikidata.org/wiki/Q79015","https://en.wikipedia.org/wiki/Superman"]',
+    );
+  });
+
+  it('omits sameAs entirely when no entity anchors exist', () => {
+    const orphan = buildCharacterBotPage(hero({ wikidata_qid: null, enwiki_title: null }), {
+      allies: [],
+      enemies: [],
+      teammates: [],
+    });
+    expect(orphan).not.toContain('sameAs');
   });
 
   it('renders profile facts and power stats', () => {
@@ -241,6 +272,23 @@ describe('buildVsBotPage', () => {
     );
     const faq = ld['@graph'].find((n: { '@type': string }) => n['@type'] === 'FAQPage');
     expect(faq.mainEntity[0].acceptedAnswer.text).toContain('open debate');
+  });
+
+  it('marks up total community votes as an InteractionCounter', () => {
+    const ld = JSON.parse(
+      html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)![1],
+    );
+    const page = ld['@graph'].find((n: { '@type': string }) => n['@type'] === 'WebPage');
+    expect(page.interactionStatistic).toMatchObject({
+      '@type': 'InteractionCounter',
+      interactionType: 'https://schema.org/VoteAction',
+      userInteractionCount: 4, // 3 + 1
+    });
+  });
+
+  it('omits the InteractionCounter when there are no votes', () => {
+    const noVotes = buildVsBotPage(a, b, { votesA: 0, votesB: 0 }, { forA: [], forB: [] });
+    expect(noVotes).not.toContain('InteractionCounter');
   });
 
   it('links both fighters and onward matchups, skipping the current pair', () => {

--- a/api/_lib/botPage.ts
+++ b/api/_lib/botPage.ts
@@ -40,7 +40,26 @@ export type BotHero = {
   combat: number | null;
   portrait_url: string | null;
   image_url: string | null;
+  // Entity anchors for JSON-LD `sameAs` — ties the page to its Knowledge-Graph
+  // node so Google/answer-engines recognise the character as a known entity.
+  wikidata_qid: string | null;
+  enwiki_title: string | null;
 };
+
+/** Build the schema.org `sameAs` list — the external authorities that identify
+ *  this character. Wikidata is the Knowledge-Graph hub; the English-Wikipedia
+ *  article is the human-readable anchor. Empty when the hero has neither. */
+export function entitySameAs(hero: Pick<BotHero, 'wikidata_qid' | 'enwiki_title'>): string[] {
+  const out: string[] = [];
+  const qid = hero.wikidata_qid?.trim();
+  if (qid && /^Q\d+$/.test(qid)) out.push(`https://www.wikidata.org/wiki/${qid}`);
+  const title = hero.enwiki_title?.trim();
+  if (title) {
+    // MediaWiki canonical form: spaces → underscores, then percent-encode.
+    out.push(`https://en.wikipedia.org/wiki/${encodeURIComponent(title.replace(/ /g, '_'))}`);
+  }
+  return out;
+}
 
 export type RelatedLite = { id: string; name: string };
 
@@ -107,6 +126,8 @@ function jsonLd(hero: BotHero, description: string): string {
     (a): a is string => !!a && a.trim() !== '' && a !== hero.name,
   );
   if (alts.length > 0) person.alternateName = alts.slice(0, 10);
+  const sameAs = entitySameAs(hero);
+  if (sameAs.length > 0) person.sameAs = sameAs;
   const crumbs = [
     { '@type': 'ListItem', position: 1, name: 'Mythique', item: SITE_URL },
     { '@type': 'ListItem', position: 2, name: 'Characters', item: `${SITE_URL}/search` },
@@ -483,7 +504,23 @@ export function buildVsBotPage(
     jsonLd: serializeLd({
       '@context': 'https://schema.org',
       '@graph': [
-        { '@type': 'WebPage', name: titleText, description: desc, url: canonicalUrl },
+        {
+          '@type': 'WebPage',
+          name: titleText,
+          description: desc,
+          url: canonicalUrl,
+          // Community votes are real user engagement — surfacing the count as an
+          // InteractionCounter signals this is an active, participatory page.
+          ...(tally.votesA + tally.votesB > 0
+            ? {
+                interactionStatistic: {
+                  '@type': 'InteractionCounter',
+                  interactionType: 'https://schema.org/VoteAction',
+                  userInteractionCount: tally.votesA + tally.votesB,
+                },
+              }
+            : {}),
+        },
         {
           '@type': 'FAQPage',
           url: canonicalUrl,

--- a/api/bot-page.ts
+++ b/api/bot-page.ts
@@ -34,7 +34,7 @@ const HERO_COLUMNS =
   'id,name,full_name,aliases,alignment,publisher,franchise,description,summary,' +
   'first_appearance,occupation,place_of_birth,race,gender,height_metric,weight_metric,' +
   'base,creators,teams,powers,intelligence,strength,speed,durability,power,combat,' +
-  'portrait_url,image_url';
+  'portrait_url,image_url,wikidata_qid,enwiki_title';
 
 async function fetchHero(id: string): Promise<BotHero | null> {
   const url = `${SUPABASE_URL}/rest/v1/heroes?id=eq.${encodeURIComponent(

--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=character&id=:id"
@@ -30,7 +30,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=title&id=:id"
@@ -41,7 +41,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=team&id=:id"
@@ -63,7 +63,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=vs&a=:hero&b=:opponent"
@@ -74,7 +74,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=category&slug=:slug"
@@ -85,7 +85,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=universe&slug=:slug"
@@ -96,7 +96,7 @@
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot).*"
+          "value": ".*([Gg]ooglebot|Google-InspectionTool|GoogleOther|[Bb]ingbot|BingPreview|DuckDuckBot|YandexBot|Baiduspider|Slurp|SeznamBot|PetalBot|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|anthropic-ai|Applebot|Amazonbot|Bytespider|CCBot|YouBot|Meta-ExternalAgent|Diffbot).*"
         }
       ],
       "destination": "/api/bot-page?kind=franchise&slug=:slug"


### PR DESCRIPTION
## Why

Follow-on to the merged crawler-coverage work (#103). With on-page coverage comprehensive, these are three **higher-leverage** structured-data / crawl wins that use data and infrastructure Mythique already has — no new data pipeline, no GSC export needed.

## What changed

**1. Entity linking (`sameAs`) — the strongest remaining signal for a new domain**
Character `ProfilePage`/`Person` JSON-LD now carries a `sameAs` list built from the hero's existing `wikidata_qid` and `enwiki_title` columns:
```json
"sameAs": ["https://www.wikidata.org/wiki/Q79015",
           "https://en.wikipedia.org/wiki/Superman"]
```
This ties each page to its **Knowledge-Graph node**, telling Google/answer-engines "this page is about the *known entity*." It's one of the few things that materially helps a low-authority site rank for entity queries and surface in knowledge panels/disambiguation. Emitted only when an anchor exists; the QID is format-validated (`^Q\d+$`) and the Wikipedia title is normalized to MediaWiki form (spaces→underscores, then encoded).

**2. Answer-engine crawlers (GEO)**
The bot-prerender user-agent gate now also matches the *fetching* AI/answer bots — GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, Perplexity-User, ClaudeBot, Claude-User, anthropic-ai, Applebot, Amazonbot, Bytespider, CCBot, YouBot, Meta-ExternalAgent, Diffbot — across all seven content routes. ChatGPT/Perplexity/Google AI Overviews now get the rich, structured bot page instead of the empty SPA shell, so they can read and **cite** Mythique. (Google-Extended and Applebot-Extended are robots *policy* tokens, not fetching user-agents, so they're intentionally not added to the UA match.)

**3. Vote engagement markup**
Versus pages add an `InteractionCounter` (`VoteAction` / total community votes) to the `WebPage` node when votes exist — signalling an active, participatory page alongside the existing `FAQPage`.

## Testing

- `yarn test:ci` — **742 passing** (added: `entitySameAs` unit tests; `sameAs` present/absent on character pages; `InteractionCounter` present/absent on versus pages).
- `yarn tsc --noEmit` clean for both the app project and the `api/` bundle; Prettier clean; `vercel.json` validated as JSON.

## Notes

- Branch was restarted from the merged `main` (not stacked on #103's pre-squash history).
- The remaining big levers are still off-site (authority/backlinks/time) plus, on the code side, a Core Web Vitals pass and true SSG — both larger, separate efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU)_