### PR TITLE
CWV: prioritize the above-the-fold LCP image on every SEO detail page

### DIFF
--- a/app/character/[id].web.tsx
+++ b/app/character/[id].web.tsx
@@ -806,6 +806,10 @@ export default function WebCharacterScreen() {
                 style={[StyleSheet.absoluteFill, styles.stageBackdrop] as object}
                 cachePolicy="memory-disk"
                 recyclingKey={id}
+                // Fills the stage, so Chrome often measures THIS as the LCP
+                // element (largest paint) over the foreground portrait — keep it
+                // high-priority too. Shares the source URI, so no extra fetch.
+                priority="high"
               />
             ) : null}
             {/* Gradient scrim keeps the identity text legible over the backdrop */}
@@ -1559,6 +1563,10 @@ export default function WebCharacterScreen() {
                       contentPosition={{ top: 0, left: '50%' }}
                       style={StyleSheet.absoluteFill}
                       recyclingKey={id}
+                      // The portrait is the above-the-fold LCP element on the
+                      // most-trafficked SEO page — fetch it at high priority so
+                      // it isn't queued behind lazy/below-the-fold requests.
+                      priority="high"
                     />
                     <View style={[styles.portraitOverlay, { pointerEvents: 'none' }] as object} />
                     <View

--- a/app/compare/[hero]/[opponent].web.tsx
+++ b/app/compare/[hero]/[opponent].web.tsx
@@ -173,6 +173,9 @@ function ArenaPortrait({
           source={image}
           contentFit="cover"
           contentPosition="top"
+          // Both fighters are the above-the-fold LCP of the versus page — fetch
+          // at high priority so the matchup paints without waiting on lazy work.
+          priority="high"
           style={
             [
               styles.arenaImage,

--- a/app/title/[id].tsx
+++ b/app/title/[id].tsx
@@ -101,7 +101,10 @@ export default function TitleScreen() {
             subline="Check your connection and try again."
             actions={[
               { label: 'Retry', primary: true, onPress: () => titleQuery.refetch() },
-              { label: 'Go back', onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) },
+              {
+                label: 'Go back',
+                onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')),
+              },
             ]}
           />
         </View>
@@ -125,7 +128,13 @@ export default function TitleScreen() {
           icon="film-outline"
           headline="Title not found"
           subline="We don't have this title in the archive yet."
-          actions={[{ label: 'Go back', primary: true, onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')) }]}
+          actions={[
+            {
+              label: 'Go back',
+              primary: true,
+              onPress: () => (router.canGoBack() ? router.back() : router.replace('/explore')),
+            },
+          ]}
         />
       </View>
     );
@@ -275,6 +284,8 @@ export default function TitleScreen() {
           contentFit="cover"
           cachePolicy="memory-disk"
           transition={300}
+          // Above-the-fold LCP element on the title page — fetch at high priority.
+          priority="high"
         />
       ) : (
         <View style={[styles.posterFloatImg, styles.posterFloatPlaceholder]}>
@@ -306,7 +317,10 @@ export default function TitleScreen() {
     return (
       <View style={styles.webPage}>
         <Stack.Screen options={{ headerShown: false }} />
-        <FilmBackdropHeader film={film} onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))} />
+        <FilmBackdropHeader
+          film={film}
+          onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))}
+        />
         {/* Header is real (seeded stub or live row); the body waits on all its
             data and dissolves in over a body skeleton — so it never shifts. */}
         <View style={styles.bodyRegion}>
@@ -378,7 +392,10 @@ export default function TitleScreen() {
         contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 40 }]}
         showsVerticalScrollIndicator={false}
       >
-        <FilmBackdropHeader film={film} onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))} />
+        <FilmBackdropHeader
+          film={film}
+          onBack={() => (router.canGoBack() ? router.back() : router.replace('/explore'))}
+        />
 
         {/* Header is real (seeded stub or live row); the body waits on all its
             data, then swaps in (gated → in place, no shift). */}

--- a/src/components/film/FilmBackdropHeader.tsx
+++ b/src/components/film/FilmBackdropHeader.tsx
@@ -56,6 +56,8 @@ export function FilmBackdropHeader({ film, onBack }: { film: HeroTitle; onBack: 
           contentFit="cover"
           cachePolicy="memory-disk"
           transition={400}
+          // Full-bleed backdrop = the above-the-fold LCP element on title pages.
+          priority="high"
         />
       ) : (
         <View style={[StyleSheet.absoluteFill, styles.backdropPlaceholder]} />


### PR DESCRIPTION
## Why

First of two Core-Web-Vitals PRs. I audited the LCP path on the pages that receive search traffic. Finding: the **browse/category pages already set `expo-image` priority** on their above-the-fold cards, but the **single-portrait detail pages** — the ones Google sends users to — left their hero image at default priority, so the LCP element could be queued behind lazy/below-the-fold image requests. This closes that gap.

## What changed

`priority="high"` on the above-the-fold LCP image of each SEO detail-page type:

- **`character/[id].web`** — the foreground portrait **and** the full-bleed `absoluteFill` backdrop (which Chrome often measures as the LCP element, being the largest paint). Both share the same source URI, so there's no extra fetch.
- **`compare/[hero]/[opponent].web`** — both fighter portraits (each is above-the-fold on the versus page).
- **`title/[id]`** — the poster.
- **`FilmBackdropHeader`** — the full-bleed film backdrop, the true title-page LCP.

`expo-image`'s `priority` is cross-platform, so the shared `title`/`FilmBackdropHeader` files stay correct on native. There's no behavioural change beyond fetch ordering. (`title/[id].tsx` also picked up a few lines of Prettier line-wrapping — pure formatting, brings the file into compliance with the repo config.)

## Scope note — the bigger LCP lever is next

The dominant content-page LCP cost isn't image priority — it's the **SPA boot gate**: nothing paints until the JS bundle downloads/executes, the fonts load, and the Supabase auth session settles. That's architectural and is addressed by the **static pre-rendering (SSG) PR to follow**, which makes content HTML paint before any of that runs. This PR is the safe, incremental win; SSG is the structural one.

Authoritative before/after numbers come from **PageSpeed Insights / CrUX on the live site** — worth a run once this deploys.

## Testing

- `yarn test:ci` — **755 passing** (no logic touched — additive props only).
- `yarn tsc --noEmit` clean; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRN1KEo3dSmSvH9RkMyFQU)_