### PR TITLE
Promote Acquisition to its own Audience sub-tab

### DIFF
--- a/src/components/admin/health/domains/AcquisitionDomain.tsx
+++ b/src/components/admin/health/domains/AcquisitionDomain.tsx
@@ -1,0 +1,142 @@
+// Acquisition domain — first-touch marketing attribution as its own Audience
+// sub-tab (promoted out of the Traffic breakdowns, where it was buried). Answers
+// "which campaigns bring visitors, and which of those become accounts?" off the
+// same admin_traffic_overview() payload the Traffic tab reads, so it adds no
+// extra query.
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../../../constants/colors';
+import { Panel } from '../Panel';
+import { Bento } from '../Bento';
+import { EmptyState, PillGroup } from '../ui';
+import { TrafficSkeleton } from '../skeletons';
+import { TrafficKpi } from './traffic/TrafficKpi';
+import type { TrafficOverview, AcquisitionRow } from '../../../../lib/db/traffic';
+
+const RANGES = [
+  { label: '7d', value: 7 },
+  { label: '28d', value: 28 },
+  { label: '90d', value: 90 },
+];
+
+// Campaign row: label, a proportional visitor bar, and a "N signed in" caption —
+// the funnel from a marketing source to actual accounts.
+function AcqRow({ row, max }: { row: AcquisitionRow; max: number }) {
+  const pct = max > 0 ? Math.max(4, Math.round((row.visitors / max) * 100)) : 0;
+  return (
+    <View style={s.barRow}>
+      <View style={s.barLabelWrap}>
+        <Text style={s.barLabel} numberOfLines={1}>
+          {row.label}
+        </Text>
+        <Text style={s.barVal}>{row.visitors.toLocaleString()}</Text>
+      </View>
+      <View style={s.barTrack}>
+        <View style={[s.barFill, { width: `${pct}%` }]} />
+      </View>
+      <Text style={s.acqCap} numberOfLines={1}>
+        {row.visitors.toLocaleString()} visitors · {row.signups.toLocaleString()} signed in
+      </Text>
+    </View>
+  );
+}
+
+export function AcquisitionDomain({
+  data,
+  loading,
+  narrow,
+  days,
+  onDaysChange,
+}: {
+  data: TrafficOverview | null;
+  loading: boolean;
+  narrow: boolean;
+  days: number;
+  onDaysChange: (d: number) => void;
+}) {
+  if (loading && !data) {
+    return <TrafficSkeleton narrow={narrow} />;
+  }
+  if (!data) {
+    return (
+      <Panel title="Acquisition">
+        <View style={s.locked}>
+          <Ionicons name="lock-closed-outline" size={26} color={COLORS.grey} />
+          <Text style={s.lockedText}>
+            Acquisition analytics are admin-only, or no page views have been recorded yet.
+          </Text>
+        </View>
+      </Panel>
+    );
+  }
+
+  const rows = data.acquisition;
+  const max = Math.max(1, ...rows.map((r) => r.visitors));
+  const totalVisitors = rows.reduce((n, r) => n + r.visitors, 0);
+  const totalSignups = rows.reduce((n, r) => n + r.signups, 0);
+  const convPct = totalVisitors > 0 ? Math.round((totalSignups / totalVisitors) * 100) : 0;
+
+  return (
+    <Bento>
+      {/* Headline: how much attributed traffic, and how much of it converted */}
+      <View style={s.kpiRow}>
+        <TrafficKpi
+          label="Attributed visitors"
+          value={totalVisitors.toLocaleString()}
+          tint={COLORS.navy}
+          footer={<Text style={s.kpiFoot}>tagged first-touch · {data.rangeDays}d</Text>}
+        />
+        <TrafficKpi
+          label="Signups"
+          value={totalSignups.toLocaleString()}
+          tint={COLORS.green}
+          footer={<Text style={s.kpiFoot}>from tagged sources</Text>}
+        />
+        <TrafficKpi
+          label="Conversion"
+          value={`${convPct}%`}
+          tint={COLORS.orange}
+          footer={<Text style={s.kpiFoot}>signups ÷ visitors</Text>}
+        />
+      </View>
+
+      {/* The campaign leaderboard — sorted by visitors, with the signed-in count */}
+      <Panel
+        title="By campaign"
+        hint="First-touch source · UTM-tagged links"
+        action={<PillGroup options={RANGES} value={days} onChange={onDaysChange} />}
+      >
+        {rows.length === 0 ? (
+          <EmptyState text="No tagged campaigns yet. Tag your TikTok destination URL / bio link with utm_* params — see docs/marketing/utm-attribution.md." />
+        ) : (
+          <View style={s.barList}>
+            {rows.map((r, i) => (
+              <AcqRow key={i} row={r} max={max} />
+            ))}
+          </View>
+        )}
+      </Panel>
+    </Bento>
+  );
+}
+
+const s = StyleSheet.create({
+  kpiRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+  kpiFoot: { fontFamily: 'Nunito_700Bold', fontSize: 11, color: COLORS.grey },
+  barList: { gap: 8 },
+  barRow: { gap: 4 },
+  barLabelWrap: { flexDirection: 'row', justifyContent: 'space-between', gap: 8 },
+  barLabel: { flex: 1, fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.black },
+  barVal: { fontFamily: 'Flame-Regular', fontSize: 13, color: COLORS.navy },
+  barTrack: { height: 6, borderRadius: 999, backgroundColor: '#efe6d6', overflow: 'hidden' },
+  barFill: { height: '100%', borderRadius: 999, backgroundColor: COLORS.orange },
+  acqCap: { fontFamily: 'Nunito_400Regular', fontSize: 10.5, color: COLORS.grey },
+  locked: { alignItems: 'center', gap: 8, paddingVertical: 24 },
+  lockedText: {
+    fontFamily: 'Nunito_400Regular',
+    fontSize: 13,
+    color: COLORS.grey,
+    textAlign: 'center',
+    maxWidth: 360,
+  },
+});

--- a/src/components/admin/health/domains/AudienceLane.tsx
+++ b/src/components/admin/health/domains/AudienceLane.tsx
@@ -8,13 +8,14 @@ import { useUrlTabState } from '../../../../hooks/useUrlTabState';
 import { useQuery } from '@tanstack/react-query';
 import { SubTabs } from '../SubTabs';
 import { TrafficDomain } from './TrafficDomain';
+import { AcquisitionDomain } from './AcquisitionDomain';
 import { CommunityDomain } from './CommunityDomain';
 import { ErrorsDomain } from './ErrorsDomain';
 import { fetchTrafficOverview } from '../../../../lib/db/traffic';
 import { fetchCommunityOverview } from '../../../../lib/db/community';
 import { fetchClientErrorOverview } from '../../../../lib/db/clientErrors';
 
-export type AudienceSub = 'traffic' | 'community' | 'errors';
+export type AudienceSub = 'traffic' | 'acquisition' | 'community' | 'errors';
 
 export function AudienceLane({
   narrow,
@@ -25,15 +26,18 @@ export function AudienceLane({
 }) {
   const [sub, setSub] = useUrlTabState<AudienceSub>('sub', 'traffic', [
     'traffic',
+    'acquisition',
     'community',
     'errors',
   ] as const);
   const [trafficDays, setTrafficDays] = useState(28);
 
+  // Traffic and Acquisition both read admin_traffic_overview() — one shared query
+  // (same key) powers both sub-tabs, so switching between them is instant.
   const trafficQ = useQuery({
     queryKey: ['trafficOverview', trafficDays],
     queryFn: () => fetchTrafficOverview(trafficDays),
-    enabled: sub === 'traffic',
+    enabled: sub === 'traffic' || sub === 'acquisition',
     staleTime: 5 * 60_000,
     placeholderData: (prev) => prev, // keep the chart up while switching ranges
   });
@@ -55,6 +59,7 @@ export function AudienceLane({
       <SubTabs<AudienceSub>
         tabs={[
           { key: 'traffic', label: 'Traffic', icon: 'trending-up-outline' },
+          { key: 'acquisition', label: 'Acquisition', icon: 'magnet-outline' },
           { key: 'community', label: 'Community', icon: 'people-outline' },
           { key: 'errors', label: 'Errors', icon: 'bug-outline' },
         ]}
@@ -63,6 +68,15 @@ export function AudienceLane({
       />
       {sub === 'traffic' ? (
         <TrafficDomain
+          data={trafficQ.data ?? null}
+          loading={trafficQ.isLoading}
+          narrow={narrow}
+          days={trafficDays}
+          onDaysChange={setTrafficDays}
+        />
+      ) : null}
+      {sub === 'acquisition' ? (
+        <AcquisitionDomain
           data={trafficQ.data ?? null}
           loading={trafficQ.isLoading}
           narrow={narrow}

--- a/src/components/admin/health/domains/TrafficDomain.tsx
+++ b/src/components/admin/health/domains/TrafficDomain.tsx
@@ -20,7 +20,6 @@ import type {
   ReferrerViews,
   DeviceViews,
   HeroViews,
-  AcquisitionRow,
 } from '../../../../lib/db/traffic';
 
 const RANGES = [
@@ -86,28 +85,6 @@ function SignedSplit({ signedIn, anon }: { signedIn: number; anon: number }) {
   );
 }
 
-// Acquisition row: campaign/source label, a visitor bar, and a "N signed in"
-// caption — the funnel from a marketing source to actual accounts.
-function AcqRow({ row, max }: { row: AcquisitionRow; max: number }) {
-  const pct = max > 0 ? Math.max(4, Math.round((row.visitors / max) * 100)) : 0;
-  return (
-    <View style={s.barRow}>
-      <View style={s.barLabelWrap}>
-        <Text style={s.barLabel} numberOfLines={1}>
-          {row.label}
-        </Text>
-        <Text style={s.barVal}>{row.visitors.toLocaleString()}</Text>
-      </View>
-      <View style={s.barTrack}>
-        <View style={[s.barFill, { width: `${pct}%` }]} />
-      </View>
-      <Text style={s.acqCap} numberOfLines={1}>
-        {row.visitors.toLocaleString()} visitors · {row.signups.toLocaleString()} signed in
-      </Text>
-    </View>
-  );
-}
-
 // Top-hero row: rank thumbnail, name, view count, and a proportional bar.
 function HeroRow({ hero, max, onPress }: { hero: HeroViews; max: number; onPress: () => void }) {
   const pct = max > 0 ? Math.max(4, Math.round((hero.views / max) * 100)) : 0;
@@ -161,8 +138,7 @@ export function TrafficDomain({
     );
   }
 
-  const { totals, prev, audience, series, topHeroes, live, activeNow, today, acquisition } = data;
-  const acqMax = Math.max(1, ...acquisition.map((a) => a.visitors));
+  const { totals, prev, audience, series, topHeroes, live, activeNow, today } = data;
   const seriesViews = series.map((d) => d.views);
   const seriesVisitors = series.map((d) => d.visitors);
   const signedTotal = audience.signedIn + audience.anon;
@@ -244,23 +220,6 @@ export function TrafficDomain({
         </Panel>
       </Bento.Row>
 
-      {/* Acquisition — where visitors (and signups) come from, by tagged campaign */}
-      <Panel
-        title="Acquisition"
-        hint="First-touch by campaign · UTM-tagged links"
-        action={<Text style={s.kpiFoot}>{acquisition.length ? '' : 'tag your links →'}</Text>}
-      >
-        {acquisition.length === 0 ? (
-          <EmptyState text="No tagged campaigns yet. Add UTM tags to your TikTok bio link and post links — see docs/marketing/utm-attribution.md." />
-        ) : (
-          <View style={s.barList}>
-            {acquisition.map((a, i) => (
-              <AcqRow key={i} row={a} max={acqMax} />
-            ))}
-          </View>
-        )}
-      </Panel>
-
       {/* Breakdowns */}
       <Bento.Row narrow={narrow}>
         <Panel title="Top pages" hint="Grouped routes" style={s.flex1}>
@@ -329,7 +288,6 @@ const s = StyleSheet.create({
   barVal: { fontFamily: 'Flame-Regular', fontSize: 13, color: COLORS.navy },
   barTrack: { height: 6, borderRadius: 999, backgroundColor: '#efe6d6', overflow: 'hidden' },
   barFill: { height: '100%', borderRadius: 999, backgroundColor: COLORS.orange },
-  acqCap: { fontFamily: 'Nunito_400Regular', fontSize: 10.5, color: COLORS.grey },
   locked: { alignItems: 'center', gap: 8, paddingVertical: 24 },
   lockedText: {
     fontFamily: 'Nunito_400Regular',


### PR DESCRIPTION
## Why

The Acquisition panel (from #104) was buried as the **last** panel in the Traffic sub-tab — below the KPIs, the trend chart, top heroes, the live feed, and three breakdown panels. For the one view that answers *"is my ad spend actually converting?"*, that's too deep to find.

## What

- **New `AcquisitionDomain`** — its own view with a KPI header (attributed visitors · signups · conversion %, all computed client-side from the existing acquisition payload) plus the campaign leaderboard and a 7/28/90d range toggle.
- **`AudienceLane`** gains an **Acquisition** sub-tab: `Traffic · Acquisition · Community · Errors`. It reuses the **same `admin_traffic_overview` query** (shared React Query key) as Traffic, so there's no extra fetch and switching between the two is instant.
- **`TrafficDomain`** — removed the buried Acquisition panel (and its row component + styles).

## Notes

- **No API or migration change** — reads the `acquisition` field `admin_traffic_overview` v3 already returns (once that migration is applied).
- Deep-linkable via `?tab=audience&sub=acquisition`.
- Pure view-layer refactor; the data path is unchanged.

## Testing

- `tsc --noEmit` clean, eslint clean, prettier clean on all touched files.
- Full suite **755/755 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF)_