### PR TITLE
Regenerate types after session_attribution migration

### DIFF
--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1530,6 +1530,42 @@ export type Database = {
           },
         ]
       }
+      session_attribution: {
+        Row: {
+          first_seen: string
+          landing_path: string | null
+          referrer: string | null
+          session_id: string
+          utm_campaign: string | null
+          utm_content: string | null
+          utm_medium: string | null
+          utm_source: string | null
+          utm_term: string | null
+        }
+        Insert: {
+          first_seen?: string
+          landing_path?: string | null
+          referrer?: string | null
+          session_id: string
+          utm_campaign?: string | null
+          utm_content?: string | null
+          utm_medium?: string | null
+          utm_source?: string | null
+          utm_term?: string | null
+        }
+        Update: {
+          first_seen?: string
+          landing_path?: string | null
+          referrer?: string | null
+          session_id?: string
+          utm_campaign?: string | null
+          utm_content?: string | null
+          utm_medium?: string | null
+          utm_source?: string | null
+          utm_term?: string | null
+        }
+        Relationships: []
+      }
       social_post_results: {
         Row: {
           comments: number | null


### PR DESCRIPTION
Follow-up to **#104** (First-touch UTM attribution). Applies the committed migration to the linked Supabase project and regenerates the types per `CLAUDE.md`.

## Migration applied
`supabase/migrations/20260715170000_session_attribution.sql` — applied via `mcp__supabase__apply_migration` (name: `session_attribution`). It was **not** previously in the project's migration history, so this was a first application (nothing re-run). No dashboard hand-edits.

## Verification
| Check | Result |
| --- | --- |
| `select count(*) from public.session_attribution` | **0** — table exists, empty ✅ |
| `(admin_traffic_overview(28) -> 'acquisition') is not null` | **true** ✅ (as an admin) |

Note on the second check: run unauthenticated (plain MCP SQL, `auth.uid()` null), the function correctly returns its `{authorized:false}` branch, which has no `acquisition` key — so the check reads `false`. Re-running it with an admin JWT simulated returns `authorized: true` **and** `acquisition_present: true`, confirming v3 is live.

## This PR
Only `src/types/database.generated.ts` (+36 lines) — the `session_attribution` Row/Insert/Update types. `admin_traffic_overview` needs no signature change (it returns `Json`, so the new `acquisition` field is already covered). Generated by `mcp__supabase__generate_typescript_types`, never hand-edited.

**tsc:** 0 errors outside `__tests__/`, and none referencing `database.generated`. (Pre-existing `__tests__` errors on this machine are unrelated local `node_modules` drift — RNTL 14.0.1 installed vs the ^13.3.3 pin; CI installs from the lockfile and is unaffected. Tracked in #100.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)