### PR TITLE
fix(attribution): Acquisition never records — RLS rejects the ignore-duplicates upsert

### DIFF
--- a/__tests__/lib/attribution.test.ts
+++ b/__tests__/lib/attribution.test.ts
@@ -2,8 +2,17 @@ import {
   parseUtm,
   deriveAttribution,
   attributionEventProps,
+  recordAttribution,
   type Attribution,
 } from '../../src/lib/attribution';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: { auth: { getSession: async () => ({ data: { session: null } }) } },
+}));
+jest.mock('../../src/lib/db/pageViews', () => ({
+  getSessionId: () => 'sid-123',
+  getReferrerHost: () => null,
+}));
 
 describe('parseUtm', () => {
   it('pulls all five UTM params from a query string', () => {
@@ -105,5 +114,112 @@ describe('attributionEventProps', () => {
       utm_source: 'www.google.com',
       utm_medium: 'referral',
     });
+  });
+});
+
+describe('recordAttribution', () => {
+  const STORE_KEY = 'mythique_attr';
+  const SENT_KEY = 'mythique_attr_sent';
+  const firstTouch: Attribution = {
+    source: 'tiktok',
+    medium: 'paid-social',
+    campaign: 'launch',
+    content: null,
+    term: null,
+    referrer: 'tiktok.com',
+    landing: '/explore',
+  };
+  const fetchMock = jest.fn();
+
+  // recordAttribution is web-only: it early-returns unless window + localStorage
+  // exist. This suite runs in the node env, so stub both.
+  const store: Record<string, string> = {};
+  const localStorageStub = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+  };
+
+  beforeAll(() => {
+    (global as Record<string, unknown>).window = {};
+    (global as Record<string, unknown>).localStorage = localStorageStub;
+  });
+  afterAll(() => {
+    delete (global as Record<string, unknown>).window;
+    delete (global as Record<string, unknown>).localStorage;
+  });
+
+  beforeEach(() => {
+    localStorageStub.clear();
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.EXPO_PUBLIC_SUPABASE_KEY = 'anon-key';
+    localStorageStub.setItem(STORE_KEY, JSON.stringify(firstTouch));
+  });
+
+  const prefer = () =>
+    (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers.prefer;
+
+  // THE REGRESSION: `resolution=ignore-duplicates` puts PostgREST on its upsert
+  // (ON CONFLICT) path, which RLS rejects on this insert-only table (401/42501),
+  // so every attribution write silently failed. See src/lib/attribution.ts.
+  it('never sends resolution=ignore-duplicates (RLS rejects the upsert path)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+    await recordAttribution();
+    expect(prefer()).not.toContain('resolution=ignore-duplicates');
+    expect(prefer()).toBe('return=minimal');
+  });
+
+  it('posts the first-touch to session_attribution and marks it sent on 201', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+    await recordAttribution();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.supabase.co/rest/v1/session_attribution');
+    expect(JSON.parse((init as { body: string }).body)).toMatchObject({
+      session_id: 'sid-123',
+      utm_source: 'tiktok',
+      utm_campaign: 'launch',
+      referrer: 'tiktok.com',
+      landing_path: '/explore',
+    });
+    expect(localStorageStub.getItem(SENT_KEY)).toBe('1');
+  });
+
+  it('treats 409 (row already exists for this session) as done', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 409 });
+    await recordAttribution();
+    expect(localStorageStub.getItem(SENT_KEY)).toBe('1');
+  });
+
+  it('leaves the flag unset on failure so a later load retries', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 }); // e.g. before the migration lands
+    await recordAttribution();
+    expect(localStorageStub.getItem(SENT_KEY)).toBeNull();
+  });
+
+  it('writes once per browser — skips when already sent', async () => {
+    localStorageStub.setItem(SENT_KEY, '1');
+    await recordAttribution();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not write for direct visits (no stored first-touch)', async () => {
+    localStorageStub.removeItem(STORE_KEY);
+    await recordAttribution();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the network fails', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+    await expect(recordAttribution()).resolves.toBeUndefined();
+    expect(localStorageStub.getItem(SENT_KEY)).toBeNull();
   });
 });

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -152,8 +152,14 @@ export async function recordAttribution(): Promise<void> {
         apikey: key,
         authorization: `Bearer ${session?.access_token ?? key}`,
         'content-type': 'application/json',
-        // Dedup on session_id if this ever runs twice for the same browser.
-        prefer: 'resolution=ignore-duplicates,return=minimal',
+        // Deliberately NOT `resolution=ignore-duplicates`. That flips PostgREST
+        // onto its upsert (ON CONFLICT) path, which under RLS also needs a
+        // SELECT policy to resolve the conflict — and this table is insert-only
+        // by design (reads go only through admin_traffic_overview). The upsert
+        // is therefore rejected with 401 / 42501 "new row violates row-level
+        // security policy", so EVERY write failed. A repeat write is instead a
+        // plain 409 on the session_id PK, handled below.
+        prefer: 'return=minimal',
       },
       body: JSON.stringify({
         session_id: sid,
@@ -166,8 +172,11 @@ export async function recordAttribution(): Promise<void> {
         landing_path: a.landing,
       }),
     });
-    // Only mark done on success, so pre-migration 404s retry until the table lands.
-    if (res.ok) localStorage.setItem(SENT_KEY, '1');
+    // Mark done on success, and on 409 — that means this session's row is
+    // already there (the session_id PK did its job), which is success for us.
+    // Anything else (404 before the migration lands, 5xx, network) leaves the
+    // flag unset so a later page load retries.
+    if (res.ok || res.status === 409) localStorage.setItem(SENT_KEY, '1');
   } catch {
     // fire-and-forget — attribution must never break the page
   }


### PR DESCRIPTION
**`recordAttribution()` has been failing on every call since #104 deployed.** `session_attribution` is empty (0 rows against **264 sessions / 379 page views in 24h** of live traffic), so the Audience → Acquisition panel would never populate. Not a "waiting for traffic" problem — a hard bug.

## Root cause
The insert sent `prefer: resolution=ignore-duplicates`, which puts PostgREST on its **upsert (`ON CONFLICT`) path**. Under RLS that path *also* needs a **SELECT policy** to resolve the conflict — but `session_attribution` is deliberately **insert-only** (reads go solely through `admin_traffic_overview`). So Postgres rejects the write:

```
401 — 42501: new row violates row-level security policy for table "session_attribution"
```

The retry logic was actually good (`SENT_KEY` only set on success) — it was just retrying into a permanent 401.

## Verified against prod (anon key, identical request, only the header differs)
| `prefer` | Result |
| --- | --- |
| `resolution=ignore-duplicates,return=minimal` ← what shipped | **401** / 42501 |
| `return=minimal` | **201 Created** |

Ruled out everything else: the policy is correct (`INSERT`, `with check: true`, roles `{anon,authenticated}`), grants are correct (anon has `INSERT`), `set role anon` + insert in raw SQL **succeeds**, and the sibling `page_views` table accepts the same anon insert. The header is the only variable.

## Fix
- Send `prefer: return=minimal`.
- Treat **409 as done** — a repeat write just means this session's row already exists (the `session_id` PK doing its job). Anything else (404 pre-migration, 5xx, network) still leaves `SENT_KEY` unset so a later load retries.
- **Privacy model unchanged** — still insert-only, no SELECT policy added (that would have been the wrong fix).

## Tests
Adds `recordAttribution` coverage — the network wrapper was **untested**, which is exactly how this shipped. Pins the regression (*never* send `resolution=ignore-duplicates`) plus 201 / 409 / retry-on-failure / once-per-browser / direct-visit / network-failure behaviour. **20/20 pass**; tsc + eslint clean.

> Note: 14 test *suites* fail on my machine with `Cannot find module 'test-renderer'` — pre-existing local `node_modules` drift (RNTL 14.0.1 installed vs the `^13.3.3` pin, from the blocked v14 install in #100). **715 tests pass, 0 fail**, attribution is not among them, and CI installs from the lockfile so it's unaffected.

## Worth knowing
- **Direct traffic writes no row by design** — `deriveAttribution` returns null with no UTM *and* no referrer; "direct" is the absence of a row. Expect only tagged/referred visits in the panel.
- Attribution before this fix is **lost** for sessions that never return (first-touch is per browser session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)