### PR TITLE
feat(quality): integrity invariant checks + nightly prod e2e smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,32 @@
+# Nightly e2e smoke over the DEPLOYED site (plus on-demand via workflow_dispatch).
+# Read-only real-browser flows — see scripts/smoke/e2e-smoke.mjs. Runs at 06:30
+# UTC, after the 00:05 daily-debate roll and the 15:00-prior deploys have long
+# settled, so a red run means the SITE broke, not a race.
+name: Smoke (prod)
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to smoke (default: production)'
+        required: false
+        default: 'https://mythique.app'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: corepack enable
+      - run: yarn install --immutable
+      - name: Run smoke flows
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://mythique.app' }}
+          # ubuntu-latest ships Chrome; playwright-core launches it via channel:'chrome'
+        run: node scripts/smoke/e2e-smoke.mjs

--- a/__tests__/lib/db/dataQuality.test.ts
+++ b/__tests__/lib/db/dataQuality.test.ts
@@ -1,0 +1,41 @@
+import { fetchDataQuality } from '../../../src/lib/db/dataQuality';
+
+const mockRpc = jest.fn();
+
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: { rpc: (...args: unknown[]) => mockRpc(...args) },
+}));
+
+beforeEach(() => mockRpc.mockReset());
+
+describe('fetchDataQuality', () => {
+  const checks = [
+    { key: 'staleDone', label: 'Stale enrichment', count: 0, sample: [] },
+    {
+      key: 'famousDupNames',
+      label: 'Famous duplicate names (same publisher)',
+      count: 2,
+      sample: [{ id: 'h1', name: 'Hulk', fame_score: 89 }],
+    },
+  ];
+
+  it('unwraps an authorized report', async () => {
+    mockRpc.mockResolvedValue({
+      data: { authorized: true, generatedAt: '2026-07-16T08:00:00Z', checks },
+      error: null,
+    });
+    const report = await fetchDataQuality();
+    expect(mockRpc).toHaveBeenCalledWith('admin_data_quality');
+    expect(report).toEqual({ generatedAt: '2026-07-16T08:00:00Z', checks });
+  });
+
+  it('returns null for non-admins (authorized:false)', async () => {
+    mockRpc.mockResolvedValue({ data: { authorized: false }, error: null });
+    await expect(fetchDataQuality()).resolves.toBeNull();
+  });
+
+  it('returns null on RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(fetchDataQuality()).resolves.toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest --watchAll",
     "test:ci": "jest --ci",
     "test:social": "node --test \"scripts/social/**/*.test.mjs\"",
+    "smoke": "node scripts/smoke/e2e-smoke.mjs",
     "social": "node scripts/social/studio.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/scripts/smoke/e2e-smoke.mjs
+++ b/scripts/smoke/e2e-smoke.mjs
@@ -1,0 +1,154 @@
+// E2E smoke over the DEPLOYED web app — the ~10 read-only flows a real visitor
+// hits, driven in a real Chrome via playwright-core (already a devDependency;
+// same launch pattern as scripts/social/lib.mjs). No auth, no writes beyond the
+// page_views/attribution beacons any visitor fires.
+//
+// Why this exists: the 2026-07-15 bug hunt found the browse grid had been
+// silently broken (multi-tag filter timing out, search chars 400ing) — failures
+// only a real navigation exercises. This suite is the tripwire.
+//
+//   BASE_URL=https://mythique.app node scripts/smoke/e2e-smoke.mjs
+//
+// Exit 0 = all flows passed; exit 1 = failures (listed). Each flow gets a hard
+// timeout so one hung page can't wedge the run. PW_CHROME overrides the Chrome
+// binary (CI uses the runner's preinstalled Chrome via channel:'chrome').
+import pw from 'playwright-core';
+
+const BASE = (process.env.BASE_URL || 'https://mythique.app').replace(/\/$/, '');
+const NAV_TIMEOUT = 30_000;
+const FLOW_TIMEOUT = 45_000;
+
+/** Wait until the page's body text contains `needle` (case-insensitive). */
+async function seeText(page, needle, timeout = 15_000) {
+  await page.waitForFunction(
+    (n) => document.body && document.body.innerText.toLowerCase().includes(n),
+    needle.toLowerCase(),
+    { timeout },
+  );
+}
+
+const flows = [
+  {
+    name: 'landing renders',
+    run: async (page) => {
+      const res = await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' });
+      if (!res.ok()) throw new Error(`HTTP ${res.status()}`);
+      await seeText(page, 'mythique');
+    },
+  },
+  {
+    name: 'explore feed renders hero rows',
+    run: async (page) => {
+      await page.goto(`${BASE}/explore`, { waitUntil: 'domcontentloaded' });
+      // The dark stage always leads with a spotlight + browse pods.
+      await seeText(page, 'browse', 20_000);
+    },
+  },
+  {
+    name: 'search finds Batman',
+    run: async (page) => {
+      await page.goto(`${BASE}/search?q=batman`, { waitUntil: 'domcontentloaded' });
+      await seeText(page, 'batman', 20_000);
+    },
+  },
+  {
+    name: 'category grid renders (marvel)',
+    run: async (page) => {
+      await page.goto(`${BASE}/category/marvel`, { waitUntil: 'domcontentloaded' });
+      // Grid + count line ("N characters") prove the browse query ran —
+      // the surface the 2026-07-15 filter bugs silently broke.
+      await seeText(page, 'characters', 20_000);
+    },
+  },
+  {
+    name: 'character page renders (Spider-Man)',
+    run: async (page) => {
+      await page.goto(`${BASE}/character/620`, { waitUntil: 'domcontentloaded' });
+      await seeText(page, 'spider-man', 20_000);
+      await seeText(page, 'power', 20_000); // Power Profile section
+    },
+  },
+  {
+    name: 'compare verdict page renders (Spider-Man vs Batman)',
+    run: async (page) => {
+      await page.goto(`${BASE}/compare/620/69`, { waitUntil: 'domcontentloaded' });
+      await seeText(page, 'spider-man', 25_000);
+      await seeText(page, 'batman', 25_000);
+    },
+  },
+  {
+    name: 'versus hub shows a daily matchup',
+    run: async (page) => {
+      await page.goto(`${BASE}/versus`, { waitUntil: 'domcontentloaded' });
+      await seeText(page, 'vs', 20_000);
+    },
+  },
+  {
+    name: 'daily game loads',
+    run: async (page) => {
+      await page.goto(`${BASE}/play`, { waitUntil: 'domcontentloaded' });
+      await seeText(page, 'guess', 20_000);
+    },
+  },
+  {
+    name: 'sitemap index is served',
+    run: async (page) => {
+      const res = await page.goto(`${BASE}/sitemap.xml`, { waitUntil: 'domcontentloaded' });
+      if (!res.ok()) throw new Error(`HTTP ${res.status()}`);
+      const body = await res.text();
+      if (!/sitemapindex|urlset/.test(body)) throw new Error('no sitemap markup in response');
+    },
+  },
+  {
+    name: 'PWA assets are served (manifest + service worker)',
+    run: async (page) => {
+      for (const path of ['/manifest.json', '/sw.js']) {
+        const res = await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded' });
+        if (!res.ok()) throw new Error(`${path}: HTTP ${res.status()}`);
+      }
+    },
+  },
+];
+
+async function launchChrome() {
+  const opts = process.env.PW_CHROME
+    ? { executablePath: process.env.PW_CHROME }
+    : { channel: 'chrome' };
+  return pw.chromium.launch({ ...opts, args: ['--no-sandbox'] });
+}
+
+const browser = await launchChrome();
+const failures = [];
+
+for (const flow of flows) {
+  const context = await browser.newContext({
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36 MythiqueSmoke/1.0',
+  });
+  const page = await context.newPage();
+  page.setDefaultNavigationTimeout(NAV_TIMEOUT);
+  const started = Date.now();
+  try {
+    await Promise.race([
+      flow.run(page),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(`flow timeout (${FLOW_TIMEOUT}ms)`)), FLOW_TIMEOUT),
+      ),
+    ]);
+    console.log(`ok   ${flow.name} (${Date.now() - started}ms)`);
+  } catch (e) {
+    failures.push(`${flow.name}: ${e?.message ?? e}`);
+    console.error(`FAIL ${flow.name} (${Date.now() - started}ms): ${e?.message ?? e}`);
+  } finally {
+    await context.close();
+  }
+}
+
+await browser.close();
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length}/${flows.length} smoke flows FAILED against ${BASE}:`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`\nAll ${flows.length} smoke flows passed against ${BASE}.`);

--- a/src/components/admin/health/domains/CatalogLane.tsx
+++ b/src/components/admin/health/domains/CatalogLane.tsx
@@ -12,6 +12,7 @@ import { CatalogDomain } from './CatalogDomain';
 import { SourcesDomain } from './SourcesDomain';
 import { HeroConsole } from '../HeroConsole';
 import { DuplicatesPanel } from '../DuplicatesPanel';
+import { IntegrityPanel } from './IntegrityPanel';
 import { UniverseGapsPanel } from '../UniverseGapsPanel';
 import { SourcesSkeleton } from '../skeletons';
 import {
@@ -148,6 +149,9 @@ export function CatalogLane({
             busy={busy}
             onReenrich={onReenrich}
           />
+          <View style={styles.gapTop}>
+            <IntegrityPanel />
+          </View>
           <View style={styles.gapTop}>
             <DuplicatesPanel
               flash={flash}

--- a/src/components/admin/health/domains/IntegrityPanel.tsx
+++ b/src/components/admin/health/domains/IntegrityPanel.tsx
@@ -1,0 +1,116 @@
+// Integrity panel — continuous data-quality invariant checks (Catalog →
+// Hygiene). Each row is one corruption class from the 2026-07-16 famous-roster
+// audit, watched forever instead of rediscovered by hand: green at zero, orange
+// with the top offenders when something regresses. Read-only — fixes happen in
+// the sibling panels (Duplicates, ComicVine review) or via re-enrichment.
+import { useCallback, useEffect, useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../../../constants/colors';
+import { Panel } from '../Panel';
+import { InfoTip } from '../InfoTip';
+import { fetchDataQuality, type DataQualityReport } from '../../../../lib/db/dataQuality';
+
+export function IntegrityPanel() {
+  const [report, setReport] = useState<DataQualityReport | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setReport(await fetchDataQuality());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, [load]);
+
+  const dirty = report?.checks.filter((c) => c.count > 0).length ?? 0;
+
+  return (
+    <Panel
+      title="Integrity"
+      hint={
+        loading
+          ? 'Running checks…'
+          : report
+            ? dirty === 0
+              ? 'All invariants hold'
+              : `${dirty} check${dirty === 1 ? '' : 's'} need attention`
+            : 'Unavailable'
+      }
+      action={
+        <View style={styles.actions}>
+          <InfoTip text="Continuous invariant checks over the catalogue: stale enrichments (marked done but empty — they never re-fetch), cross-franchise collision drift (should stay zero; growth means the publisher gate leaked), gaps on famous characters, and same-name-same-publisher duplicates. Green means the invariant holds; tap refresh after fixing." />
+          <Pressable onPress={load} disabled={loading} accessibilityLabel="Re-run integrity checks">
+            <Ionicons name="refresh" size={16} color={loading ? COLORS.grey : COLORS.navy} />
+          </Pressable>
+        </View>
+      }
+    >
+      {loading && !report ? (
+        <ActivityIndicator color={COLORS.orange} style={styles.spin} />
+      ) : !report ? (
+        <Text style={styles.unavailable}>Couldn’t load the integrity report.</Text>
+      ) : (
+        <View style={styles.list}>
+          {report.checks.map((c) => {
+            const ok = c.count === 0;
+            return (
+              <View key={c.key} style={styles.row}>
+                <Ionicons
+                  name={ok ? 'checkmark-circle' : 'alert-circle'}
+                  size={16}
+                  color={ok ? COLORS.green : COLORS.orange}
+                />
+                <View style={styles.body}>
+                  <Text style={styles.label}>
+                    {c.label}
+                    <Text style={[styles.count, !ok && styles.countBad]}>
+                      {'  '}
+                      {c.count.toLocaleString()}
+                    </Text>
+                  </Text>
+                  {!ok && c.sample.length > 0 ? (
+                    <Text style={styles.sample} numberOfLines={2}>
+                      {c.sample.map((s) => s.name).join(' · ')}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </Panel>
+  );
+}
+
+const styles = StyleSheet.create({
+  actions: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  spin: { marginVertical: 10 },
+  unavailable: { fontFamily: 'Nunito_400Regular', fontSize: 12.5, color: COLORS.grey },
+  list: { gap: 2 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 9,
+    paddingVertical: 7,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(41,60,67,0.06)',
+  },
+  body: { flex: 1, minWidth: 0, gap: 1 },
+  label: { fontFamily: 'Nunito_700Bold', fontSize: 13, color: COLORS.navy },
+  count: {
+    fontFamily: 'Nunito_700Bold',
+    fontSize: 12.5,
+    color: COLORS.green,
+    fontVariant: ['tabular-nums'],
+  },
+  countBad: { color: COLORS.orange },
+  sample: { fontFamily: 'Nunito_400Regular', fontSize: 11.5, color: COLORS.grey, lineHeight: 15 },
+});

--- a/src/lib/db/dataQuality.ts
+++ b/src/lib/db/dataQuality.ts
@@ -1,0 +1,44 @@
+import { supabase } from '../supabase';
+
+// Data-quality invariant checks (command center → Catalog → Hygiene → Integrity
+// panel). Wraps the admin-guarded admin_data_quality() RPC, which codifies the
+// corruption classes found by hand in the 2026-07-16 famous-roster audit —
+// stale done rows (the Hulk/Thor signature), cross-franchise collision drift
+// (issue #65's smell test), famous-row gaps, and same-name+same-publisher dups.
+
+export interface DataQualitySample {
+  id: string;
+  name: string;
+  fame_score: number | null;
+}
+
+export interface DataQualityCheck {
+  key: string;
+  label: string;
+  count: number;
+  sample: DataQualitySample[];
+}
+
+export interface DataQualityReport {
+  generatedAt: string;
+  checks: DataQualityCheck[];
+}
+
+type ReportJson =
+  | ({ authorized: true; generatedAt: string; checks: DataQualityCheck[] } | { authorized: false })
+  | null;
+
+/**
+ * Fetch the integrity report. Returns null for non-admins or on error so the
+ * panel can render a locked/empty state.
+ */
+export async function fetchDataQuality(): Promise<DataQualityReport | null> {
+  const { data, error } = await supabase.rpc('admin_data_quality');
+  if (error) {
+    console.warn('[fetchDataQuality] error:', error.message);
+    return null;
+  }
+  const json = data as unknown as ReportJson;
+  if (!json || json.authorized !== true) return null;
+  return { generatedAt: json.generatedAt, checks: json.checks };
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2043,6 +2043,7 @@ export type Database = {
       }
       admin_community_overview: { Args: never; Returns: Json }
       admin_cron_status: { Args: never; Returns: Json }
+      admin_data_quality: { Args: never; Returns: Json }
       admin_delete_campaign: { Args: { p_id: string }; Returns: number }
       admin_delete_hero: { Args: { p_hero_id: string }; Returns: number }
       admin_edit_hero: {

--- a/supabase/migrations/20260716080000_admin_data_quality.sql
+++ b/supabase/migrations/20260716080000_admin_data_quality.sql
@@ -1,0 +1,117 @@
+-- Data-quality invariant checks (admin command center → Catalog → Hygiene).
+-- Codifies the classes of corruption found by hand in the 2026-07-16 famous-
+-- roster audit so they're watched continuously instead of rediscovered:
+--   * staleDone          — comicvine_status='done' with a comicvine_id but NULL
+--                          issue_count: the "Hulk/Thor" signature (stale/broken
+--                          stored data that the client will never re-fetch).
+--   * collisionSuspects  — hand-curated rows (non cv- id) wearing a Marvel/DC
+--                          publisher next to a real franchise: the cross-
+--                          franchise collision smell test (issue #65). Should
+--                          stay at 0; regrowth means the publisher gate leaked.
+--   * famousNullPublisher / famousNoSummary / famousMissingPortrait — visible
+--                          gaps on high-fame (>=80) characters.
+--   * famousDupNames     — the same name AND same publisher on 2+ rows where
+--                          the most famous is >=70: near-certain duplicates
+--                          needing a merge. (Grouping by publisher too keeps
+--                          legitimate cross-publisher same-name characters —
+--                          two "Atlas"es — out of the signal: 94 noisy → 16 real.)
+-- Read live (cheap: every check is over indexed columns or the tiny fame>=80
+-- head), admin-guarded like every command-center RPC.
+create or replace function public.admin_data_quality()
+returns json
+language plpgsql
+stable
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    return json_build_object('authorized', false);
+  end if;
+
+  return json_build_object(
+    'authorized', true,
+    'generatedAt', now(),
+    'checks', json_build_array(
+      json_build_object(
+        'key', 'staleDone',
+        'label', 'Stale enrichment (done, but empty)',
+        'count', (select count(*) from heroes
+                   where comicvine_status = 'done' and comicvine_id is not null
+                     and issue_count is null),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select id, name, fame_score from heroes
+           where comicvine_status = 'done' and comicvine_id is not null
+             and issue_count is null
+           order by fame_score desc nulls last limit 8) s)
+      ),
+      json_build_object(
+        'key', 'collisionSuspects',
+        'label', 'Cross-franchise collision suspects',
+        'count', (select count(*) from heroes
+                   where comicvine_status = 'done' and id not like 'cv-%'
+                     and (publisher ilike '%marvel%' or publisher ilike '%dc comics%' or publisher = 'DC')
+                     and franchise is not null),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select id, name, fame_score from heroes
+           where comicvine_status = 'done' and id not like 'cv-%'
+             and (publisher ilike '%marvel%' or publisher ilike '%dc comics%' or publisher = 'DC')
+             and franchise is not null
+           order by fame_score desc nulls last limit 8) s)
+      ),
+      json_build_object(
+        'key', 'famousNullPublisher',
+        'label', 'Famous, no publisher',
+        'count', (select count(*) from heroes where fame_score >= 80 and publisher is null),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select id, name, fame_score from heroes
+           where fame_score >= 80 and publisher is null
+           order by fame_score desc limit 8) s)
+      ),
+      json_build_object(
+        'key', 'famousNoSummary',
+        'label', 'Famous, no summary',
+        'count', (select count(*) from heroes
+                   where fame_score >= 80 and (summary is null or length(summary) = 0)),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select id, name, fame_score from heroes
+           where fame_score >= 80 and (summary is null or length(summary) = 0)
+           order by fame_score desc limit 8) s)
+      ),
+      json_build_object(
+        'key', 'famousMissingPortrait',
+        'label', 'Famous, no portrait',
+        'count', (select count(*) from heroes where fame_score >= 80 and portrait_url is null),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select id, name, fame_score from heroes
+           where fame_score >= 80 and portrait_url is null
+           order by fame_score desc limit 8) s)
+      ),
+      json_build_object(
+        'key', 'famousDupNames',
+        'label', 'Famous duplicate names (same publisher)',
+        'count', (select count(*) from (
+          select name from heroes
+          group by name, lower(coalesce(publisher, ''))
+          having count(*) > 1 and max(fame_score) >= 70) d),
+        'sample', (select coalesce(json_agg(s), '[]'::json) from (
+          select min(id) as id, name, max(fame_score) as fame_score
+            from heroes
+          group by name, lower(coalesce(publisher, ''))
+          having count(*) > 1 and max(fame_score) >= 70
+           order by max(fame_score) desc limit 8) s)
+      )
+    )
+  );
+end;
+$function$;
+
+do $$
+declare f text;
+begin
+  foreach f in array array['public.admin_data_quality()']
+  loop
+    execute format('revoke all on function %s from public, anon;', f);
+    execute format('grant execute on function %s to authenticated, service_role;', f);
+  end loop;
+end $$;


### PR DESCRIPTION
Program **#6** of the improvement batch — two tripwires so the bug classes found by hand this week stay found automatically.

## 1. Integrity checks — admin → Catalog → Hygiene → **Integrity** panel
New admin-guarded `admin_data_quality()` RPC codifying the famous-roster audit's invariants:

| Check | Meaning | Baseline |
| --- | --- | --- |
| `staleDone` | `done` + comicvine_id + NULL issue_count — the **Hulk/Thor** stale-enrichment signature | **0** ✅ |
| `collisionSuspects` | issue #65's cross-franchise smell test — regrowth = the publisher gate leaked | **0** ✅ |
| `famousNullPublisher` / `famousNoSummary` | gaps on fame ≥ 80 | **0 / 0** ✅ |
| `famousMissingPortrait` | fame ≥ 80, no portrait | 40 (known, deferred) |
| `famousDupNames` | same name **and** same publisher, max fame ≥ 70 (publisher grouping cuts 94 noisy → **16** real) | 16 (review queue) |

**It already earned its keep:** the first run found **2 more stale rows** below my earlier top-500 hand-scan (Orion, Metron — New Gods, fame 3). Both re-enriched during this PR; the shipped baseline is green.

Applied to prod via MCP; types regenerated. Panel is read-only (green check / orange count + top offenders, refresh button) beside DuplicatesPanel.

## 2. Nightly e2e smoke over the deployed site
`scripts/smoke/e2e-smoke.mjs` (`yarn smoke`) — **10 read-only real-Chrome flows** via `playwright-core` (already a devDep; same `channel:'chrome'` launch as `scripts/social`): landing, explore, search, **category grid** (the exact surface the 2026-07-15 filter bugs silently broke), character page, compare verdict, versus hub, daily game, sitemap, manifest+sw. Per-flow hard timeouts, exit 1 on failure.

**Verified against production: 10/10 in ~12s.**

`.github/workflows/smoke.yml` runs it nightly at 06:30 UTC + on-demand (`workflow_dispatch`, `base_url` overridable).

## Verification
tsc clean (0 non-drift errors) · **718 tests pass** (+3 wrapper tests) · eslint clean on new files · smoke suite green against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)