### PR TITLE
Split web font loading so the boot gate opens sooner

### DIFF
--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -224,12 +224,25 @@ export default function WebRootLayout() {
     };
   }, []);
 
+  // Fonts load in two passes so the cold-start boot gate opens sooner WITHOUT any
+  // flash of fallback text on visible content:
+  //   • Critical (blocking) — every font used above the fold on the boot screen
+  //     and first content paint: the brand Flame faces + the two common Nunito
+  //     weights. The gate below waits on these, so visible text is never unstyled.
+  //   • Deferred (non-blocking) — the heavy display weights + Righteous, used
+  //     ONLY on detail pages, filter controls, the footer and admin — never above
+  //     the fold on entry. Loading them in a second, un-awaited pass keeps ~300 KB
+  //     of font bytes off the critical path (it matters on cellular); they resolve
+  //     long before a visitor reaches a surface that uses them, so no swap shows.
   const [fontsLoaded, fontError] = useFonts({
     'FlameSans-Regular': require('../assets/fonts/FlameSans-Regular.ttf'),
     'Flame-Regular': require('../assets/fonts/Flame-Regular.ttf'),
     'Flame-Bold': require('../assets/fonts/Flame-Bold.ttf'),
     Nunito_400Regular,
     Nunito_700Bold,
+  });
+  // Deliberately not awaited by the boot gate — see note above.
+  useFonts({
     Nunito_800ExtraBold,
     Nunito_900Black,
     Righteous_400Regular,


### PR DESCRIPTION
## Why

Paid TikTok traffic was leaking before the app painted (~5% of clicks captured). One cause: the cold-start boot gate holds the `LogoLoader` until **all 8 web fonts** are ready — and those ~755 KB of fonts are only fetched *after* the JS bundle downloads and runs `useFonts`. On cellular that's a real slice of time-to-interactive.

## What

Load fonts in two passes on web (`app/_layout.web.tsx`), keeping the exact same clean single-loader boot:

- **Critical (blocking):** the three Flame faces + `Nunito_400Regular` / `Nunito_700Bold` — every font used above the fold on the boot screen and first content paint. The gate still waits on these, so **visible text never flashes unstyled**.
- **Deferred (non-blocking):** `Nunito_800ExtraBold`, `Nunito_900Black`, `Righteous_400Regular` (~300 KB) — a second, un-awaited `useFonts()` pass. Usage audit confirms these appear **only** on detail pages, filter controls, the footer, and admin — never above the fold on entry — so they resolve long before a visitor reaches a surface that uses them, and no swap is ever visible.

Net: the boot gate opens ~300 KB of font bytes sooner on the critical path, with **no change to the visible boot experience** — same continuous logo, no flash of fallback text.

## Deliberately left alone

- **Auth gate** — already resolves fast for logged-out visitors (local `getSession`, 8 s backstop), and it's what keeps the post-login redirect clean. Not worth the risk.
- **Native layout** (`_layout.tsx`) — loads fonts from the local bundle; not the bottleneck.

## Testing

- `tsc --noEmit` clean, eslint clean, prettier clean.
- Full suite **765/765 passing**.
- Pure boot-path change; no runtime surface a unit test exercises (per the repo's testing guidance), so verified via the usage audit that no deferred font sits above the fold.

## Companion (no code)

The bigger lever is still Tier 0 — pointing paid traffic at a battle (`/compare/...`) instead of `/`, which skips the ~130 KB+ three.js chunk the landing pulls in. That's a destination-URL change, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF)_