### PR TITLE
feat(retention): daily streaks + Today's Dailies hub + streak-at-risk push

### DIFF
--- a/__tests__/lib/db/dailies.test.ts
+++ b/__tests__/lib/db/dailies.test.ts
@@ -1,0 +1,109 @@
+import {
+  recordDailyCompletion,
+  recordDebateCompletionIfDaily,
+  recordTeamBattleCompletionIfDaily,
+  getMyDailyStreak,
+} from '../../../src/lib/db/dailies';
+
+const mockRpc = jest.fn().mockResolvedValue({ data: null, error: null });
+let mockSession: object | null = { user: { id: 'u1' } };
+
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    auth: { getSession: async () => ({ data: { session: mockSession } }) },
+  },
+}));
+
+const mockGetDailyDebate = jest.fn();
+jest.mock('../../../src/lib/db/dailyDebate', () => ({
+  todayIso: () => '2026-07-16',
+  getDailyDebate: (...args: unknown[]) => mockGetDailyDebate(...args),
+}));
+
+const mockGetTodaysTeamBattle = jest.fn();
+jest.mock('../../../src/lib/db/teams', () => ({
+  getTodaysTeamBattle: (...args: unknown[]) => mockGetTodaysTeamBattle(...args),
+}));
+
+beforeEach(() => {
+  mockRpc.mockClear();
+  mockGetDailyDebate.mockReset();
+  mockGetTodaysTeamBattle.mockReset();
+  mockSession = { user: { id: 'u1' } };
+});
+
+describe('recordDailyCompletion', () => {
+  it('records for a signed-in user', async () => {
+    await recordDailyCompletion('puzzle');
+    expect(mockRpc).toHaveBeenCalledWith('record_daily_completion', { p_surface: 'puzzle' });
+  });
+
+  it('no-ops when logged out', async () => {
+    mockSession = null;
+    await recordDailyCompletion('puzzle');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordDebateCompletionIfDaily', () => {
+  it('records when the voted pair IS today’s debate (order-insensitive)', async () => {
+    mockGetDailyDebate.mockResolvedValue({ heroAId: 'a1', heroBId: 'b1', hookText: null });
+    await recordDebateCompletionIfDaily('b1', 'a1'); // reversed order
+    expect(mockRpc).toHaveBeenCalledWith('record_daily_completion', { p_surface: 'debate' });
+  });
+
+  it('does NOT record for an arbitrary (non-daily) pair', async () => {
+    mockGetDailyDebate.mockResolvedValue({ heroAId: 'a1', heroBId: 'b1', hookText: null });
+    await recordDebateCompletionIfDaily('a1', 'someone-else');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no debate row today', async () => {
+    mockGetDailyDebate.mockResolvedValue(null);
+    await recordDebateCompletionIfDaily('a1', 'b1');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordTeamBattleCompletionIfDaily', () => {
+  it('records only for today’s deterministic pair', async () => {
+    mockGetTodaysTeamBattle.mockResolvedValue({ teamA: { id: 't1' }, teamB: { id: 't2' } });
+    await recordTeamBattleCompletionIfDaily('t2', 't1');
+    expect(mockRpc).toHaveBeenCalledWith('record_daily_completion', { p_surface: 'team_battle' });
+    mockRpc.mockClear();
+    await recordTeamBattleCompletionIfDaily('t1', 't9'); // a draft/deep-linked battle
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMyDailyStreak', () => {
+  it('unwraps the RPC json', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: { current: 4, longest: 5, today: { puzzle: false, debate: true, team_battle: false } },
+      error: null,
+    });
+    await expect(getMyDailyStreak()).resolves.toEqual({
+      current: 4,
+      longest: 5,
+      today: { puzzle: false, debate: true, team_battle: false },
+    });
+  });
+
+  it('returns zeros when logged out (without calling the RPC)', async () => {
+    mockSession = null;
+    const s = await getMyDailyStreak();
+    expect(s.current).toBe(0);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('returns zeros on error', async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+    const s = await getMyDailyStreak();
+    expect(s).toEqual({
+      current: 0,
+      longest: 0,
+      today: { puzzle: false, debate: false, team_battle: false },
+    });
+  });
+});

--- a/app/(tabs)/versus.tsx
+++ b/app/(tabs)/versus.tsx
@@ -18,6 +18,7 @@ import { ShowdownCards } from '../../src/components/versus/ShowdownCards';
 import { RivalriesRail } from '../../src/components/versus/RivalriesRail';
 import { HallOfInfamy } from '../../src/components/home/HallOfInfamy';
 import { YesterdayStrip } from '../../src/components/versus/YesterdayStrip';
+import { TodaysDailies } from '../../src/components/game/TodaysDailies';
 
 export default function VersusScreen() {
   const router = useRouter();
@@ -132,6 +133,24 @@ export default function VersusScreen() {
               </View>
             </Pressable>
           </View>
+
+          {/* ── Today's Dailies — streak + the three daily surfaces ── */}
+          <View style={styles.dailiesWrap}>
+            <TodaysDailies
+              onPuzzle={() => router.push('/play')}
+              onDebate={() => (matchup ? openArena(matchup.heroA, matchup.heroB) : undefined)}
+              onTeamBattle={
+                teamBattle
+                  ? () =>
+                      router.push(
+                        `/versus/team/${teamBattle.teamA.id}-vs-${teamBattle.teamB.id}` as Parameters<
+                          typeof router.push
+                        >[0],
+                      )
+                  : undefined
+              }
+            />
+          </View>
         </LinearGradient>
 
         {/* ── Featured team battle ── */}
@@ -207,6 +226,7 @@ const styles = StyleSheet.create({
   },
 
   actions: { flexDirection: 'row', gap: 12, marginTop: 26, alignSelf: 'stretch' },
+  dailiesWrap: { alignSelf: 'stretch', marginTop: 14 },
   act: {
     flex: 1,
     flexDirection: 'row',

--- a/app/(tabs)/versus.web.tsx
+++ b/app/(tabs)/versus.web.tsx
@@ -20,6 +20,7 @@ import { YesterdayStrip } from '../../src/components/web/versus/YesterdayStrip';
 import { useDiscoveryRows } from '../../src/hooks/useDiscoveryRows';
 import { HallOfInfamy } from '../../src/components/web/home/HallOfInfamy';
 import { Reveal } from '../../src/components/web/Reveal';
+import { TodaysDailies } from '../../src/components/game/TodaysDailies';
 
 export default function VersusHubWeb() {
   // The page ends on the dark deck section — keep the canvas deep-navy so it
@@ -29,8 +30,17 @@ export default function VersusHubWeb() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
   const contentPad = width < 640 ? 16 : 32;
-  const { matchup, hookText, takesCount, yesterday, iconicPool, loading, feedSettled, mostFeared } =
-    useVersusHub();
+  const {
+    matchup,
+    hookText,
+    takesCount,
+    yesterday,
+    iconicPool,
+    loading,
+    feedSettled,
+    mostFeared,
+    teamBattle,
+  } = useVersusHub();
 
   const openArena = (a: FighterArt, b: FighterArt) => {
     stashFighters(a, b);
@@ -174,6 +184,24 @@ export default function VersusHubWeb() {
                 <Text style={s.actSub}>Random iconic clash</Text>
               </View>
             </Pressable>
+          </View>
+
+          {/* ── Today's Dailies — streak + the three daily surfaces ── */}
+          <View style={s.dailiesWrap}>
+            <TodaysDailies
+              onPuzzle={() => router.push('/play')}
+              onDebate={() => (matchup ? openArena(matchup.heroA, matchup.heroB) : undefined)}
+              onTeamBattle={
+                teamBattle
+                  ? () =>
+                      router.push(
+                        `/versus/team/${teamBattle.teamA.id}-vs-${teamBattle.teamB.id}` as Parameters<
+                          typeof router.push
+                        >[0],
+                      )
+                  : undefined
+              }
+            />
           </View>
         </View>
       </View>
@@ -396,6 +424,7 @@ const s = StyleSheet.create({
     maxWidth: 560,
     justifyContent: 'center',
   },
+  dailiesWrap: { width: '100%', maxWidth: 560, marginTop: 14 },
   act: {
     flex: 1,
     flexDirection: 'row',

--- a/src/components/game/TodaysDailies.tsx
+++ b/src/components/game/TodaysDailies.tsx
@@ -1,0 +1,135 @@
+// Today's Dailies — the games-hub strip. One glance: your streak, the three
+// daily surfaces, which are done. Sits on the ink stage (versus hub, both
+// platforms — plain RN primitives). Completion checks come from the signed-in
+// server calendar (useDailies); logged out, the strip still works as a launcher
+// with the local puzzle streak folded in by the caller's screens elsewhere.
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/colors';
+import { useDailies } from '../../hooks/useDailies';
+
+interface DailyItem {
+  key: 'puzzle' | 'debate' | 'team_battle';
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress: () => void;
+}
+
+export function TodaysDailies({
+  onPuzzle,
+  onDebate,
+  onTeamBattle,
+}: {
+  onPuzzle: () => void;
+  onDebate: () => void;
+  /** Omit while today's battle is still resolving — the chip hides. */
+  onTeamBattle?: () => void;
+}) {
+  const { current, today } = useDailies();
+
+  const items: DailyItem[] = [
+    { key: 'debate', label: 'Daily Debate', icon: 'flash-outline', onPress: onDebate },
+    { key: 'puzzle', label: 'Guess the Hero', icon: 'help-circle-outline', onPress: onPuzzle },
+  ];
+  if (onTeamBattle) {
+    items.push({
+      key: 'team_battle',
+      label: 'Team Battle',
+      icon: 'people-outline',
+      onPress: onTeamBattle,
+    });
+  }
+  const doneCount = items.filter((i) => today[i.key]).length;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.eyebrow}>Today’s Dailies</Text>
+        <View style={styles.streak}>
+          <Ionicons name="flame" size={13} color={current > 0 ? COLORS.orange : COLORS.grey} />
+          <Text style={[styles.streakText, current === 0 && styles.streakZero]}>
+            {current > 0 ? `${current}-day streak` : 'Start a streak'}
+          </Text>
+          {doneCount > 0 ? (
+            <Text style={styles.doneCount}>
+              {' '}
+              · {doneCount}/{items.length} done
+            </Text>
+          ) : null}
+        </View>
+      </View>
+      <View style={styles.row}>
+        {items.map((item) => {
+          const done = today[item.key];
+          return (
+            <Pressable
+              key={item.key}
+              onPress={item.onPress}
+              accessibilityRole="button"
+              accessibilityLabel={`${item.label}${done ? ' — completed today' : ''}`}
+              style={({ pressed }) => [styles.chip, done && styles.chipDone, pressed && styles.dim]}
+            >
+              <Ionicons
+                name={done ? 'checkmark-circle' : item.icon}
+                size={15}
+                color={done ? COLORS.green : COLORS.goldAccent}
+              />
+              <Text style={[styles.chipText, done && styles.chipTextDone]} numberOfLines={1}>
+                {item.label}
+              </Text>
+              {!done ? (
+                <Ionicons name="chevron-forward" size={12} color="rgba(245,235,220,0.4)" />
+              ) : null}
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(245,235,220,0.12)',
+    backgroundColor: 'rgba(245,235,220,0.05)',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    gap: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  eyebrow: {
+    fontFamily: 'Nunito_800ExtraBold',
+    fontSize: 11,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: 'rgba(245,235,220,0.55)',
+  },
+  streak: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  streakText: { fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.beige },
+  streakZero: { color: 'rgba(245,235,220,0.55)' },
+  doneCount: { fontFamily: 'Nunito_400Regular', fontSize: 12, color: 'rgba(245,235,220,0.55)' },
+  row: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(245,235,220,0.16)',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    minWidth: 0,
+  },
+  chipDone: { borderColor: 'rgba(74,153,110,0.5)', backgroundColor: 'rgba(74,153,110,0.12)' },
+  chipText: { fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.beige },
+  chipTextDone: { color: 'rgba(245,235,220,0.75)' },
+  dim: { opacity: 0.7 },
+});

--- a/src/hooks/useDailies.ts
+++ b/src/hooks/useDailies.ts
@@ -1,0 +1,33 @@
+// Today's dailies state for the hub strip: the signed-in cross-surface streak
+// + which of the three surfaces are done today. Refetches on focus so checks
+// light up when the player returns from a completed daily. Logged out it
+// resolves to zeros/unchecked (the strip still works as a launcher).
+import { useCallback, useState } from 'react';
+import { useFocusEffect } from 'expo-router';
+import { getMyDailyStreak, type DailyStreak } from '../lib/db/dailies';
+
+const EMPTY: DailyStreak = {
+  current: 0,
+  longest: 0,
+  today: { puzzle: false, debate: false, team_battle: false },
+};
+
+export function useDailies(): DailyStreak {
+  const [state, setState] = useState<DailyStreak>(EMPTY);
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+      getMyDailyStreak()
+        .then((s) => {
+          if (active) setState(s);
+        })
+        .catch(() => {});
+      return () => {
+        active = false;
+      };
+    }, []),
+  );
+
+  return state;
+}

--- a/src/hooks/useDailyHero.ts
+++ b/src/hooks/useDailyHero.ts
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getDailyHero, type DailyPuzzle } from '../lib/db/dailyHero';
 import { getDailyDistribution, recordDailyResult } from '../lib/db/dailyStats';
+import { recordDailyCompletion } from '../lib/db/dailies';
 import { blurForGuess, buildClues, visibleClues, type Clue } from '../lib/game/reveal';
 import { buildDossier } from '../lib/game/dossier';
 import { buildShareGrid } from '../lib/game/shareGrid';
@@ -127,6 +128,9 @@ export function useDailyHero() {
           AsyncStorage.setItem(STATS_KEY, JSON.stringify(updated)).catch(() => {});
           return updated;
         });
+        // Signed-in daily-streak calendar (playing counts, win or lose).
+        // Fire-and-forget; no-ops when logged out.
+        void recordDailyCompletion('puzzle');
       }
     },
     [puzzle, status, guesses],

--- a/src/hooks/useDailyStreak.ts
+++ b/src/hooks/useDailyStreak.ts
@@ -1,11 +1,16 @@
-// Reads the locally-stored daily-game streak so home-screen surfaces (the
-// Explore banner) can show it without pulling in the whole game hook. Refreshes
-// whenever the screen regains focus, so a streak earned today shows up on
-// return without a reload.
+// The streak number for home-screen surfaces (the Explore banner, the dailies
+// hub) without pulling in the whole game hook. Two sources, merged:
+//   - local: the on-device puzzle streak (works logged out — the original).
+//   - server: the signed-in cross-surface daily streak (get_my_daily_streak),
+//     which counts puzzle OR debate vote OR team-battle vote per UTC day.
+// We show max(local, server) so a signed-in player whose local puzzle history
+// predates the server calendar never sees their number drop on upgrade.
+// Refreshes on focus, so a streak earned today shows up on return.
 import { useCallback, useState } from 'react';
 import { useFocusEffect } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { EMPTY_STREAK, type StreakState } from '../lib/game/streak';
+import { getMyDailyStreak } from '../lib/db/dailies';
 
 const STREAK_KEY = 'dh_streak_v1';
 
@@ -15,13 +20,19 @@ export function useDailyStreak(): number {
   useFocusEffect(
     useCallback(() => {
       let active = true;
-      AsyncStorage.getItem(STREAK_KEY)
+      const localP = AsyncStorage.getItem(STREAK_KEY)
         .then((raw) => {
-          if (!active || !raw) return;
+          if (!raw) return 0;
           const s = JSON.parse(raw) as StreakState;
-          setCurrent(s?.current ?? EMPTY_STREAK.current);
+          return s?.current ?? EMPTY_STREAK.current;
         })
-        .catch(() => {});
+        .catch(() => 0);
+      const serverP = getMyDailyStreak()
+        .then((s) => s.current)
+        .catch(() => 0);
+      Promise.all([localP, serverP]).then(([local, server]) => {
+        if (active) setCurrent(Math.max(local, server));
+      });
       return () => {
         active = false;
       };

--- a/src/hooks/useMatchupVote.ts
+++ b/src/hooks/useMatchupVote.ts
@@ -14,6 +14,7 @@ import { matchupVoteKey, type MatchupSide } from '../lib/home/matchupVote';
 import { getMatchupTallyV2, castMatchupVoteV2, type MatchupTally } from '../lib/db/matchupVotes';
 import { getVoterKey } from '../lib/voterKey';
 import { trackEvent } from '../lib/analytics';
+import { recordDebateCompletionIfDaily } from '../lib/db/dailies';
 
 export interface MatchupVoteState {
   /** The picked hero id, or null before the user has voted. */
@@ -78,7 +79,12 @@ export function useMatchupVote(heroAId: string, heroBId: string): MatchupVoteSta
       trackEvent('matchup_vote', { authed: !!user });
       getVoterKey()
         .then((vk) => castMatchupVoteV2(heroAId, heroBId, picked, vk))
-        .then((t) => t && setTally(t))
+        .then((t) => {
+          if (t) setTally(t);
+          // Daily-streak calendar: counts only when this pair IS today's daily
+          // debate (the guard lives in the lib — this hook votes on any pair).
+          void recordDebateCompletionIfDaily(heroAId, heroBId);
+        })
         .catch(() => {});
     },
     [pickedId, user, key, heroAId, heroBId],

--- a/src/hooks/useTeamBattle.ts
+++ b/src/hooks/useTeamBattle.ts
@@ -13,6 +13,7 @@ import {
 import { getCachedTeamVerdict } from '../lib/db/teamVerdicts';
 import { generateTeamVerdict } from '../lib/api';
 import { resolveTeamBattle, type TeamSide, type TeamBattleResult } from '../lib/teamBattle';
+import { recordTeamBattleCompletionIfDaily } from '../lib/db/dailies';
 
 export interface UseTeamBattle {
   loading: boolean;
@@ -118,6 +119,9 @@ export function useTeamBattle(battleId?: string): UseTeamBattle {
       if (!b) return;
       const fresh = await castTeamBattleVote(b.aId, b.bId, teamId);
       if (fresh) qc.setQueryData(['teamTally', b.aId, b.bId], fresh);
+      // Daily-streak calendar: counts only when this pair IS today's battle
+      // (deep-linked/draft battles vote on arbitrary pairs — guard in the lib).
+      void recordTeamBattleCompletionIfDaily(b.aId, b.bId);
     },
     [b, qc],
   );

--- a/src/lib/db/dailies.ts
+++ b/src/lib/db/dailies.ts
@@ -1,0 +1,104 @@
+import { supabase } from '../supabase';
+import { getDailyDebate, todayIso } from './dailyDebate';
+import { getTodaysTeamBattle } from './teams';
+
+// Daily-streak plumbing (signed-in only). Completing ANY daily surface counts
+// the day; the server keeps the calendar (user_daily_completions) and computes
+// the streak (get_my_daily_streak). Logged-out users keep the local puzzle
+// streak — there is no cross-surface anon identity.
+
+export type DailySurface = 'puzzle' | 'debate' | 'team_battle';
+
+export interface DailyStreak {
+  current: number;
+  longest: number;
+  today: Record<DailySurface, boolean>;
+}
+
+const EMPTY: DailyStreak = {
+  current: 0,
+  longest: 0,
+  today: { puzzle: false, debate: false, team_battle: false },
+};
+
+/**
+ * Record a completion for TODAY (UTC — the server stamps current_date itself).
+ * Fire-and-forget: silently no-ops when logged out or on any failure; a missed
+ * write costs one day of streak, never breaks the surface that called it.
+ */
+export async function recordDailyCompletion(surface: DailySurface): Promise<void> {
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) return;
+    await supabase.rpc('record_daily_completion', { p_surface: surface });
+  } catch {
+    // never throw into a game/vote flow
+  }
+}
+
+/**
+ * Record a debate completion only if the voted pair IS today's daily debate —
+ * the vote hook is shared by every matchup surface (compare pages vote on
+ * arbitrary pairs), so the daily check lives here, against the cached
+ * daily_debate row. Pair order-insensitive (daily_debate stores a <= b).
+ */
+export async function recordDebateCompletionIfDaily(
+  heroAId: string,
+  heroBId: string,
+): Promise<void> {
+  try {
+    const today = await getDailyDebate(todayIso());
+    if (!today) return;
+    const voted = [heroAId, heroBId].sort();
+    const daily = [today.heroAId, today.heroBId].sort();
+    if (voted[0] === daily[0] && voted[1] === daily[1]) {
+      await recordDailyCompletion('debate');
+    }
+  } catch {
+    /* fire-and-forget */
+  }
+}
+
+/** Same guard for the team battle: only today's deterministic pair counts. */
+export async function recordTeamBattleCompletionIfDaily(
+  teamAId: string,
+  teamBId: string,
+): Promise<void> {
+  try {
+    const today = await getTodaysTeamBattle();
+    if (!today) return;
+    const voted = [teamAId, teamBId].sort();
+    const daily = [today.teamA.id, today.teamB.id].sort();
+    if (voted[0] === daily[0] && voted[1] === daily[1]) {
+      await recordDailyCompletion('team_battle');
+    }
+  } catch {
+    /* fire-and-forget */
+  }
+}
+
+/** The signed-in streak + today's per-surface completion. EMPTY when logged out/error. */
+export async function getMyDailyStreak(): Promise<DailyStreak> {
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) return EMPTY;
+    const { data, error } = await supabase.rpc('get_my_daily_streak');
+    if (error || !data) return EMPTY;
+    const json = data as unknown as DailyStreak;
+    return {
+      current: json.current ?? 0,
+      longest: json.longest ?? 0,
+      today: {
+        puzzle: json.today?.puzzle ?? false,
+        debate: json.today?.debate ?? false,
+        team_battle: json.today?.team_battle ?? false,
+      },
+    };
+  } catch {
+    return EMPTY;
+  }
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1918,6 +1918,27 @@ export type Database = {
         }
         Relationships: []
       }
+      user_daily_completions: {
+        Row: {
+          created_at: string
+          day: string
+          surface: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          day: string
+          surface: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          day?: string
+          surface?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_favourites: {
         Row: {
           created_at: string | null
@@ -2293,6 +2314,7 @@ export type Database = {
       }
       get_my_battle_record: { Args: never; Returns: Json }
       get_my_contributions: { Args: never; Returns: Json }
+      get_my_daily_streak: { Args: never; Returns: Json }
       get_my_taste_profile: { Args: never; Returns: Json }
       get_new_comics: {
         Args: {
@@ -2347,6 +2369,13 @@ export type Database = {
         }[]
       }
       get_source_coverage: { Args: never; Returns: Json }
+      get_streaks_at_risk: {
+        Args: { p_min?: number }
+        Returns: {
+          streak: number
+          user_id: string
+        }[]
+      }
       get_team_battle_tally: {
         Args: { p_a: string; p_b: string }
         Returns: Json
@@ -2491,6 +2520,10 @@ export type Database = {
       rebuild_hero_relationships: { Args: never; Returns: undefined }
       rebuild_teams: { Args: never; Returns: undefined }
       recompute_fame_scores: { Args: never; Returns: number }
+      record_daily_completion: {
+        Args: { p_surface: string }
+        Returns: undefined
+      }
       record_daily_result: {
         Args: { p_date: string; p_guesses: number; p_won: boolean }
         Returns: undefined

--- a/supabase/functions/send-daily-push/index.ts
+++ b/supabase/functions/send-daily-push/index.ts
@@ -62,6 +62,19 @@ Deno.serve(async () => {
       }
     }
 
+    // Streak-at-risk overrides beat the favourite line: a user whose daily
+    // streak (>=3) ended yesterday with nothing today gets the sharper nudge.
+    // Service-role-only RPC; empty map on any failure.
+    const streakByUser = new Map<string, number>();
+    try {
+      const { data: atRisk } = await supabase.rpc('get_streaks_at_risk', { p_min: 3 });
+      for (const r of (atRisk ?? []) as { user_id: string; streak: number }[]) {
+        streakByUser.set(r.user_id, r.streak);
+      }
+    } catch {
+      /* streak nudge is best-effort */
+    }
+
     const { data: subs } = await supabase
       .from('push_subscriptions')
       .select('id, user_id, endpoint, p256dh, auth');
@@ -71,11 +84,20 @@ Deno.serve(async () => {
     let pruned = 0;
     let failed = 0;
     for (const s of subs as SubRow[]) {
-      const payload = JSON.stringify({
-        title: favTitleByUser.get(s.user_id) ?? genericTitle,
-        body,
-        url: '/versus',
-      });
+      const atRiskStreak = streakByUser.get(s.user_id);
+      const payload = JSON.stringify(
+        atRiskStreak
+          ? {
+              title: `Your ${atRiskStreak}-day streak is on the line`,
+              body: 'Play any of today’s dailies to keep it alive',
+              url: '/versus',
+            }
+          : {
+              title: favTitleByUser.get(s.user_id) ?? genericTitle,
+              body,
+              url: '/versus',
+            },
+      );
       try {
         await webpush.sendNotification(
           { endpoint: s.endpoint, keys: { p256dh: s.p256dh, auth: s.auth } },

--- a/supabase/migrations/20260716090000_daily_streaks.sql
+++ b/supabase/migrations/20260716090000_daily_streaks.sql
@@ -1,0 +1,140 @@
+-- Daily streaks — the retention backbone tying the three daily surfaces
+-- (puzzle / daily debate vote / daily team-battle vote) into one per-user
+-- completion calendar and a streak. Completing ANY surface counts the day;
+-- a "perfect day" (all three) is left for a future badge.
+--
+-- Identity: signed-in only. Logged-out users keep the existing local-only
+-- puzzle streak (AsyncStorage) — there is no cross-surface anon identity
+-- (voter_key covers debate votes only), so the server calendar starts at auth.
+--
+-- Writes go through record_daily_completion() (SECURITY DEFINER, auth-required,
+-- always stamps the CURRENT UTC day — no backfilling). Honour-system on the
+-- puzzle, same posture as record_daily_result ("the puzzle is honour-system,
+-- not a server secret"). Reads via get_my_daily_streak(); the push cron uses
+-- get_streaks_at_risk() (service-role only) for the "streak on the line" nudge.
+
+create table if not exists public.user_daily_completions (
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  day        date not null,
+  surface    text not null check (surface in ('puzzle', 'debate', 'team_battle')),
+  created_at timestamptz not null default now(),
+  primary key (user_id, day, surface)
+);
+
+alter table public.user_daily_completions enable row level security;
+
+-- Own-row reads only ((select auth.uid()) = InitPlan form, per the RLS-initplan
+-- lesson). No insert/update/delete policies — writes are RPC-only.
+drop policy if exists udc_select on public.user_daily_completions;
+create policy udc_select on public.user_daily_completions
+  for select to authenticated using ((select auth.uid()) = user_id);
+
+revoke insert, update, delete on public.user_daily_completions from anon, authenticated;
+
+-- ── record_daily_completion ──────────────────────────────────────────────────
+create or replace function public.record_daily_completion(p_surface text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if auth.uid() is null then
+    raise exception 'not authenticated';
+  end if;
+  if p_surface not in ('puzzle', 'debate', 'team_battle') then
+    raise exception 'unknown surface %', p_surface;
+  end if;
+  insert into user_daily_completions (user_id, day, surface)
+  values (auth.uid(), current_date, p_surface)
+  on conflict (user_id, day, surface) do nothing;
+end;
+$function$;
+
+-- ── get_my_daily_streak ──────────────────────────────────────────────────────
+-- { current, longest, today: { puzzle, debate, team_battle } }
+-- `current` counts the consecutive-day island whose last day is today OR
+-- yesterday (the standard grace: today isn't over yet).
+create or replace function public.get_my_daily_streak()
+returns json
+language plpgsql
+stable
+security definer
+set search_path = public
+as $function$
+declare
+  v_uid uuid := auth.uid();
+  v_current int;
+  v_longest int;
+begin
+  if v_uid is null then
+    return json_build_object('current', 0, 'longest', 0,
+      'today', json_build_object('puzzle', false, 'debate', false, 'team_battle', false));
+  end if;
+
+  with days as (
+    select distinct day from user_daily_completions where user_id = v_uid
+  ), grp as (
+    select day, day - (row_number() over (order by day))::int as g from days
+  ), islands as (
+    select max(day) as fin, count(*)::int as len from grp group by g
+  )
+  select
+    coalesce((select len from islands where fin >= current_date - 1 order by fin desc limit 1), 0),
+    coalesce((select max(len) from islands), 0)
+  into v_current, v_longest;
+
+  return json_build_object(
+    'current', v_current,
+    'longest', v_longest,
+    'today', (select json_build_object(
+      'puzzle',      coalesce(bool_or(surface = 'puzzle'), false),
+      'debate',      coalesce(bool_or(surface = 'debate'), false),
+      'team_battle', coalesce(bool_or(surface = 'team_battle'), false)
+    ) from user_daily_completions
+      where user_id = v_uid and day = current_date)
+  );
+end;
+$function$;
+
+-- ── get_streaks_at_risk ──────────────────────────────────────────────────────
+-- Users whose streak island ends EXACTLY yesterday (nothing yet today) with
+-- length >= p_min — the "streak on the line" push audience. Service-role only
+-- (called by the send-daily-push cron); never client-visible.
+create or replace function public.get_streaks_at_risk(p_min integer default 3)
+returns table (user_id uuid, streak integer)
+language sql
+stable
+security definer
+set search_path = public
+as $function$
+  with days as (
+    select distinct udc.user_id, udc.day from user_daily_completions udc
+  ), grp as (
+    select days.user_id, days.day,
+           days.day - (row_number() over (partition by days.user_id order by days.day))::int as g
+    from days
+  ), islands as (
+    select grp.user_id, max(grp.day) as fin, count(*)::int as len
+    from grp group by grp.user_id, grp.g
+  )
+  select islands.user_id, islands.len
+  from islands
+  where islands.fin = current_date - 1 and islands.len >= greatest(p_min, 1);
+$function$;
+
+-- Grants: recorder + reader for signed-in users; at-risk sweep for the cron only.
+do $$
+declare f text;
+begin
+  foreach f in array array[
+    'public.record_daily_completion(text)',
+    'public.get_my_daily_streak()'
+  ]
+  loop
+    execute format('revoke all on function %s from public, anon;', f);
+    execute format('grant execute on function %s to authenticated, service_role;', f);
+  end loop;
+  revoke all on function public.get_streaks_at_risk(integer) from public, anon, authenticated;
+  grant execute on function public.get_streaks_at_risk(integer) to service_role;
+end $$;


### PR DESCRIPTION
Program **#3** of the improvement batch — the compounding retention mechanic. Completing **any** daily surface (Guess-the-Hero puzzle, daily debate vote, daily team-battle vote) counts the UTC day toward one signed-in streak.

## Server (migration applied to prod via MCP)
- **`user_daily_completions`** — per-user daily calendar (RLS select-own, initplan `auth.uid()`; writes RPC-only).
- **`record_daily_completion(surface)`** — auth-required, always stamps `current_date` (no backfilling). Honour-system on the puzzle, matching `record_daily_result`'s existing posture.
- **`get_my_daily_streak()`** — `{current, longest, today{...}}`; `current` counts the consecutive-day island ending today **or yesterday** (grace — today isn't over). **Verified with synthetic data** (current 4 / longest 5 / per-surface today map; rolled back).
- **`get_streaks_at_risk(min)`** — service-role only: islands ending exactly yesterday with length ≥ min. Verified.

## Recording — three call sites, all fire-and-forget
- **Puzzle**: `useDailyHero` on win *or* lose (playing counts).
- **Debate**: `useMatchupVote` after a successful cast — with a lib guard so only the pair that **is** today's `daily_debate` counts (the hook votes on arbitrary compare pairs).
- **Team battle**: `useTeamBattle.vote` — same guard vs today's deterministic pair (drafts/deep links don't count).

No-ops when logged out; never throws into a game/vote flow. **Logged-out users keep the existing local puzzle streak** — there's no cross-surface anon identity (research: voter_key covers debate only), so the server calendar starts at sign-in. `useDailyStreak` now returns `max(local, server)` so nobody's number visually drops on upgrade.

## UI — Today's Dailies hub
New shared strip on the **versus stage (web + native)**: streak flame ("N-day streak" / "Start a streak"), the three surfaces as chips with green done-checks + `2/3 done`, each launching its daily. Ink-surface styling per the constant-ink rules. The Explore banner's existing streak pill inherits the unified number automatically.

## Push — "streak on the line"
`send-daily-push` **v2 redeployed** (smoke-tested, still inert until VAPID keys): users with a streak ≥ 3 that ended yesterday and nothing today get *"Your N-day streak is on the line"*, overriding the favourite/generic title.

## Verification
tsc clean (0 non-drift) · **727 tests pass** (+9 dailies tests incl. order-insensitive daily-pair guard + non-daily rejection) · eslint clean · `expo export -p web` OK · migration + function verified live with synthetic data (rolled back).

## Follow-up candidates (not in this PR)
Perfect-day badge (all 3 in one day) · profile streak tile switch-over · a second later-in-day cron for the at-risk nudge (currently rides the 15:00 UTC send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)