### PR TITLE
feat(explore): "Picked For You" — discovery personalization row

### DIFF
--- a/__tests__/lib/db/forYou.test.ts
+++ b/__tests__/lib/db/forYou.test.ts
@@ -1,0 +1,32 @@
+import { getForYou } from '../../../src/lib/db/forYou';
+
+const mockRpc = jest.fn();
+
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: { rpc: (...args: unknown[]) => mockRpc(...args) },
+}));
+
+beforeEach(() => mockRpc.mockReset());
+
+describe('getForYou', () => {
+  it('passes the limit and returns the rows', async () => {
+    const rows = [
+      { id: '346', name: 'Iron Man', image_url: 'i.jpg', portrait_url: 'p.png' },
+      { id: '226', name: 'Doctor Strange', image_url: null, portrait_url: 'q.png' },
+    ];
+    mockRpc.mockResolvedValue({ data: rows, error: null });
+    await expect(getForYou(12)).resolves.toEqual(rows);
+    expect(mockRpc).toHaveBeenCalledWith('get_my_for_you', { p_limit: 12 });
+  });
+
+  it('defaults the limit to 20', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+    await getForYou();
+    expect(mockRpc).toHaveBeenCalledWith('get_my_for_you', { p_limit: 20 });
+  });
+
+  it('returns [] on error (the row simply hides)', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(getForYou()).resolves.toEqual([]);
+  });
+});

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -67,6 +67,7 @@ type FeedRow =
   | { type: 'daily' }
   | { type: 'ticker'; heroCount: number; newlyAddedCount: number }
   | { type: 'recent'; heroes: RowHero[] }
+  | { type: 'foryou'; heroes: RowHero[] }
   | { type: 'favourites'; heroes: RowHero[] }
   | {
       type: 'rightnow';
@@ -135,6 +136,7 @@ export default function HomeScreen() {
     rivalries,
     recentlyViewed,
     favourites,
+    forYou,
     browseCovers,
   } = useExploreData();
   const spotlight = spotlightAll.slice(0, SPOTLIGHT_POOL);
@@ -258,6 +260,8 @@ export default function HomeScreen() {
     }
     if (recentlyViewed.length > 0)
       out.push({ type: 'recent', heroes: recentlyViewed.map(toRowHero) });
+    // Discovery: characters you haven't engaged with yet (taste + graph).
+    if (forYou.length > 0) out.push({ type: 'foryou', heroes: forYou.map(toRowHero) });
 
     // The Library — an authored canon feature, then the browse grid (the map that
     // replaces the old wall of category rails), then the one fresh rail.
@@ -288,6 +292,7 @@ export default function HomeScreen() {
     heroCount,
     recentlyViewed,
     favourites,
+    forYou,
     iconic,
     onScreen,
     comingSoon,
@@ -362,6 +367,16 @@ export default function HomeScreen() {
                 title="Recently Viewed"
                 heroes={item.heroes}
                 variant="thumb"
+                onPress={handlePress}
+                disabled={navigating}
+              />
+            );
+          case 'foryou':
+            return (
+              <HomeHeroRow
+                label="Discover"
+                title="Picked For You"
+                heroes={item.heroes}
                 onPress={handlePress}
                 disabled={navigating}
               />

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -1274,7 +1274,7 @@ export default function WebHomeScreen() {
   // Shared, platform-neutral data layer (see useExploreData). Web keeps reading
   // rows via `homeData.*`; these aliases preserve the existing render references.
   const homeData = useExploreData();
-  const { recentlyViewed, favourites } = homeData;
+  const { recentlyViewed, favourites, forYou } = homeData;
   const homeStarted = homeData.started;
   const totalHeroCount = homeData.heroCount;
   const handlePress = useCallback(
@@ -1416,6 +1416,14 @@ export default function WebHomeScreen() {
                 heroes={recentlyViewed}
                 onPress={handlePress}
               />
+            </Reveal>
+
+            {/* ── Picked For You — DISCOVERY: characters you haven't engaged
+                 with yet, from your favourites' relationship graph + taste
+                 affinity (get_my_for_you). Hidden when logged out / signal-less
+                 (HomeRow nulls on empty). ─────────────────────────────────── */}
+            <Reveal>
+              <HomeRow label="Discover" title="Picked For You" heroes={forYou} onPress={handlePress} />
             </Reveal>
 
             {/* ── Hall of Fame — Most Iconic, authored: a chosen #1 + ranked list

--- a/src/lib/db/forYou.ts
+++ b/src/lib/db/forYou.ts
@@ -1,0 +1,16 @@
+import { supabase } from '../supabase';
+import type { FavouriteHero } from '../../types';
+
+// "Picked For You" — the discovery row (see migration 20260716100000). The
+// get_my_for_you RPC blends graph neighbors of your recent favourites with
+// taste-affinity (franchise/publisher) picks, EXCLUDING everything you've
+// already favourited or viewed. Identity is auth.uid() server-side; logged out
+// (or signal-less) it returns [] and the row hides.
+export async function getForYou(limit = 20): Promise<FavouriteHero[]> {
+  const { data, error } = await supabase.rpc('get_my_for_you', { p_limit: limit });
+  if (error) {
+    console.warn('[getForYou] error:', error.message);
+    return [];
+  }
+  return (data ?? []) as FavouriteHero[];
+}

--- a/src/lib/query/exploreQueries.ts
+++ b/src/lib/query/exploreQueries.ts
@@ -9,6 +9,7 @@ import {
 } from '../db/heroes';
 import { fetchExploreBundle, type ExploreBundle } from '../db/exploreBundle';
 import { getUserFavouriteHeroes } from '../db/favourites';
+import { getForYou } from '../db/forYou';
 import {
   getTrendingForUser,
   synthesizeCampaignFromPool,
@@ -62,6 +63,8 @@ export interface ExploreData {
   trendingForUser: TrendingTitleCharacter[];
   recentlyViewed: FavouriteHero[];
   favourites: FavouriteHero[];
+  /** Discovery: characters you HAVEN'T engaged with, from taste + graph. */
+  forYou: FavouriteHero[];
 }
 
 // Stable empty-array identity for the field fallbacks below, so the memoised
@@ -149,6 +152,11 @@ export function useExploreData(): ExploreData {
     queryFn: () => getTrendingForUser(userId!),
     enabled: !!userId,
   });
+  const forYou = useQuery({
+    queryKey: exploreKeys.forYou(userId ?? ''),
+    queryFn: () => getForYou(),
+    enabled: !!userId,
+  });
 
   // `started` flips once the bundle settles — either it has data (fresh or
   // cached) or its retries were exhausted. Either way the skeleton clears; a
@@ -176,6 +184,7 @@ export function useExploreData(): ExploreData {
       trendingForUser: userId ? (trendingForUser.data ?? EMPTY) : EMPTY,
       recentlyViewed: userId ? (recentlyViewed.data ?? EMPTY) : EMPTY,
       favourites: userId ? (favourites.data ?? EMPTY) : EMPTY,
+      forYou: userId ? (forYou.data ?? EMPTY) : EMPTY,
     }),
     [
       started,
@@ -189,6 +198,7 @@ export function useExploreData(): ExploreData {
       trendingForUser.data,
       recentlyViewed.data,
       favourites.data,
+      forYou.data,
     ],
   );
 }

--- a/src/lib/query/keys.ts
+++ b/src/lib/query/keys.ts
@@ -51,6 +51,7 @@ export const exploreKeys = {
   recentlyViewed: (userId: string) => ['explore', 'recentlyViewed', userId] as const,
   favourites: (userId: string) => ['explore', 'favourites', userId] as const,
   trendingForUser: (userId: string) => ['explore', 'trendingForUser', userId] as const,
+  forYou: (userId: string) => ['explore', 'forYou', userId] as const,
 };
 
 // Title (film/TV/game) detail-screen keys, under a 'titles' root so the whole

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1918,6 +1918,27 @@ export type Database = {
         }
         Relationships: []
       }
+      user_daily_completions: {
+        Row: {
+          created_at: string
+          day: string
+          surface: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          day: string
+          surface: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          day?: string
+          surface?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_favourites: {
         Row: {
           created_at: string | null
@@ -2293,6 +2314,16 @@ export type Database = {
       }
       get_my_battle_record: { Args: never; Returns: Json }
       get_my_contributions: { Args: never; Returns: Json }
+      get_my_daily_streak: { Args: never; Returns: Json }
+      get_my_for_you: {
+        Args: { p_limit?: number }
+        Returns: {
+          id: string
+          image_url: string
+          name: string
+          portrait_url: string
+        }[]
+      }
       get_my_taste_profile: { Args: never; Returns: Json }
       get_new_comics: {
         Args: {
@@ -2347,6 +2378,13 @@ export type Database = {
         }[]
       }
       get_source_coverage: { Args: never; Returns: Json }
+      get_streaks_at_risk: {
+        Args: { p_min?: number }
+        Returns: {
+          streak: number
+          user_id: string
+        }[]
+      }
       get_team_battle_tally: {
         Args: { p_a: string; p_b: string }
         Returns: Json
@@ -2491,6 +2529,10 @@ export type Database = {
       rebuild_hero_relationships: { Args: never; Returns: undefined }
       rebuild_teams: { Args: never; Returns: undefined }
       recompute_fame_scores: { Args: never; Returns: number }
+      record_daily_completion: {
+        Args: { p_surface: string }
+        Returns: undefined
+      }
       record_daily_result: {
         Args: { p_date: string; p_guesses: number; p_won: boolean }
         Returns: undefined

--- a/supabase/migrations/20260716100000_get_my_for_you.sql
+++ b/supabase/migrations/20260716100000_get_my_for_you.sql
@@ -1,0 +1,77 @@
+-- "Picked For You" — the DISCOVERY personalization row (program #4). Explore's
+-- existing personalized rows all resurface what you've already touched (Jump
+-- Back In = views, Your Favourites = saves, In Your Universe = trending ∩
+-- taste); this one recommends characters you HAVEN'T engaged with yet:
+--
+--   graph : allies/enemies of your most recent favourites (hero_relationships,
+--           rank-indexed + fame-gated), weighted by inverse rank — "people who
+--           love Batman get Nightwing/Bane before deep cuts".
+--   taste : recognizable (fame >= 40) heroes from your top franchises and
+--           publishers, weighted by your engagement (favourite=3, view=1 — the
+--           same 3:1 blend get_my_taste_profile uses).
+--
+-- Everything you've favourited OR viewed is excluded, a portrait is required
+-- (this row sells discovery visually), and the caller identity comes from
+-- auth.uid() — SECURITY DEFINER so the per-user RLS tables join to the RLS-free
+-- catalog without the planner trap. Logged out ⇒ empty set.
+create or replace function public.get_my_for_you(p_limit integer default 20)
+returns table (id text, name text, image_url text, portrait_url text)
+language sql
+stable
+security definer
+set search_path = public
+as $function$
+  with engaged as (
+    select hero_id, 3 as w from user_favourites where user_id = auth.uid()
+    union all
+    select hero_id, 1 as w from user_view_history where user_id = auth.uid()
+  ),
+  top_favs as (
+    select hero_id from user_favourites
+    where user_id = auth.uid()
+    order by created_at desc
+    limit 8
+  ),
+  graph as (
+    select r.related_id as hero_id, sum(3.0 / (r.rank + 2)) as score
+    from hero_relationships r
+    join top_favs f on f.hero_id = r.hero_id
+    where r.kind in ('ally', 'enemy') and r.rank <= 12
+    group by r.related_id
+  ),
+  aff as (
+    select h.publisher, h.franchise, sum(e.w)::numeric as w
+    from engaged e
+    join heroes h on h.id = e.hero_id
+    where h.publisher is not null or h.franchise is not null
+    group by h.publisher, h.franchise
+  ),
+  taste as (
+    select h.id as hero_id, max(a.w) * 0.15 as score
+    from aff a
+    join heroes h
+      on (a.franchise is not null and h.franchise = a.franchise)
+      or (a.publisher is not null and h.publisher = a.publisher)
+    where h.fame_score >= 40
+    group by h.id
+  ),
+  cand as (
+    select u.hero_id, sum(u.score) as score
+    from (select * from graph union all select * from taste) u
+    group by u.hero_id
+  )
+  select h.id, h.name, h.image_url, h.portrait_url
+  from cand c
+  join heroes h on h.id = c.hero_id
+  where not exists (select 1 from engaged e where e.hero_id = c.hero_id)
+    and h.portrait_url is not null
+    and coalesce(h.fame_score, 0) >= 20
+  order by c.score desc, h.fame_score desc nulls last
+  limit greatest(least(p_limit, 40), 1);
+$function$;
+
+do $$
+begin
+  revoke all on function public.get_my_for_you(integer) from public, anon;
+  grant execute on function public.get_my_for_you(integer) to authenticated, service_role;
+end $$;


### PR DESCRIPTION
Program **#4** of the improvement batch. Explore's personalized rows all resurface what you've already touched (Jump Back In = views, Your Favourites = saves, In Your Universe = trending ∩ taste). This adds the missing **discovery** dimension: *characters you haven't engaged with yet*, picked from your taste + your favourites' relationship graph.

## Server — `get_my_for_you(p_limit)` (migration applied to prod via MCP)
Two signal sources, blended and deduped:
- **Graph**: allies/enemies of your 8 most recent favourites (`hero_relationships`, rank ≤ 12, inverse-rank weighted) — *love Batman → get Nightwing/Bane before deep cuts*.
- **Taste**: recognizable (fame ≥ 40) heroes from your top franchises/publishers, weighted by the same favourite=3 / view=1 blend `get_my_taste_profile` uses.

**Excludes everything you've favourited or viewed**, requires a portrait (the row sells discovery visually), fame floor 20. `SECURITY DEFINER` (per-user RLS tables join the RLS-free catalog — the planner lesson), identity from `auth.uid()`, logged out ⇒ empty.

**Verified live** on the heaviest real user: high-quality picks (Iron Man, Doctor Strange, Jean Grey, Kitty Pryde…), **81 ms** EXPLAIN ANALYZE, all shared-buffer hits — far inside the 3 s timeout.

## Client
- `src/lib/db/forYou.ts` — the RPC's row shape **is** `FavouriteHero`, so no adapter; rides the standard user-keyed `enabled: !!userId` query pattern (`exploreKeys.forYou`).
- **Web**: `HomeRow label="Discover" title="Picked For You"` directly after Jump Back In; hides on empty/logged-out (HomeRow nulls).
- **Native**: new `'foryou'` feed section + `HomeHeroRow`, same position.

## Verification
tsc clean (0 non-drift) · **721 tests pass** (+3 lib tests) · eslint clean · `expo export -p web` OK · RPC verified live with real user data + EXPLAIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)