### PR TITLE
feat(support): supporter tier (recognition, no paywall) + ads decision revised

### DIFF
--- a/__tests__/lib/profile/badges.test.ts
+++ b/__tests__/lib/profile/badges.test.ts
@@ -19,6 +19,12 @@ describe('computeBadges', () => {
     expect(find({ accountCreatedAt: null }, 'day-one').earned).toBe(false);
   });
 
+  it('earns Supporter only from the stored flag (and defaults locked)', () => {
+    expect(find({ isSupporter: true }, 'supporter').earned).toBe(true);
+    expect(find({ isSupporter: false }, 'supporter').earned).toBe(false);
+    expect(find({}, 'supporter').earned).toBe(false); // omitted → locked
+  });
+
   it('earns Veteran only after 180 days of tenure', () => {
     expect(find({ accountCreatedAt: '2026-06-01T00:00:00Z' }, 'veteran').earned).toBe(false);
     expect(find({ accountCreatedAt: '2025-01-01T00:00:00Z' }, 'veteran').earned).toBe(true);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -360,6 +360,7 @@ export default function ProfileScreen() {
     votes: battle?.total ?? 0,
     streak: battle?.streak ?? 0,
     topPublisher: taste?.publishers[0]?.name ?? null,
+    isSupporter: profile?.is_supporter ?? false,
   });
   const badgesEarned = earnedCount(badges);
 
@@ -915,7 +916,7 @@ export default function ProfileScreen() {
       {universeCard}
       <Toast message={toast.message} visible={toast.visible} />
       <DonateNudge
-        visible={nudge.visible}
+        visible={nudge.visible && !profile?.is_supporter}
         onConvert={nudge.onConvert}
         onDismiss={nudge.onDismiss}
       />

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -372,6 +372,7 @@ export default function WebProfileScreen() {
     votes: battle?.total ?? 0,
     streak: battle?.streak ?? 0,
     topPublisher: taste?.publishers[0]?.name ?? null,
+    isSupporter: profile?.is_supporter ?? false,
   });
   const badgesEarned = earnedCount(badges);
 
@@ -889,7 +890,7 @@ export default function WebProfileScreen() {
         {universeCard}
         <Toast message={toast.message} visible={toast.visible} />
         <DonateNudge
-          visible={nudge.visible}
+          visible={nudge.visible && !profile?.is_supporter}
           onConvert={nudge.onConvert}
           onDismiss={nudge.onDismiss}
         />
@@ -1271,7 +1272,7 @@ export default function WebProfileScreen() {
       {universeCard}
       <Toast message={toast.message} visible={toast.visible} />
       <DonateNudge
-        visible={nudge.visible}
+        visible={nudge.visible && !profile?.is_supporter}
         onConvert={nudge.onConvert}
         onDismiss={nudge.onDismiss}
       />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -187,9 +187,22 @@ export default function SettingsScreen() {
         )}
 
         <SectionShell title="Support">
-          <Text style={styles.supportBlurb}>
-            Mythique is a free, unofficial fan project. If you enjoy it, a coffee keeps it going.
-          </Text>
+          {profile?.is_supporter ? (
+            <SettingRow
+              icon="star"
+              label="You’re a supporter — thank you"
+              value={
+                profile.supporter_since
+                  ? `since ${new Date(profile.supporter_since).toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' })}`
+                  : undefined
+              }
+              tone="orange"
+            />
+          ) : (
+            <Text style={styles.supportBlurb}>
+              Mythique is a free, unofficial fan project. If you enjoy it, a coffee keeps it going.
+            </Text>
+          )}
           <SettingRow
             icon="information-circle-outline"
             label="About supporting"

--- a/app/settings.web.tsx
+++ b/app/settings.web.tsx
@@ -246,9 +246,22 @@ export default function WebSettingsScreen() {
         )}
 
         <SectionShell title="Support">
-          <Text style={styles.supportBlurb}>
-            Mythique is a free, unofficial fan project. If you enjoy it, a coffee keeps it going.
-          </Text>
+          {profile?.is_supporter ? (
+            <SettingRow
+              icon="star"
+              label="You’re a supporter — thank you"
+              value={
+                profile.supporter_since
+                  ? `since ${new Date(profile.supporter_since).toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' })}`
+                  : undefined
+              }
+              tone="orange"
+            />
+          ) : (
+            <Text style={styles.supportBlurb}>
+              Mythique is a free, unofficial fan project. If you enjoy it, a coffee keeps it going.
+            </Text>
+          )}
           <SettingRow
             icon="information-circle-outline"
             label="About supporting"

--- a/docs/superpowers/specs/2026-07-16-monetization-options.md
+++ b/docs/superpowers/specs/2026-07-16-monetization-options.md
@@ -1,6 +1,7 @@
 # Monetization — options + recommendation (decision doc)
 
-**Status:** awaiting owner decision. No code until a direction is picked.
+**Status:** DECIDED 2026-07-16 — Option A (supporter tier) green-lit and built;
+ads revised from "never" to scale-gated (see C). Affiliate (B) still open.
 **Grounding:** repo research 2026-07-16 (donation surfacing, ad-safety specs,
 cost instrumentation, legal copy, outbound-link inventory).
 
@@ -52,25 +53,55 @@ so "adding a partner is one entry."
 - **Constraint:** honors "ad-free" (affiliate ≠ ads) but weakens "fan project,
   not monetised" copy → update the Support screen wording honestly.
 
-### C. Ads (recommend against, now and probably ever)
-Directly contradicts the shipped "free & ad-free" promise in three places,
-requires a Privacy Policy rewrite (ad networks = cross-site tracking), degrades
-the award-pass design language, and — most importantly — converts the app into
-a commercial exploitation of third-party characters, the exact thing the
-non-commercial framing protects against. The revenue at current traffic
-(~hundreds of sessions/day) would be trivially small anyway.
+### C. Ads (revised 2026-07-16: not "never" — scale-gated "not yet")
 
-## Recommendation
+**The math decides this, not principle.** At today's ~11.5k pageviews/month,
+realistic display RPM ($1–5) yields **$12–60/month** — four $3 Ko-fi supporters
+beat the whole program, while costing trust, a privacy rewrite, and design
+damage. The equation only flips at scale:
 
-**A now, B when traffic justifies the paperwork, C never (revisit only if the
-model fundamentally changes).** A is a weekend-sized PR that starts the revenue
-learning loop without breaking a single promise; B layers on cleanly once
-there's enough click volume for affiliate payouts to matter.
+| Scale | Monthly ad revenue (realistic) |
+| --- | --- |
+| today (~11.5k pv/mo) | $12–60 |
+| 100k pv/mo | $100–500 |
+| 1M pv/mo | $1,000–5,000 |
 
-## Decision needed from the owner
+**Steelman (what "never" got wrong):** ad-funded fan encyclopedias are the
+industry norm (Fandom), ads are the only revenue that scales automatically with
+the SEO strategy, and they monetize the anonymous long-tail visitor who will
+never sign in or donate. **Counterweights that still win today:** "the clean,
+ad-free alternative to Fandom" is Mythique's sharpest positioning wedge (Fandom
+is *hated* for ad bloat); the non-commercial framing is the solo project's one
+cheap IP-defense card; and programmatic creative next to the award-pass design
+is self-harm.
 
-1. Green-light **A** (supporter tier) as specced? → I build it.
-2. Green-light **B** now, later, or never? (If now: which programs — Amazon?
-   JustWatch?)
-3. Confirm **C** is off the table so the "ad-free" promise can be treated as
-   load-bearing in future design decisions.
+**The tasteful playbook, if/when the gate (~250–500k pv/mo) is reached:**
+1. **Sponsorship, not programmatic.** One "Sponsor" card per page max, styled
+   as a native feed card with a `SPONSOR` eyebrow. Never sticky/interstitial/
+   autoplay/mid-article. Hard ban on AdSense/AdMob-class networks.
+2. **Direct + contextual, zero tracking** (direct-sold comic/collectible/
+   streaming sponsors, or privacy-first contextual networks) — no cookies, no
+   consent banner, minimal privacy-policy delta.
+3. **Placement bans:** character-page top viewport, the dailies/games, the
+   compare arena.
+4. **Supporters see none** — makes the tier materially valuable and reframes
+   the promise as "free, and sponsor-free for supporters".
+5. **House-ads first:** the SponsorCard slot can ship early filled with house
+   content (TikTok/Ko-fi/daily game promos) — free optionality, no promise
+   broken.
+6. **Honest copy migration** — update the three "ad-free" surfaces BEFORE the
+   first sponsor renders, with the why.
+
+## Recommendation (updated after decision)
+
+**A shipped. B when traffic justifies the paperwork. C behind a hard traffic
+gate (~250–500k pv/mo), and then only as the sponsorship playbook above —
+programmatic never.** Until the gate, "ad-free" remains load-bearing copy and a
+deliberate competitive wedge.
+
+## Decision log
+
+- 2026-07-16 — Owner green-lit **A** (built: `is_supporter` flag +
+  `admin_set_supporter` RPC, Supporter badge, settings thank-you, donation-nudge
+  suppression). Ads revised to scale-gated per analysis above. **B remains
+  open** (owner to pick programs when ready).

--- a/src/lib/db/profiles.ts
+++ b/src/lib/db/profiles.ts
@@ -10,6 +10,9 @@ export interface UserProfile {
   cover_url: string | null;
   created_at: string | null;
   is_admin: boolean | null;
+  /** Ko-fi supporter recognition flag (admin-set; see admin_set_supporter). */
+  is_supporter: boolean | null;
+  supporter_since: string | null;
 }
 
 export async function getProfile(userId: string): Promise<UserProfile | null> {

--- a/src/lib/profile/badges.ts
+++ b/src/lib/profile/badges.ts
@@ -14,6 +14,9 @@ export interface BadgeInput {
   streak: number;
   /** Short top-publisher name from the taste profile, or null. */
   topPublisher: string | null;
+  /** user_profiles.is_supporter — the one stored-flag badge (Ko-fi supporters,
+   *  set by an admin). Optional so older call sites/tests need no change. */
+  isSupporter?: boolean;
 }
 
 export interface Badge {
@@ -50,10 +53,17 @@ function loyaltyLabel(pub: string | null): string {
  * `now` is injectable so tenure badges are deterministic in tests.
  */
 export function computeBadges(input: BadgeInput, now: number = Date.now()): Badge[] {
-  const { accountCreatedAt, favourites, votes, streak, topPublisher } = input;
+  const { accountCreatedAt, favourites, votes, streak, topPublisher, isSupporter } = input;
   const days = tenureDays(accountCreatedAt, now);
 
   const badges: Badge[] = [
+    {
+      id: 'supporter',
+      label: 'Supporter',
+      description: 'Keeps Mythique free for everyone',
+      icon: 'star',
+      earned: !!isSupporter,
+    },
     {
       id: 'day-one',
       label: 'Day One',

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1976,7 +1976,9 @@ export type Database = {
           display_name: string | null
           id: string
           is_admin: boolean
+          is_supporter: boolean
           last_seen_at: string | null
+          supporter_since: string | null
         }
         Insert: {
           avatar_url?: string | null
@@ -1985,7 +1987,9 @@ export type Database = {
           display_name?: string | null
           id: string
           is_admin?: boolean
+          is_supporter?: boolean
           last_seen_at?: string | null
+          supporter_since?: string | null
         }
         Update: {
           avatar_url?: string | null
@@ -1994,7 +1998,9 @@ export type Database = {
           display_name?: string | null
           id?: string
           is_admin?: boolean
+          is_supporter?: boolean
           last_seen_at?: string | null
+          supporter_since?: string | null
         }
         Relationships: []
       }
@@ -2127,6 +2133,10 @@ export type Database = {
         Returns: undefined
       }
       admin_set_drain_cron: { Args: { p_enabled: boolean }; Returns: string }
+      admin_set_supporter: {
+        Args: { p_on: boolean; p_user_id: string }
+        Returns: undefined
+      }
       admin_set_universe: {
         Args: { p_hero_id: string; p_publisher: string }
         Returns: Json

--- a/supabase/migrations/20260716110000_supporter_tier.sql
+++ b/supabase/migrations/20260716110000_supporter_tier.sql
@@ -1,0 +1,35 @@
+-- Supporter tier (monetization option A — see
+-- docs/superpowers/specs/2026-07-16-monetization-options.md). Recognition-based,
+-- Ko-fi-powered, NO paywall: a stored flag on user_profiles (the is_admin
+-- additive pattern), surfaced as a badge + settings thank-you, and used to
+-- suppress donation nudges for people who already gave. Set manually by an
+-- admin from Ko-fi receipts at current scale (webhook automation later).
+
+alter table public.user_profiles
+  add column if not exists is_supporter boolean not null default false;
+alter table public.user_profiles
+  add column if not exists supporter_since timestamptz;
+
+-- Admin-only toggle, following the resolve_hero_qid SECURITY DEFINER template.
+create or replace function public.admin_set_supporter(p_user_id uuid, p_on boolean)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+begin
+  if not exists (select 1 from user_profiles where id = auth.uid() and is_admin) then
+    raise exception 'not authorized';
+  end if;
+  update public.user_profiles
+     set is_supporter = p_on,
+         supporter_since = case when p_on then coalesce(supporter_since, now()) else null end
+   where id = p_user_id;
+end;
+$function$;
+
+do $$
+begin
+  revoke all on function public.admin_set_supporter(uuid, boolean) from public, anon;
+  grant execute on function public.admin_set_supporter(uuid, boolean) to authenticated, service_role;
+end $$;


### PR DESCRIPTION
Monetization **option A** as green-lit, plus the decision doc updated with the full ads think-through.

## Supporter tier — recognition, zero paywall
- **Server** (migration applied to prod via MCP): `user_profiles.is_supporter` + `supporter_since` (the `is_admin` additive pattern) and `admin_set_supporter(user_id, on)` — SECURITY DEFINER, admin-guarded; `supporter_since` sticks from first enable. Set manually from Ko-fi receipts at current scale (webhook automation later).
- **Supporter badge** in the profile badges wall — the first stored-flag badge. Its *locked* state ("Supporter — Keeps Mythique free for everyone") doubles as a quiet, tasteful discovery path to Ko-fi. Optional `BadgeInput.isSupporter` keeps every existing call site/test untouched.
- **Settings thank-you** (web + native): supporters see "You're a supporter — thank you · since Jul 2026" in place of the donation blurb.
- **DonateNudge suppressed** for supporters at all 3 render sites — people who already gave stop being asked. (This also pre-wires the future "supporters see no sponsors" perk.)

Every shipped promise holds: no paywall, no ads, nothing gated.

## Ads decision — revised from "never" to scale-gated
The doc now carries the honest math: at today's ~11.5k pv/month, display ads earn **$12–60/month** — four $3 supporters beat the whole program — while spending Mythique's sharpest wedge ("the clean alternative to Fandom") and its non-commercial IP posture. The Fandom steelman is acknowledged (ad-funded fan encyclopedias are the norm; ads scale automatically with SEO). Verdict: **hard traffic gate (~250–500k pv/mo)**, and then only the tasteful sponsorship playbook (one native sponsor card, direct + contextual zero-tracking only, placement bans, supporters exempt, programmatic never). Decision log added.

## Verification
tsc clean (0 non-drift) · **731 tests pass** (+1 supporter badge case) · eslint clean · `expo export -p web` OK · migration + RPC live in prod.

## To flag someone as a supporter (until an admin UI lands)
As an admin, run: `select admin_set_supporter('<user-uuid>', true);`

🤖 Generated with [Claude Code](https://claude.com/claude-code)