### PR TITLE
feat(growth): the sponsor slot — house-filled, placement-disciplined, supporter-exempt

### DIFF
--- a/__tests__/lib/sponsor/houseAds.test.ts
+++ b/__tests__/lib/sponsor/houseAds.test.ts
@@ -1,0 +1,38 @@
+import { HOUSE_PROMOS, promoForDay, utcDayIndex } from '../../../src/lib/sponsor/houseAds';
+
+describe('house promo rotation', () => {
+  it('is deterministic for a given UTC day', () => {
+    const d = new Date('2026-07-16T10:00:00Z');
+    expect(promoForDay(d)).toBe(promoForDay(new Date('2026-07-16T23:59:59Z')));
+  });
+
+  it('rotates to a different creative the next UTC day', () => {
+    const today = promoForDay(new Date('2026-07-16T12:00:00Z'));
+    const tomorrow = promoForDay(new Date('2026-07-17T12:00:00Z'));
+    expect(tomorrow).not.toBe(today);
+  });
+
+  it('cycles through every creative across consecutive days', () => {
+    const seen = new Set(
+      Array.from({ length: HOUSE_PROMOS.length }, (_, i) =>
+        promoForDay(new Date(Date.UTC(2026, 6, 16 + i))),
+      ),
+    );
+    expect(seen.size).toBe(HOUSE_PROMOS.length);
+  });
+
+  it('uses the UTC calendar (same convention as the dailies)', () => {
+    // 23:30 UTC and 00:30 UTC next day are different rotation days regardless
+    // of any local timezone.
+    expect(utcDayIndex(new Date('2026-07-16T23:30:00Z'))).toBe(
+      utcDayIndex(new Date('2026-07-16T00:30:00Z')),
+    );
+    expect(utcDayIndex(new Date('2026-07-17T00:30:00Z'))).toBe(
+      utcDayIndex(new Date('2026-07-16T23:30:00Z')) + 1,
+    );
+  });
+
+  it('house creatives are honestly labeled — never "Sponsor"', () => {
+    for (const p of HOUSE_PROMOS) expect(p.eyebrow).toBe('From Mythique');
+  });
+});

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -49,6 +49,7 @@ import { CategoryPodGrid, BROWSE_PODS } from '../../src/components/home/Category
 import { PublisherGrid } from '../../src/components/home/PublisherGrid';
 import { PulseTicker } from '../../src/components/home/PulseTicker';
 import { DailyChallengeBanner } from '../../src/components/game/DailyChallengeBanner';
+import { SponsorSlot } from '../../src/components/SponsorSlot';
 import { useExploreData } from '../../src/lib/query/exploreQueries';
 import type { FavouriteHero } from '../../src/types';
 
@@ -68,6 +69,7 @@ type FeedRow =
   | { type: 'ticker'; heroCount: number; newlyAddedCount: number }
   | { type: 'recent'; heroes: RowHero[] }
   | { type: 'foryou'; heroes: RowHero[] }
+  | { type: 'sponsorslot' }
   | { type: 'favourites'; heroes: RowHero[] }
   | {
       type: 'rightnow';
@@ -276,6 +278,8 @@ export default function HomeScreen() {
         title: 'Newly Added',
         heroes: newlyAdded,
       });
+    // The page's ONE promo unit (house content; see the sponsorship playbook).
+    out.push({ type: 'sponsorslot' });
 
     // The Arena — a featured rivalry leads; the rest live in /versus.
     if (rivalries.length > 0) {
@@ -380,6 +384,12 @@ export default function HomeScreen() {
                 onPress={handlePress}
                 disabled={navigating}
               />
+            );
+          case 'sponsorslot':
+            return (
+              <View style={styles.sponsorWrap}>
+                <SponsorSlot placement="explore-feed" />
+              </View>
             );
           case 'rightnow':
             return (
@@ -519,6 +529,7 @@ const styles = StyleSheet.create({
   // Deep navy so the overscroll rubber-band reveals the same dark as the stage
   // (no lighter-navy band behind the zooming portrait).
   root: { flex: 1, backgroundColor: COLORS.deepNavy },
+  sponsorWrap: { paddingHorizontal: 16, paddingVertical: 6 },
   // Transparent so the dark navy root shows under the status bar and on
   // overscroll (matching the spotlight) instead of a beige band.
   scroll: { flex: 1, backgroundColor: 'transparent' },

--- a/app/(tabs)/explore.web.tsx
+++ b/app/(tabs)/explore.web.tsx
@@ -41,6 +41,7 @@ import { PublisherPods } from '../../src/components/web/home/PublisherPods';
 import { CategoryBrowseGrid } from '../../src/components/web/home/CategoryBrowseGrid';
 import { HallOfFame } from '../../src/components/web/home/HallOfFame';
 import { FeaturedRivalry } from '../../src/components/web/home/FeaturedRivalry';
+import { SponsorSlot } from '../../src/components/SponsorSlot';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 const ROW_CARD_HEIGHT = 310;
@@ -1467,6 +1468,15 @@ export default function WebHomeScreen() {
                 heroes={homeData.newlyAdded ?? []}
                 onPress={handlePress}
               />
+            </Reveal>
+
+            {/* ── The sponsor slot — the page's ONE promo unit (house content
+                 today; see the tasteful-sponsorship playbook). Supporters see
+                 nothing here. ─────────────────────────────────────────────── */}
+            <Reveal>
+              <View style={{ paddingHorizontal: gutter } as object}>
+                <SponsorSlot placement="explore-feed" />
+              </View>
             </Reveal>
 
             {/* ── The Arena — one featured rivalry leads; the rest live in /versus. */}

--- a/src/components/SponsorSlot.tsx
+++ b/src/components/SponsorSlot.tsx
@@ -1,0 +1,109 @@
+// The sponsor slot — the ONLY promo unit the app is allowed to render, built to
+// the tasteful-sponsorship playbook (docs/superpowers/specs/
+// 2026-07-16-monetization-options.md §C):
+//   * max ONE per page — enforce at the call site; this file is the only unit.
+//   * native feed-card grammar (beige-canvas card, eyebrow label), never
+//     sticky/interstitial/autoplay.
+//   * BANNED placements: character-page top viewport, the dailies/games, the
+//     compare arena.
+//   * supporters see none — their Ko-fi support already bought that.
+//   * house content today (honest "From Mythique" eyebrow); a paid sponsor one
+//     day just swaps the creative source + eyebrow to "Sponsor".
+// Impressions + clicks flow to Vercel custom events, so the slot earns real
+// CTR data long before any sponsor conversation happens.
+import { useEffect, useRef } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { useRouter, type Href } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../constants/colors';
+import { useAuth } from '../hooks/useAuth';
+import { useProfile } from '../hooks/useProfile';
+import { promoForDay } from '../lib/sponsor/houseAds';
+import { openKofi } from '../lib/support/kofi';
+import { trackEvent } from '../lib/analytics';
+
+export function SponsorSlot({ placement }: { placement: string }) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { profile } = useProfile(user?.id);
+  const promo = promoForDay();
+  const seen = useRef(false);
+
+  const suppressed = !!profile?.is_supporter;
+
+  useEffect(() => {
+    if (suppressed || seen.current) return;
+    seen.current = true;
+    trackEvent('sponsor_impression', { promo: promo.id, placement });
+  }, [suppressed, promo.id, placement]);
+
+  // Supporters browse promo-free — the quiet perk of the tier.
+  if (suppressed) return null;
+
+  const open = () => {
+    trackEvent('sponsor_click', { promo: promo.id, placement });
+    if (promo.target === 'kofi') openKofi();
+    else router.push(promo.target as Href);
+  };
+
+  return (
+    <Pressable
+      onPress={open}
+      accessibilityRole="button"
+      accessibilityLabel={`${promo.title} — ${promo.cta}`}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <View style={styles.iconWrap}>
+        <Ionicons name={promo.icon as keyof typeof Ionicons.glyphMap} size={20} color={COLORS.orange} />
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.eyebrow}>{promo.eyebrow}</Text>
+        <Text style={styles.title} numberOfLines={1}>
+          {promo.title}
+        </Text>
+        <Text style={styles.sub} numberOfLines={2}>
+          {promo.sub}
+        </Text>
+      </View>
+      <View style={styles.cta}>
+        <Text style={styles.ctaText}>{promo.cta}</Text>
+        <Ionicons name="chevron-forward" size={13} color={COLORS.orange} />
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    backgroundColor: '#fffdf8',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(41,60,67,0.08)',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  pressed: { opacity: 0.85 },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: 'rgba(231,115,51,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: { flex: 1, minWidth: 0, gap: 1 },
+  eyebrow: {
+    fontFamily: 'Nunito_800ExtraBold',
+    fontSize: 9.5,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: COLORS.grey,
+  },
+  title: { fontFamily: 'Nunito_800ExtraBold', fontSize: 14.5, color: COLORS.navy },
+  sub: { fontFamily: 'Nunito_400Regular', fontSize: 12.5, color: COLORS.grey, lineHeight: 17 },
+  cta: { flexDirection: 'row', alignItems: 'center', gap: 2 },
+  ctaText: { fontFamily: 'Nunito_700Bold', fontSize: 12.5, color: COLORS.orange },
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -7,7 +7,17 @@ import { attributionEventProps, getAttribution } from './attribution';
 // page views. Web-only: native has no Vercel beacon and track() warns off-web,
 // so we hard-gate on platform. Keep names snake_case and stable; they surface
 // as event rows in the Vercel dashboard.
-export type AnalyticsEvent = 'sign_up' | 'log_in' | 'matchup_vote' | 'favourite_add' | 'search';
+export type AnalyticsEvent =
+  | 'sign_up'
+  | 'log_in'
+  | 'matchup_vote'
+  | 'favourite_add'
+  | 'search'
+  // The sponsor/house-promo slot (see src/components/SponsorSlot.tsx): one
+  // impression per mount + clicks, so the slot earns real CTR data before any
+  // paid sponsor ever fills it.
+  | 'sponsor_impression'
+  | 'sponsor_click';
 
 // Vercel only accepts flat primitive properties.
 type EventProps = Record<string, string | number | boolean | null>;

--- a/src/lib/sponsor/houseAds.ts
+++ b/src/lib/sponsor/houseAds.ts
@@ -1,0 +1,61 @@
+// House creatives for the sponsor slot (monetization playbook — see
+// docs/superpowers/specs/2026-07-16-monetization-options.md §C). Until a real
+// sponsor exists, the slot promotes Mythique's own surfaces, which buys the
+// infrastructure, the placement discipline, and CTR data for free.
+//
+// The rotation is DETERMINISTIC by UTC day (same convention as the dailies —
+// everyone sees the same creative on the same day, and SSR/client can't
+// disagree the way Math.random would). Pure + unit-tested.
+
+export interface HousePromo {
+  id: string;
+  /** Slot eyebrow. House content is honestly labeled — never "SPONSOR". */
+  eyebrow: 'From Mythique';
+  title: string;
+  sub: string;
+  cta: string;
+  /** Ionicons glyph. */
+  icon: string;
+  /** Internal route, or 'kofi' for the external support link. */
+  target: string;
+}
+
+export const HOUSE_PROMOS: HousePromo[] = [
+  {
+    id: 'kofi',
+    eyebrow: 'From Mythique',
+    title: 'Keep Mythique free',
+    sub: 'No ads, no paywall — powered by readers like you.',
+    cta: 'Buy a coffee',
+    icon: 'heart',
+    target: 'kofi',
+  },
+  {
+    id: 'daily-game',
+    eyebrow: 'From Mythique',
+    title: 'Today’s daily is live',
+    sub: 'Guess the mystery character in four tries.',
+    cta: 'Play now',
+    icon: 'help-circle',
+    target: '/play',
+  },
+  {
+    id: 'arena',
+    eyebrow: 'From Mythique',
+    title: 'Settle today’s debate',
+    sub: 'Two icons enter. The crowd decides.',
+    cta: 'Cast your vote',
+    icon: 'flash',
+    target: '/versus',
+  },
+];
+
+/** UTC day index (days since epoch) — the rotation clock. */
+export function utcDayIndex(d: Date = new Date()): number {
+  return Math.floor(d.getTime() / 86_400_000);
+}
+
+/** The one house creative for a given day. Deterministic; same for everyone. */
+export function promoForDay(d: Date = new Date()): HousePromo {
+  return HOUSE_PROMOS[utcDayIndex(d) % HOUSE_PROMOS.length];
+}


### PR DESCRIPTION
The **free-optionality piece** of the ads decision (monetization doc §C): build the one promo unit now, filled with **house content**, so the infrastructure, placement discipline, and CTR data all exist long before any sponsor conversation — and every shipped promise stays intact (house self-promo ≠ ads; "ad-free" holds).

## What
- **`houseAds.ts`** — three creatives (Ko-fi "Keep Mythique free", daily game, arena), rotated **deterministically by UTC day** (the dailies' calendar — same creative for everyone, no hydration-unsafe randomness). Eyebrow is honestly **"From Mythique"** — it only ever says "Sponsor" if a paid creative fills the slot someday.
- **`SponsorSlot.tsx`** — the *only* promo unit the app is allowed to render, with the playbook's rules written into its header: **max one per page**, native feed-card grammar (no sticky/interstitial/autoplay), **banned placements** (character-page top viewport, dailies/games, compare arena), and **supporters see none** — the tier's quiet perk goes live with this PR.
- **Measurement** — `sponsor_impression` / `sponsor_click` Vercel custom events, tagged with promo id + placement. Real CTR data from day one, so if a sponsorship conversation ever happens you'll negotiate with numbers.
- **Placement**: exactly one per explore page (web + native), low in the beige canvas after "Newly Added" — far from the games, the arena, and any character page.

## Verification
tsc clean (0 non-drift) · **758 tests pass** (+5 rotation tests incl. the UTC-calendar and honest-labeling invariants) · eslint clean · `expo export -p web` OK.

No migrations, no schema changes — pure client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)