### PR TITLE
perf(admin): index-only metric-refresh (fixes dashboard timeouts, #121)

### DIFF
--- a/supabase/migrations/20260716140000_admin_metrics_perf.sql
+++ b/supabase/migrations/20260716140000_admin_metrics_perf.sql
@@ -1,0 +1,90 @@
+-- Admin-metrics refresh perf: kill the 15s (44s peak) refresh_admin_metrics()
+-- cron that ran every 5 min and full-scanned the 106MB heroes heap for counts,
+-- starving interactive dashboard queries (3s statement timeout) → the "database
+-- may be busy" LoadFailed screen. Two covering indexes turn the two hot compute
+-- functions into index-only scans, and compute_get_source_coverage becomes a
+-- single pass instead of 17 subqueries.
+--
+--   compute_catalog_health       7.3s → ~0.03s   (partial index, 4.5k enriched rows)
+--   compute_get_source_coverage  8.6s → ~0.3s    (covering index + single pass)
+--
+-- Indexes were first built in prod with CREATE INDEX CONCURRENTLY (no lock);
+-- these IF NOT EXISTS forms are no-ops there and set up a fresh DB correctly.
+-- The cron cadence change (5min → 20min) is an operational cron.alter_job made
+-- out of band — it isn't schema and doesn't belong in a versioned migration.
+
+-- Covering index for compute_get_source_coverage's whole-catalogue counts and
+-- catalog_health's comicvine_status group-by → index-only scans, no heap read.
+create index if not exists heroes_source_cov_idx
+  on public.heroes (comicvine_status, wikidata_status)
+  include (superhero_api_id, comicvine_id, wikidata_qid, wikidata_enriched_at);
+
+-- Partial covering index for catalog_health's per-metric + by-publisher aggregate
+-- over the ~4.5k enriched heroes (vs seq-scanning all 50k). Boolean expressions
+-- match the function body exactly so the scan stays index-only (never touches the
+-- fat summary/portrait/image text columns on the heap).
+create index if not exists heroes_health_enriched_idx
+  on public.heroes (
+    publisher,
+    (portrait_url is not null),
+    (image_url is not null),
+    (intelligence is not null),
+    (summary is not null),
+    (first_issue_id is not null)
+  )
+  where enriched_at is not null;
+
+-- Single-pass rewrite: one index-only scan of heroes with count(*) filter (...)
+-- instead of 10 separate `select count(*) from heroes where ...` subqueries.
+-- Output is byte-identical to the previous definition.
+create or replace function public.compute_get_source_coverage()
+  returns json
+  language sql
+  stable
+  set search_path to 'public'
+as $function$
+  select json_build_object(
+    'total', h.total,
+    'superhero_api', json_build_object('linked', h.sa_linked),
+    'comicvine', json_build_object(
+      'linked',  h.cv_linked,
+      'done',    h.cv_done,
+      'pending', h.cv_pending,
+      'failed',  h.cv_failed
+    ),
+    'wikidata', json_build_object(
+      'resolved',   h.wd_resolved,
+      'ambiguous',  h.wd_ambiguous,
+      'unresolved', h.wd_unresolved,
+      'enriched',   h.wd_enriched
+    ),
+    'tmdb', json_build_object(
+      'titles',   t.titles,
+      'enriched', t.enriched,
+      'films',    t.films,
+      'tv',       t.tv
+    )
+  )
+  from (
+    select
+      count(*)                                                as total,
+      count(*) filter (where superhero_api_id is not null)    as sa_linked,
+      count(*) filter (where comicvine_id is not null)        as cv_linked,
+      count(*) filter (where comicvine_status = 'done')       as cv_done,
+      count(*) filter (where comicvine_status = 'pending')    as cv_pending,
+      count(*) filter (where comicvine_status = 'failed')     as cv_failed,
+      count(*) filter (where wikidata_qid is not null)        as wd_resolved,
+      count(*) filter (where wikidata_status = 'ambiguous')   as wd_ambiguous,
+      count(*) filter (where wikidata_status = 'unresolved')  as wd_unresolved,
+      count(*) filter (where wikidata_enriched_at is not null) as wd_enriched
+    from heroes
+  ) h,
+  (
+    select
+      count(*)                                          as titles,
+      count(*) filter (where enriched_at is not null)   as enriched,
+      count(*) filter (where media_type = 'film')       as films,
+      count(*) filter (where media_type = 'tv')         as tv
+    from titles
+  ) t;
+$function$;


### PR DESCRIPTION
## Problem

The command center intermittently showed **"Couldn't load … the database may be busy"** (the `LoadFailed`/Retry state added in #122). Root cause, diagnosed live:

- `refresh_admin_metrics()` runs **every 5 minutes** and takes **15s avg, 44s peak**.
- 94% of that was two reporting functions full-scanning the **106MB `heroes` heap** (50k rows with fat text columns) just to compute counts:
  - `compute_get_source_coverage` — 8.6s
  - `compute_catalog_health` — 7.3s
- Reading 106MB from cold cache every 5 min saturates IO; any dashboard query in that window trips the app's 3s statement timeout.

## Fix

Two covering indexes turn both functions into **index-only scans** (never touch the heap):

| Index | Serves | Effect |
| --- | --- | --- |
| `heroes_source_cov_idx` | source-coverage counts + cv group-by | 8.6s → ~0.3s |
| `heroes_health_enriched_idx` (partial, 4.5k enriched rows, boolean expressions) | catalog_health metric + by-publisher aggregate | 7.3s → ~0.03s |

Plus `compute_get_source_coverage` rewritten from 10 subqueries to a single pass — **output verified byte-identical** to the previous definition.

**Measured: full refresh 15s → 85ms warm.** Cron cadence also dialed 5 min → 20 min (admin counts don't need 5-min freshness). Collision probability with interactive queries drops ~99%.

## Applied to prod already

- Indexes built with `CREATE INDEX CONCURRENTLY` (no table lock) + `VACUUM ANALYZE heroes` to set the visibility map (fetch-free index-only scans).
- Function rewrite applied via migration `20260716140000_admin_metrics_perf`.
- `cron.alter_job(60, '*/20 * * * *')` (operational; not schema, so not in the migration).

This migration file records it for repo/fresh-DB parity (index DDL is `IF NOT EXISTS` → no-op in prod). Types regenerated: no diff (function signature unchanged). Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)