### PR TITLE
fix(insights): mobile overflow + guard audit snapshots from public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,8 @@ supabase/.temp/
 reference-portraits/
 out/
 assets/silhouettes/raw/
+
+# Design-audit snapshots — full-page admin screenshots contain LIVE business
+# data (traffic, revenue, member counts). This repo is public: never commit
+# them. Keep snapshots in a private store. See scripts/design-audit/README.md.
+scripts/design-audit/history/

--- a/scripts/design-audit/README.md
+++ b/scripts/design-audit/README.md
@@ -12,9 +12,14 @@ Two jobs:
    `report.json` names the offending elements. Run it after any command-center
    layout change.
 2. **Living history (Mobbin-style).** Each dated folder is a frozen snapshot of
-   every admin flow. Commit a snapshot whenever a design pass lands and you get
-   a browsable timeline of how the flows evolved — diff any two dates by eye.
-   (A proper viewer UI over these folders is a planned follow-up.)
+   every admin flow — a browsable timeline of how the flows evolved; diff any
+   two dates by eye. (A proper viewer UI over these folders is a planned
+   follow-up.)
+
+> ⚠️ **Never commit snapshots to this repo — it is public.** Full-page captures
+> show LIVE business data (traffic, acquisition, revenue, member counts).
+> `history/` is gitignored for exactly this reason. Keep the living history in a
+> private store (private bucket, private repo, or local), not here.
 
 ## Running
 

--- a/src/components/admin/health/Panel.tsx
+++ b/src/components/admin/health/Panel.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   useWindowDimensions,
   type ViewStyle,
+  type StyleProp,
 } from 'react-native';
 import { type ReactNode } from 'react';
 import { COLORS } from '../../../constants/colors';
@@ -26,7 +27,7 @@ export function Panel({
   hint?: string;
   action?: ReactNode;
   children?: ReactNode;
-  style?: ViewStyle | ViewStyle[];
+  style?: StyleProp<ViewStyle>;
   // Height-filling dashboard cell: stretch to the row's height and clip, so the
   // body can scroll internally instead of growing the page. The single source of
   // truth for the desktop "divide the viewport" layout.
@@ -47,7 +48,7 @@ export function Panel({
         styles.panel,
         narrow && styles.panelNarrow,
         fill && styles.fill,
-        style as ViewStyle,
+        style,
         // Mobile stacks panels vertically, so any `flex`/`flex:1.5` a domain passes
         // (for desktop side-by-side width ratios) must be neutralised — otherwise a
         // flex-basis:0% panel gets sized by flex instead of its content and a tall

--- a/src/components/admin/health/domains/SocialInsightsDomain.tsx
+++ b/src/components/admin/health/domains/SocialInsightsDomain.tsx
@@ -278,11 +278,11 @@ export function SocialInsightsDomain() {
       </Panel>
 
       {/* WORKSPACE — the decision tool (left) beside platform context (right rail) */}
-      <View style={styles.split}>
+      <View style={[styles.split, narrow && styles.splitNarrow]}>
         <Panel
           title="What's working"
           hint="Avg views per post, by format — this steers the next batch"
-          style={[styles.panel, styles.splitMain]}
+          style={[styles.panel, styles.splitMain, narrow && styles.splitItemNarrow]}
         >
           {angleRows.map((a, i) => (
             <View key={a.angle} style={styles.angleRow}>
@@ -310,7 +310,7 @@ export function SocialInsightsDomain() {
         <Panel
           title="By platform"
           hint="Where the attention lives"
-          style={[styles.panel, styles.splitRail]}
+          style={[styles.panel, styles.splitRail, narrow && styles.splitItemNarrow]}
         >
           {platformRows.map((p) => (
             <View key={p.platform} style={styles.platRow}>
@@ -485,6 +485,13 @@ const styles = StyleSheet.create({
   split: { flexDirection: 'row', flexWrap: 'wrap', gap: 12, alignItems: 'flex-start' },
   splitMain: { flexGrow: 2, flexBasis: 460, minWidth: 0 },
   splitRail: { flexGrow: 1, flexBasis: 280, minWidth: 0 },
+  // Narrow: stack the two panels full-width instead of relying on flex-wrap +
+  // flexBasis math (RN defaults flexShrink to 0, so a 280/460 basis won't shrink
+  // to fit a 366px column — the rail spilled ~18px past the viewport). Column +
+  // stretch makes each panel exactly the content width; flexBasis:auto/grow:0
+  // stops the basis being read as a height in the column axis.
+  splitNarrow: { flexDirection: 'column', alignItems: 'stretch' },
+  splitItemNarrow: { flexBasis: 'auto', flexGrow: 0, width: '100%' },
 
   topRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Insights mobile overflow (last item from the design audit)

`publish/insights` overflowed 390px viewports by ~18px. The post-deploy audit's offender list pointed at the sub-tab strip, but a live DOM probe cleared it — every sub-tab pill is correctly clipped inside its horizontal scroller. The real culprit was the **"By platform" rail**, the only non-scroller element past the viewport edge.

Root cause: the workspace split used flex-wrap + `flexBasis` (460/280), but React Native defaults `flexShrink` to **0**, so the 280 rail wouldn't shrink to fit the 366px content column. Fix: stack the two panels into a **full-width column on narrow** — a panel that is the column width can't exceed it. `Panel.style` widened to `StyleProp<ViewStyle>` so conditional narrow styles compose without a cast.

## Security fix: audit snapshots must not reach this public repo

While committing the "living history" baseline I nearly pushed **full-page admin screenshots with live business data** (traffic, acquisition, revenue, member counts) to this **public** repo. That's the same exposure class as #121. This PR:

- gitignores `scripts/design-audit/history/`
- adds a prominent warning to the audit README: snapshots contain live data, keep them in a **private** store, never here.

The capture tool still works; its output just stays local/private now.

## Verification
- `tsc --noEmit`: 0 errors outside the known RNTL test-type drift
- The overflow fix is structural (full-width column) and confirmed against the probed offender; a re-probe will run once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)