### PR TITLE
Self-running content engine: weighted plan, scenario hooks, monthly CI refill

### DIFF
--- a/.github/workflows/social-refill.yml
+++ b/.github/workflows/social-refill.yml
@@ -1,0 +1,99 @@
+# Social content refill — the self-running half of the growth engine.
+#
+# Monthly (and on demand), this renders a full batch of ad-safe social content
+# (batch-month: weighted plan → carousels + reels) and publishes it straight
+# into the app's posting queue (publish-posts → Cloudinary + social_posts), so
+# the command-center Publish › Social lane refills itself. The owner's job
+# shrinks to posting from the queue and running promotes from Publish › Promote.
+#
+# ONE-TIME SETUP — add these repository secrets (Settings → Secrets → Actions):
+#   EXPO_PUBLIC_SUPABASE_URL     same values as .env.local
+#   EXPO_PUBLIC_SUPABASE_KEY
+#   SUPABASE_SERVICE_ROLE_KEY    used for reads (no statement timeout) + publish
+#   CLOUDINARY_CLOUD_NAME        image hosting for the queue previews
+#   CLOUDINARY_API_KEY
+#   CLOUDINARY_API_SECRET
+# Until the secrets exist the run fails fast at the "check secrets" step.
+#
+# Manual run: Actions → "Social content refill" → Run workflow (pick n).
+name: Social content refill
+
+on:
+  schedule:
+    # 06:00 UTC on the 1st — a fresh month of content lands before the month starts.
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      n:
+        description: 'How many pieces to generate'
+        required: false
+        default: '30'
+
+concurrency:
+  group: social-refill
+  cancel-in-progress: false
+
+jobs:
+  refill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Check secrets
+        env:
+          URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          SRK: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CCN: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+        run: |
+          missing=""
+          [ -z "$URL" ] && missing="$missing EXPO_PUBLIC_SUPABASE_URL"
+          [ -z "$SRK" ] && missing="$missing SUPABASE_SERVICE_ROLE_KEY"
+          [ -z "$CCN" ] && missing="$missing CLOUDINARY_*"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secrets:$missing — see the header of this workflow file."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: corepack enable
+      - run: yarn install --immutable
+
+      - name: Install ffmpeg (reels)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Generate the batch
+        env:
+          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # GH ubuntu runners ship Google Chrome; lib.mjs honours PW_CHROME.
+          PW_CHROME: /usr/bin/google-chrome
+        # Seed from run_number: each month differs, a re-run of the same run
+        # regenerates identically (matches the plan's determinism contract).
+        run: |
+          node scripts/social/ads/batch-month.mjs \
+            --n "${{ github.event.inputs.n || '30' }}" \
+            --seed "${{ github.run_number }}"
+
+      - name: Publish to the app's posting queue
+        env:
+          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
+        run: node scripts/social/publish-posts.mjs
+
+      - name: Upload batch for preview
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: social-batch-${{ github.run_number }}
+          path: out/social
+          retention-days: 7
+          if-no-files-found: ignore

--- a/scripts/social/ads/data.mjs
+++ b/scripts/social/ads/data.mjs
@@ -142,10 +142,13 @@ export async function fetchLore(sb, rand, { excludeTierS = false } = {}) {
 export async function fetchPools(sb, rand, { excludeTierS = false } = {}) {
   const pool = (await famousPool(sb)).map(toSafeHero).filter((h) => !excludeTierS || h.tier !== 'S');
 
-  // matchups: rivalries that resolve, topped up with contrasting famous pairs
+  // matchups: rivalries that resolve, topped up with contrasting famous pairs.
+  // Pool sized for the weighted plan (matchup is ~43% of a batch — see
+  // plan.mjs ANGLES), so a 30-piece month never runs the angle dry.
+  const MATCHUP_POOL = 16;
   const matchups = [];
   for (const [an, bn] of RIVALRIES) {
-    if (matchups.length >= 10) break;
+    if (matchups.length >= MATCHUP_POOL) break;
     const [ar, br] = await Promise.all([heroByName(sb, an), heroByName(sb, bn)]);
     if (!ar || !br) continue;
     const a = toSafeHero(ar), b = toSafeHero(br);
@@ -154,7 +157,7 @@ export async function fetchPools(sb, rand, { excludeTierS = false } = {}) {
     if (rounds.length >= 3) matchups.push({ a, b, rounds });
   }
   let attempts = 0;
-  while (matchups.length < 10 && pool.length > 4 && attempts < 400) {
+  while (matchups.length < MATCHUP_POOL && pool.length > 4 && attempts < 400) {
     attempts++;
     const a = pool[Math.floor(rand() * Math.min(40, pool.length))];
     const b = pool[Math.floor(rand() * Math.min(40, pool.length))];

--- a/scripts/social/ads/plan.mjs
+++ b/scripts/social/ads/plan.mjs
@@ -7,12 +7,29 @@ export function rng(seed) {
   return () => { seed |= 0; seed = (seed + 0x6d2b79f5) | 0; let t = Math.imul(seed ^ (seed >>> 15), 1 | seed); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; };
 }
 
+// Scenario framings for matchup hooks — the paid data (Jul '26 promotes) showed
+// a scenario question ("Who runs the city?") out-clicking plain "who wins" by a
+// wide margin, so matchup captions rotate through stakes-framed hooks. Picked
+// deterministically per pair (name hash) so regenerating a batch is stable.
+const MATCHUP_HOOKS = [
+  'who takes it? ⚔️',
+  'one city. one throne. who runs it? 👀',
+  'last one standing walks away — who is it? 🥊',
+  'everything on the line. who wins? ⚡',
+  'no prep, no help, right now — who survives? 🔥',
+];
+const matchupHook = (a, b) => {
+  let h = 0;
+  for (const ch of a + '|' + b) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+  return MATCHUP_HOOKS[h % MATCHUP_HOOKS.length];
+};
+
 // Per-angle: consume the next unused pool item → { title, data, caption }.
 const MAKERS = {
   matchup: (m) => ({
     title: `${m.a.name} vs ${m.b.name}`,
     data: m,
-    caption: `${m.a.name} vs ${m.b.name} — who takes it? ⚔️\n\nRound by round, stat by stat. Cast your vote on mythique.app\n\n#whowouldwin #superheroes #comics #mythique`,
+    caption: `${m.a.name} vs ${m.b.name} — ${matchupHook(m.a.name, m.b.name)}\n\nRound by round, stat by stat. Cast your vote on mythique.app\n\n#whowouldwin #superheroes #comics #mythique`,
   }),
   ranking: (r) => ({
     title: `Top 10 ${r.label}`,
@@ -47,7 +64,13 @@ const MAKERS = {
     };
   },
 };
-const ANGLES = ['matchup', 'ranking', 'guess', 'fact', 'lore'];
+// Weighted angle cycle — matchup appears 3× per 7 slots (~43%) because the paid
+// promote data shows pick-a-side matchups are the click winner (TikTok's own
+// budget allocator fed them 51% of spend); every other angle still appears once
+// per cycle so a batch keeps full variety. When the matchup pool runs dry the
+// round-robin skips to the next live angle, so a heavier weight can never stall
+// a batch. Re-tune by editing this list as new performance data lands.
+const ANGLES = ['matchup', 'ranking', 'matchup', 'guess', 'fact', 'matchup', 'lore'];
 const POOL_KEY = { matchup: 'matchups', ranking: 'rankings', guess: 'guesses', fact: 'facts', lore: 'lore' };
 // music.mjs kinds: matchup|ranking|bio|brand|post — map guess/fact to fitting kinds.
 const MUSIC_KIND = { matchup: 'matchup', ranking: 'ranking', guess: 'post', fact: 'brand', lore: 'brand' };
@@ -92,14 +115,18 @@ export function buildPlan({ n = 30, seed = 1, mix = { carousel: 18, reel: 12 }, 
   for (let i = 0; i < n; i++) {
     const format = formats[i];
     const ai = streamAngleCursor[format];
-    // round-robin angles within this format's stream, skipping exhausted pools
-    let item = null, angle = null;
+    // round-robin the weighted cycle within this format's stream, skipping
+    // exhausted pools. Track the CYCLE POSITION (idx), not indexOf(angle) —
+    // the cycle repeats 'matchup', and indexOf would always resolve to its
+    // first slot, collapsing the rotation.
+    let item = null, angle = null, idx = ai;
     for (let tries = 0; tries < ANGLES.length && !item; tries++) {
-      angle = ANGLES[(ai + tries) % ANGLES.length];
+      idx = (ai + tries) % ANGLES.length;
+      angle = ANGLES[idx];
       item = next(angle);
     }
     if (!item) break; // all pools exhausted
-    streamAngleCursor[format] = (ANGLES.indexOf(angle) + 1) % ANGLES.length;
+    streamAngleCursor[format] = (idx + 1) % ANGLES.length;
     const made = MAKERS[angle](item);
     entries.push({
       ord: entries.length + 1,


### PR DESCRIPTION
## Why

The growth loop should run itself: content generated and queued automatically, tuned by what the paid data says works, with the owner's role reduced to posting from the queue and running promotes. This PR closes the two automation gaps.

## What

### 1. Data-driven plan weighting (`plan.mjs`)
- The angle cycle is now weighted: **matchup ≈ 43% of a batch** (3 slots per 7-slot cycle). Justification: on the R300 promote, TikTok's own budget allocator fed pick-a-side matchups 51% of spend and they won clicks decisively; every other angle still appears once per cycle so batches keep full variety.
- **Fixed a latent rotation bug**: the cursor advanced via `ANGLES.indexOf(angle)`, which with a repeated angle always resolves to its first slot — collapsing the cycle to two angles. The cursor now tracks cycle position directly.
- **Scenario hooks**: matchup captions rotate 5 stakes-framed hooks ("one city, one throne — who runs it?", "no prep, no help, right now…") — the "Who runs the city?" framing out-clicked plain "who wins". Deterministic per pair (charcode hash) so a batch regenerates identically, preserving the plan's determinism contract.
- `data.mjs`: matchup pool 10 → 16 so the heavier weight never exhausts (exhaustion falls through cleanly regardless).

### 2. Monthly self-refill (`.github/workflows/social-refill.yml`)
- Cron (1st of the month, 06:00 UTC) + `workflow_dispatch`: runs `batch-month` (weighted plan → carousels + reels, Chrome via `PW_CHROME`, ffmpeg installed) then `publish-posts` (Cloudinary upload + `social_posts` upsert). The **Publish › Social queue refills itself**; the rendered batch is uploaded as a run artifact (7-day retention) for preview.
- Fails fast with a named-secrets error until the six repo secrets are added — all documented in the workflow header. Idempotent end-to-end (seeded plan + upsert-by-(batch, ord)).

## Owner follow-up (one-time)

Add the six repository secrets (Settings → Secrets and variables → Actions) — same values as `.env.local`: `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`. Then trigger the first run from the Actions tab.

## Testing

- `yarn test:social` 53/53; full suite 787/787; `tsc --noEmit` clean; eslint clean; workflow YAML validated.
- Verified the weighted distribution empirically (14/30 matchup on a 30-piece plan, all five angles present) and hook rotation across real rivalry names (all 5 hooks in use).
- Rebased onto latest `main` (post-#117 squash + the command-center UX commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnVLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFGsYJpMBvbU3jU1RnmVLF)_